### PR TITLE
MCP template resources passthrough and read-path stability hardening

### DIFF
--- a/.github/workflows/analyst-toolkit-mcp-ci.yml
+++ b/.github/workflows/analyst-toolkit-mcp-ci.yml
@@ -8,8 +8,28 @@ on:
     branches: [ main, master ]
 
 jobs:
+  secret-scan:
+    name: Secret Scan (Gitleaks)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Gitleaks
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/gitleaks/gitleaks/master/install.sh \
+            | sh -s -- -b /usr/local/bin v8.28.0
+
+      - name: Run Gitleaks
+        run: gitleaks detect --source . --no-banner --redact
+
   lint-and-test:
     name: Lint, Test, and Docker Build
+    needs: [secret-scan]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -27,7 +27,7 @@ ENV PYTHONPATH=/app/src
 EXPOSE 8001
 
 # Health check
-HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
-  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8001/health')"
+HEALTHCHECK --interval=30s --timeout=15s --start-period=30s --retries=5 \
+  CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8001/health', timeout=3)"
 
 CMD ["python", "-m", "analyst_toolkit.mcp_server.server"]

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Ship the toolkit as an MCP server and plug it into Claude Desktop, FridAI, or an
 - **⛓️ Pipeline Mode:** Chain multiple tools in memory using `session_id` — no intermediate saves.
 - **🕹️ Executive Cockpit:** Get a **0-100 Data Health Score** and a detailed **Healing Ledger**.
 - **📀 Golden Templates:** Mountable library of industry-standard configurations for Fraud, Migration, and Compliance.
+- **📚 Template Resources:** MCP `resources/list` + `resources/read` expose both standard and golden YAML templates directly to clients/agents.
 - **🤖 Auto-Heal:** One-click inference and repair — from raw data to certified output in a single tool call.
 - [📡 MCP Server Guide](resource_hub/mcp_server_guide.md) — full setup, tool reference, and host integrations
 

--- a/docker-compose.mcp.yml
+++ b/docker-compose.mcp.yml
@@ -34,14 +34,12 @@ services:
     volumes:
       # Mount GCS service account key — requires GCP_CREDS_PATH to be set in shell/.envrc
       - ${GCP_CREDS_PATH:-/dev/null}:/run/secrets/gcp_creds:ro
-      # Mount Golden Templates for easy updates/additions
-      - ./config/golden_templates:/app/config/golden_templates
       # Mount exports for local persistence of history and reports
       - ./exports:/app/exports
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8001/health')"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8001/health', timeout=3)"]
       interval: 30s
-      timeout: 5s
-      retries: 3
-      start_period: 15s
+      timeout: 15s
+      retries: 5
+      start_period: 30s

--- a/src/analyst_toolkit/mcp_server/templates.py
+++ b/src/analyst_toolkit/mcp_server/templates.py
@@ -1,11 +1,102 @@
 """
-templates.py — Dynamically loads Golden Configuration Templates from the config directory.
+templates.py — Template discovery for tool calls and MCP resources.
 """
 
-import os
 from pathlib import Path
+from urllib.parse import unquote, urlparse
 
 import yaml
+
+RESOURCE_SCHEME = "analyst"
+RESOURCE_HOST = "templates"
+
+CONFIG_DIR = Path("config")
+GOLDEN_TEMPLATE_DIR = CONFIG_DIR / "golden_templates"
+
+
+def _iter_golden_template_files() -> list[Path]:
+    if not GOLDEN_TEMPLATE_DIR.exists():
+        return []
+    return sorted(p for p in GOLDEN_TEMPLATE_DIR.glob("*.yaml") if p.is_file())
+
+
+def _iter_standard_template_files() -> list[Path]:
+    if not CONFIG_DIR.exists():
+        return []
+    return sorted(p for p in CONFIG_DIR.glob("*_template.yaml") if p.is_file())
+
+
+def list_template_resources() -> list[dict[str, str]]:
+    """
+    Build MCP resource metadata for all YAML templates.
+    """
+    resources: list[dict[str, str]] = []
+
+    for path in _iter_golden_template_files():
+        resources.append(
+            {
+                "name": f"golden::{path.stem}",
+                "uri": f"{RESOURCE_SCHEME}://{RESOURCE_HOST}/golden/{path.name}",
+                "description": f"Golden template: {path.stem}",
+                "mimeType": "application/x-yaml",
+            }
+        )
+
+    for path in _iter_standard_template_files():
+        resources.append(
+            {
+                "name": f"config::{path.stem}",
+                "uri": f"{RESOURCE_SCHEME}://{RESOURCE_HOST}/config/{path.name}",
+                "description": f"Config template: {path.stem}",
+                "mimeType": "application/x-yaml",
+            }
+        )
+
+    return resources
+
+
+def resolve_template_uri(uri: str) -> Path:
+    """
+    Resolve a template URI to a local path, allowing only whitelisted templates.
+    """
+    parsed = urlparse(uri)
+    if parsed.scheme != RESOURCE_SCHEME or parsed.netloc != RESOURCE_HOST:
+        raise FileNotFoundError(f"Unsupported resource URI: {uri}")
+
+    path = unquote(parsed.path.lstrip("/"))
+    parts = [p for p in path.split("/") if p]
+    if len(parts) != 2:
+        raise FileNotFoundError(f"Invalid template resource URI path: {uri}")
+
+    group, filename = parts
+    if filename in {"", ".", ".."} or "/" in filename or not filename.endswith(".yaml"):
+        raise FileNotFoundError(f"Invalid template filename in URI: {uri}")
+
+    if group == "golden":
+        base = GOLDEN_TEMPLATE_DIR
+    elif group == "config":
+        if not filename.endswith("_template.yaml"):
+            raise FileNotFoundError(
+                f"Only *_template.yaml files are allowed for config resources: {uri}"
+            )
+        base = CONFIG_DIR
+    else:
+        raise FileNotFoundError(f"Unknown template group in URI: {uri}")
+
+    candidate = (base / filename).resolve()
+    base_resolved = base.resolve()
+    if base_resolved not in candidate.parents:
+        raise FileNotFoundError(f"Template path escapes template root: {uri}")
+    if not candidate.exists() or not candidate.is_file():
+        raise FileNotFoundError(f"Template resource not found: {uri}")
+
+    return candidate
+
+
+def read_template_resource(uri: str) -> str:
+    """Read a template resource by URI and return raw YAML text."""
+    path = resolve_template_uri(uri)
+    return path.read_text(encoding="utf-8")
 
 
 def get_golden_configs() -> dict:
@@ -13,21 +104,12 @@ def get_golden_configs() -> dict:
     Scans config/golden_templates/ for YAML files and returns them as a dictionary.
     """
     templates = {}
-    # Path relative to the project root (where server usually runs)
-    template_dir = Path("config/golden_templates")
-
-    if not template_dir.exists():
-        return {}
-
-    for file in template_dir.glob("*.yaml"):
+    for file in _iter_golden_template_files():
         try:
-            with open(file, "r") as f:
-                name = file.stem
-                templates[name] = yaml.safe_load(f)
+            with file.open("r", encoding="utf-8") as f:
+                templates[file.stem] = yaml.safe_load(f)
         except Exception:
-            # Skip malformed templates
             continue
-
     return templates
 
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5,9 +5,14 @@ Uses FastAPI's TestClient to verify the JSON-RPC 2.0 dispatcher
 without requiring a live network port.
 """
 
+import asyncio
+import time
+
 import pytest
 from fastapi.testclient import TestClient
 
+import analyst_toolkit.mcp_server.server as server_module
+import analyst_toolkit.mcp_server.tools.cockpit as cockpit_module
 from analyst_toolkit.mcp_server.server import TOOL_REGISTRY, app
 
 client = TestClient(app)
@@ -31,6 +36,7 @@ def test_rpc_initialize():
     result = response.json()["result"]
     assert result["protocolVersion"] == "2024-05-01"
     assert result["serverInfo"]["name"] == "analyst-toolkit"
+    assert "resources" in result["capabilities"]
 
 
 def test_rpc_tools_list():
@@ -43,6 +49,179 @@ def test_rpc_tools_list():
     tool_names = [t["name"] for t in result["tools"]]
     assert "diagnostics" in tool_names
     assert "outliers" in tool_names
+    assert "get_agent_playbook" in tool_names
+    assert "get_user_quickstart" in tool_names
+    assert "get_capability_catalog" in tool_names
+    assert "get_cockpit_help" not in tool_names
+    assert "get_agent_instructions" not in tool_names
+
+
+def test_rpc_capability_catalog_tool():
+    """Verify capability catalog exposes editable knobs including fuzzy matching."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 24,
+        "method": "tools/call",
+        "params": {"name": "get_capability_catalog", "arguments": {}},
+    }
+    response = client.post("/rpc", json=payload)
+    assert response.status_code == 200
+    result = response.json()["result"]
+    assert result["status"] == "pass"
+    assert result["summary"]["editable_configs"] is True
+    assert any(
+        p.endswith("fuzzy_matching.settings.<column>.score_cutoff")
+        for item in result["highlight_examples"]
+        for p in item["paths"]
+    )
+    modules = {item["tool"]: item for item in result["modules"]}
+    final_audit_knobs = {k["path"]: k["default"] for k in modules["final_audit"]["key_knobs"]}
+    assert "summary.run" not in final_audit_knobs
+    assert final_audit_knobs["final_edits.run"] is True
+
+    global_controls = result["global_controls"]
+    plotting_control = next(c for c in global_controls if "Plotting toggles" in c["description"])
+    assert plotting_control["path"] == "module-specific"
+    assert "outlier_detection.plotting.run" in plotting_control["example_paths"]
+
+
+def test_rpc_user_quickstart_tool():
+    """Verify user quickstart tool returns human-readable guide text."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 25,
+        "method": "tools/call",
+        "params": {"name": "get_user_quickstart", "arguments": {}},
+    }
+    response = client.post("/rpc", json=payload)
+    assert response.status_code == 200
+    result = response.json()["result"]
+    assert result["status"] == "pass"
+    assert result["content"]["format"] == "markdown"
+    assert result["content"]["title"] == "Analyst Toolkit Quickstart"
+    assert "fuzzy matching" in result["content"]["markdown"].lower()
+    assert "plotting" in result["content"]["markdown"].lower()
+    assert len(result["quick_actions"]) >= 2
+    assert any(a["tool"] == "diagnostics" for a in result["quick_actions"])
+    assert any(a["tool"] == "infer_configs" for a in result["quick_actions"])
+
+
+def test_rpc_resources_list():
+    """Verify template resources are discoverable via MCP resources/list."""
+    payload = {"jsonrpc": "2.0", "id": 20, "method": "resources/list", "params": {}}
+    response = client.post("/rpc", json=payload)
+    assert response.status_code == 200
+    result = response.json()["result"]
+    assert "resources" in result
+    uris = [r["uri"] for r in result["resources"]]
+    assert any(uri.startswith("analyst://templates/golden/") for uri in uris)
+    assert any(uri.startswith("analyst://templates/config/") for uri in uris)
+
+
+def test_rpc_resource_templates_list():
+    """Verify MCP resources/templates/list returns URI templates."""
+    payload = {"jsonrpc": "2.0", "id": 23, "method": "resources/templates/list", "params": {}}
+    response = client.post("/rpc", json=payload)
+    assert response.status_code == 200
+    result = response.json()["result"]
+    assert "resourceTemplates" in result
+    template_uris = [t["uriTemplate"] for t in result["resourceTemplates"]]
+    assert "analyst://templates/config/{name}_template.yaml" in template_uris
+    assert "analyst://templates/golden/{name}.yaml" in template_uris
+
+
+def test_rpc_resources_read():
+    """Verify MCP resources/read returns YAML for a known template URI."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 21,
+        "method": "resources/read",
+        "params": {"uri": "analyst://templates/golden/fraud_detection.yaml"},
+    }
+    response = client.post("/rpc", json=payload)
+    assert response.status_code == 200
+    contents = response.json()["result"]["contents"]
+    assert len(contents) == 1
+    assert contents[0]["uri"] == "analyst://templates/golden/fraud_detection.yaml"
+    assert "fraud" in contents[0]["text"].lower()
+
+
+def test_rpc_resources_read_not_found():
+    """Verify resources/read returns invalid params for unknown resource URI."""
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 22,
+        "method": "resources/read",
+        "params": {"uri": "analyst://templates/golden/does_not_exist.yaml"},
+    }
+    response = client.post("/rpc", json=payload)
+    assert response.status_code == 200
+    error = response.json()["error"]
+    assert error["code"] == -32602
+    assert "Resource not found" in error["message"]
+
+
+def test_rpc_resources_list_timeout(mocker):
+    """Verify resources/list surfaces timeout as a non-hanging RPC error."""
+    mocker.patch.object(
+        server_module,
+        "_resource_models_with_timeout",
+        mocker.AsyncMock(side_effect=asyncio.TimeoutError),
+    )
+    payload = {"jsonrpc": "2.0", "id": 26, "method": "resources/list", "params": {}}
+    response = client.post("/rpc", json=payload)
+    assert response.status_code == 200
+    error = response.json()["error"]
+    assert error["code"] == -32000
+    assert "timed out" in error["message"].lower()
+
+
+def test_rpc_resources_read_timeout(mocker):
+    """Verify resources/read surfaces timeout as a non-hanging RPC error."""
+    mocker.patch.object(
+        server_module,
+        "_read_template_with_timeout",
+        mocker.AsyncMock(side_effect=asyncio.TimeoutError),
+    )
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 27,
+        "method": "resources/read",
+        "params": {"uri": "analyst://templates/config/outlier_config_template.yaml"},
+    }
+    response = client.post("/rpc", json=payload)
+    assert response.status_code == 200
+    error = response.json()["error"]
+    assert error["code"] == -32000
+    assert "timed out" in error["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_toolkit_get_capability_catalog_timeout(mocker):
+    """Verify capability catalog fails fast on template read timeout."""
+    mocker.patch.object(cockpit_module, "TEMPLATE_IO_TIMEOUT_SEC", 0.01)
+    mocker.patch.object(
+        cockpit_module,
+        "_build_capability_catalog",
+        side_effect=lambda: time.sleep(0.05),
+    )
+    result = await cockpit_module._toolkit_get_capability_catalog()
+    assert result["status"] == "error"
+    assert "timed out" in result["error"].lower()
+
+
+@pytest.mark.asyncio
+async def test_toolkit_get_golden_templates_timeout(mocker):
+    """Verify golden template loading fails fast on timeout."""
+    mocker.patch.object(cockpit_module, "TEMPLATE_IO_TIMEOUT_SEC", 0.01)
+    mocker.patch.object(
+        cockpit_module,
+        "get_golden_configs",
+        side_effect=lambda: time.sleep(0.05),
+    )
+    result = await cockpit_module._toolkit_get_golden_templates()
+    assert result["status"] == "error"
+    assert "timed out" in result["error"].lower()
 
 
 def test_rpc_tool_not_found():


### PR DESCRIPTION
## Summary
- expose YAML templates as MCP resources/templates with URI validation and read handlers
- rework cockpit guidance/tools for agent+human use (`get_agent_playbook`, structured `get_user_quickstart`, capability catalog)
- harden resource/template reads with timeout-guarded thread offload to avoid event-loop wedging
- strengthen health checks and remove golden-template bind mount (templates now served from image)
- add/expand MCP tests including timeout regression coverage
- add CI secret scan stage and docs updates

## Validation
- `conda run -n analyst_toolkit_env python -m pytest -q tests/test_mcp_server.py` -> 15 passed
- `conda run -n analyst_toolkit_env mypy src/analyst_toolkit/mcp_server/server.py src/analyst_toolkit/mcp_server/tools/cockpit.py` -> success
