### PR TITLE
MCP post-hardening fixes: stabilize validation/history/imputation/preflight/export semantics

### DIFF
--- a/src/analyst_toolkit/mcp_server/tools/final_audit.py
+++ b/src/analyst_toolkit/mcp_server/tools/final_audit.py
@@ -18,6 +18,7 @@ from analyst_toolkit.mcp_server.io import (
     generate_default_export_path,
     get_session_metadata,
     load_input,
+    make_json_safe,
     resolve_run_context,
     save_output,
     save_to_session,
@@ -139,7 +140,7 @@ async def _toolkit_final_audit(
         if isinstance(check, dict) and "passed" in check and not check["passed"]
     ]
     violations_detail = {
-        name: check.get("details", {})
+        name: make_json_safe(check.get("details", {}))
         for name, check in validation_results.items()
         if isinstance(check, dict) and "passed" in check and not check["passed"]
     }

--- a/src/analyst_toolkit/mcp_server/tools/validation.py
+++ b/src/analyst_toolkit/mcp_server/tools/validation.py
@@ -16,6 +16,7 @@ from analyst_toolkit.mcp_server.io import (
     generate_default_export_path,
     get_session_metadata,
     load_input,
+    make_json_safe,
     resolve_run_context,
     save_output,
     save_to_session,
@@ -82,7 +83,7 @@ async def _toolkit_validation(
                 checks_run += 1
                 if not check["passed"]:
                     violations_found.append(check_name)
-                    violations_detail[check_name] = check.get("details", {})
+                    violations_detail[check_name] = make_json_safe(check.get("details", {}))
 
     passed = len(violations_found) == 0
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -380,6 +380,28 @@ def test_rpc_preflight_config_strict_fails_on_unknown_keys():
     assert any("Unknown top-level keys" in w for w in result["warnings"])
 
 
+def test_rpc_preflight_config_strict_fails_on_nested_unknown_keys():
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 44,
+        "method": "tools/call",
+        "params": {
+            "name": "preflight_config",
+            "arguments": {
+                "module_name": "normalization",
+                "strict": True,
+                "config": {"normalization": {"run": True, "bogus_key_for_test": 123}},
+            },
+        },
+    }
+    response = client.post("/rpc", json=payload)
+    assert response.status_code == 200
+    result = response.json()["result"]
+    assert result["status"] == "error"
+    assert result["summary"]["unknown_key_count"] >= 1
+    assert any("bogus_key_for_test" in k for k in result["unknown_keys"])
+
+
 def test_rpc_preflight_config_non_strict_warns_on_unknown_keys():
     payload = {
         "jsonrpc": "2.0",


### PR DESCRIPTION
## Summary
This PR fixes the next-layer defects found during the deep penguins MCP stress test and addresses issues #18-#22.

### Fixed
- JSON-safe serialization for validation/final_audit detail payloads and history writes.
- Corruption-tolerant run history reading with parse metadata (`parse_errors`, `skipped_records`).
- Atomic history file writes to prevent partial/truncated JSON.
- Imputation summary stability for duplicate-column DataFrames (prevents ambiguous Series truth-value crashes).
- Strict preflight unknown-key enforcement on normalized effective config (including nested normalization keys).
- Artifact contract data-export semantics improved for local paths:
  - detect missing local export path
  - explicit server-local export warning.

### Tool response updates
- `get_run_history` and `get_data_health_report` now surface parse metadata and return `status=warn` when parse recovery occurred.

## Tests
- Added regressions for:
  - JSON-safe history serialization of DataFrame-containing entries
  - corrupt history recovery + metadata
  - strict preflight nested unknown-key failure
  - imputation duplicate-column summary safety
  - local export artifact warning semantics

## Validation
- `pre-commit run --all-files` passed (ruff, ruff-format, mypy, pytest).

Closes #18
Closes #19
Closes #20
Closes #21
Closes #22