### PR TITLE
docs: expose auto-heal agent templates

### DIFF
--- a/config/auto_heal_request_template.yaml
+++ b/config/auto_heal_request_template.yaml
@@ -1,0 +1,23 @@
+runtime:
+  run:
+    run_id: "auto_heal_run_001"
+    input_path: "gs://bucket/path/to/input.csv"
+  artifacts:
+    export_html: true
+    plotting: false
+  destinations:
+    gcs:
+      enabled: false
+      bucket_uri: "gs://bucket/path/to/reviews"
+      prefix: "auto_heal"
+  execution:
+    upload_artifacts: true
+
+auto_heal:
+  session_id: ""
+  gcs_path: ""
+  mode: "sync"
+  notes:
+    - "Provide either runtime.run.input_path, gcs_path, or session_id."
+    - "Use auto_heal for one-shot remediation only when the user explicitly requests automation."
+    - "Treat dashboard_url or dashboard_path as the main operator review surface after execution."

--- a/src/analyst_toolkit/mcp_server/tools/cockpit_capabilities.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit_capabilities.py
@@ -180,6 +180,7 @@ def build_capability_catalog(*, golden_configs: dict[str, Any]) -> dict[str, Any
             "manual_override_recommended": True,
             "runtime_overlay_available": True,
             "runtime_template_path": "config/runtime_overlay_template.yaml",
+            "auto_heal_template_path": "config/auto_heal_request_template.yaml",
         },
         "global_controls": [
             {
@@ -245,6 +246,16 @@ def build_capability_catalog(*, golden_configs: dict[str, Any]) -> dict[str, Any
         ],
         "highlight_examples": [
             {
+                "feature": "Auto-heal one-shot remediation",
+                "paths": [
+                    "config/auto_heal_request_template.yaml",
+                    "runtime.run.run_id",
+                    "runtime.run.input_path",
+                    "runtime.artifacts.export_html",
+                    "runtime.destinations.gcs.enabled",
+                ],
+            },
+            {
                 "feature": "Runtime overlay controls",
                 "paths": [
                     "runtime.run.run_id",
@@ -272,6 +283,14 @@ def build_capability_catalog(*, golden_configs: dict[str, Any]) -> dict[str, Any
                     "imputation.settings.plotting.run",
                 ],
             },
+        ],
+        "workflow_templates": [
+            {
+                "tool": "auto_heal",
+                "template_path": "config/auto_heal_request_template.yaml",
+                "description": "One-shot automated cleaning request with runtime-scoped controls and dashboard output.",
+                "outputs": ["session_id", "dashboard_url?", "dashboard_path?", "export_url?"],
+            }
         ],
         "golden_templates": sorted(golden_configs.keys()),
         "modules": modules,

--- a/src/analyst_toolkit/mcp_server/tools/cockpit_content.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit_content.py
@@ -24,6 +24,7 @@ def user_quickstart_payload() -> dict:
 - Module tools can return `dashboard_url` when standalone HTML reports are uploaded or exposed for review.
 - Agents should surface those dashboard links to users instead of burying them in long summaries.
 - Use the dashboard artifact as the primary review surface when it exists.
+- `auto_heal` returns its own standalone dashboard artifact and should be surfaced the same way.
 
 ## Runtime Overlay
 - Use `runtime` for run-scoped execution policy.
@@ -35,6 +36,12 @@ def user_quickstart_payload() -> dict:
   - `runtime.destinations.gcs.*`
 - Keep module `config` for business logic like normalization rules, validation rules, imputation strategies, and outlier detection settings.
 - Prefer `runtime` over editing every module config when the change is cross-cutting.
+
+## Auto Heal
+- Use `auto_heal` only when the user explicitly wants one-shot remediation.
+- Start from `config/auto_heal_request_template.yaml` for agent-authored requests.
+- Prefer `runtime` for `run_id`, `input_path`, HTML export, and destination controls.
+- After the call, surface `dashboard_url` first and `dashboard_path` only as fallback.
 
 ## Key Example: Fuzzy Matching
 In normalization config:
@@ -101,6 +108,19 @@ Turn plotting off for speed on large datasets, on for exploratory analysis.
                 "tool": "infer_configs",
                 "arguments": {"session_id": "<session_id_from_diagnostics>"},
             },
+            {
+                "tool": "auto_heal",
+                "arguments": {
+                    "runtime": {
+                        "run": {
+                            "input_path": "gs://bucket/data.csv",
+                            "run_id": "auto_heal_run_001",
+                        },
+                        "artifacts": {"export_html": True, "plotting": False},
+                    },
+                    "mode": "sync",
+                },
+            },
         ],
     }
     return {
@@ -126,6 +146,13 @@ Turn plotting off for speed on large datasets, on for exploratory analysis.
                 "label": "Open capabilities",
                 "tool": "get_capability_catalog",
                 "arguments_schema_hint": {"required": []},
+            },
+            {
+                "label": "Run auto-heal",
+                "tool": "auto_heal",
+                "arguments_schema_hint": {
+                    "required": ["gcs_path|session_id|runtime.run.input_path"]
+                },
             },
         ],
     }
@@ -200,6 +227,20 @@ def agent_playbook_payload() -> dict:
             },
             {
                 "step": 6,
+                "tool": "auto_heal",
+                "required_inputs": [
+                    "gcs_path|session_id|runtime.run.input_path",
+                    "run_id|runtime.run.run_id",
+                ],
+                "outputs": ["session_id", "dashboard_url?", "dashboard_path?", "export_url?"],
+                "notes": [
+                    "Use only when the user explicitly wants one-shot automation.",
+                    "Open or link the auto-heal dashboard artifact for review.",
+                ],
+                "next": [7],
+            },
+            {
+                "step": 7,
                 "tool_chain": [
                     "normalization",
                     "duplicates",
@@ -214,10 +255,10 @@ def agent_playbook_payload() -> dict:
                     "Prefer the standalone dashboard artifact as the main review surface.",
                     "Use runtime instead of editing every module config when the override is cross-cutting.",
                 ],
-                "next": [7],
+                "next": [8],
             },
             {
-                "step": 7,
+                "step": 8,
                 "tool_chain": ["final_audit", "get_run_history"],
                 "required_inputs": ["session_id", "run_id"],
                 "outputs": ["final certificate artifacts", "healing ledger"],

--- a/tests/mcp_server/test_rpc_resources.py
+++ b/tests/mcp_server/test_rpc_resources.py
@@ -57,6 +57,22 @@ def test_rpc_resources_read(client):
     assert "fraud" in contents[0]["text"].lower()
 
 
+def test_rpc_resources_read_auto_heal_template(client):
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 121,
+        "method": "resources/read",
+        "params": {"uri": "analyst://templates/config/auto_heal_request_template.yaml"},
+    }
+    response = client.post("/rpc", json=payload)
+    assert response.status_code == 200
+    contents = response.json()["result"]["contents"]
+    assert len(contents) == 1
+    assert contents[0]["uri"] == "analyst://templates/config/auto_heal_request_template.yaml"
+    assert "auto_heal" in contents[0]["text"]
+    assert "runtime" in contents[0]["text"]
+
+
 def test_rpc_resources_read_not_found(client):
     """Verify resources/read returns invalid params for unknown resource URI."""
     payload = {

--- a/tests/mcp_server/test_rpc_tools.py
+++ b/tests/mcp_server/test_rpc_tools.py
@@ -48,10 +48,16 @@ def test_rpc_capability_catalog_tool(client):
     result = response.json()["result"]
     assert result["status"] == "pass"
     assert result["summary"]["editable_configs"] is True
+    assert result["summary"]["auto_heal_template_path"] == "config/auto_heal_request_template.yaml"
     assert any(
         p.endswith("fuzzy_matching.settings.<column>.score_cutoff")
         for item in result["highlight_examples"]
         for p in item["paths"]
+    )
+    assert any(
+        item["tool"] == "auto_heal"
+        and item["template_path"] == "config/auto_heal_request_template.yaml"
+        for item in result["workflow_templates"]
     )
     modules = {item["tool"]: item for item in result["modules"]}
     final_audit_knobs = {k["path"]: k["default"] for k in modules["final_audit"]["key_knobs"]}
@@ -111,12 +117,14 @@ def test_rpc_user_quickstart_tool(client):
     assert result["content"]["title"] == "Analyst Toolkit Quickstart"
     assert "fuzzy matching" in result["content"]["markdown"].lower()
     assert "plotting" in result["content"]["markdown"].lower()
+    assert "auto_heal" in result["content"]["markdown"]
     assert "machine_guide" in result
     assert result["machine_guide"]["ordered_steps"][1]["tool"] == "infer_configs"
     assert result["machine_guide"]["ordered_steps"][1]["required_inputs"] == ["gcs_path|session_id"]
     assert len(result["quick_actions"]) >= 2
     assert any(a["tool"] == "diagnostics" for a in result["quick_actions"])
     assert any(a["tool"] == "infer_configs" for a in result["quick_actions"])
+    assert any(a["tool"] == "auto_heal" for a in result["quick_actions"])
     infer_quick = next(a for a in result["quick_actions"] if a["tool"] == "infer_configs")
     assert infer_quick["arguments_schema_hint"]["required"] == ["gcs_path|session_id"]
     assert isinstance(result.get("trace_id"), str)
@@ -138,6 +146,13 @@ def test_rpc_agent_playbook_infer_configs_inputs_allow_path_or_session(client):
         step for step in result["ordered_steps"] if step.get("tool") == "infer_configs"
     )
     assert infer_step["required_inputs"] == ["gcs_path|session_id"]
+    auto_heal_step = next(
+        step for step in result["ordered_steps"] if step.get("tool") == "auto_heal"
+    )
+    assert auto_heal_step["required_inputs"] == [
+        "gcs_path|session_id|runtime.run.input_path",
+        "run_id|runtime.run.run_id",
+    ]
 
 
 def test_rpc_get_config_schema_supports_final_audit(client):


### PR DESCRIPTION
## Summary
- add a concrete auto-heal request template resource for agents
- expose auto-heal workflow/template metadata in the capability catalog
- update cockpit quickstart/playbook guidance to surface auto-heal and its dashboard artifact

## Validation
- ruff check src/analyst_toolkit/mcp_server/tools/cockpit_capabilities.py src/analyst_toolkit/mcp_server/tools/cockpit_content.py tests/mcp_server/test_rpc_resources.py tests/mcp_server/test_rpc_tools.py
- ruff format --check src/analyst_toolkit/mcp_server/tools/cockpit_capabilities.py src/analyst_toolkit/mcp_server/tools/cockpit_content.py tests/mcp_server/test_rpc_resources.py tests/mcp_server/test_rpc_tools.py
- pytest tests/mcp_server/test_rpc_resources.py tests/mcp_server/test_rpc_tools.py -q
