### PR TITLE
refactor: split dashboard renderer foundation

### DIFF
--- a/src/analyst_toolkit/m00_utils/dashboard_certification.py
+++ b/src/analyst_toolkit/m00_utils/dashboard_certification.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import html
+from collections.abc import Sized
 from typing import Any
 
 import pandas as pd
@@ -17,12 +18,24 @@ from analyst_toolkit.m00_utils.dashboard_shared import (
 from analyst_toolkit.m00_utils.dashboard_tables import _render_df
 
 
+def _extract_checks(results: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {
+        key: value
+        for key, value in results.items()
+        if isinstance(value, dict) and "passed" in value
+    }
+
+
+def _is_countable_issue_payload(value: Any) -> bool:
+    return isinstance(value, Sized) and not isinstance(value, (str, bytes))
+
+
 def _build_validation_summary_df(results: dict[str, Any]) -> pd.DataFrame:
-    checks = {k: v for k, v in results.items() if isinstance(v, dict) and "passed" in v}
+    checks = _extract_checks(results)
     rows = []
     for name, check in checks.items():
         details = check.get("details")
-        issue_count = len(details) if hasattr(details, "__len__") else 0
+        issue_count = len(details) if _is_countable_issue_payload(details) else 0
         status_label = "Pass" if check.get("passed") else f"Fail ({issue_count} issues)"
         status_class = "pass" if check.get("passed") else "fail"
         rows.append(
@@ -38,15 +51,15 @@ def _build_validation_summary_df(results: dict[str, Any]) -> pd.DataFrame:
 def _count_validation_issue_units(details: Any) -> int:
     if isinstance(details, dict):
         return sum(
-            len(value) if hasattr(value, "__len__") else 1 for value in details.values()
+            len(value) if _is_countable_issue_payload(value) else 1 for value in details.values()
         ) or len(details)
-    if hasattr(details, "__len__"):
+    if _is_countable_issue_payload(details):
         return len(details)
     return 0
 
 
 def _render_validation_drilldowns(results: dict[str, Any]) -> str:
-    checks = {k: v for k, v in results.items() if isinstance(v, dict) and "passed" in v}
+    checks = _extract_checks(results)
     blocks = []
     for name, check in checks.items():
         if check.get("passed"):
@@ -90,7 +103,14 @@ def _render_validation_drilldowns(results: dict[str, Any]) -> str:
                 f"{_render_df(df, full_preview=True)}</div>"
             )
         elif name == "dtype_enforcement":
-            df = pd.DataFrame.from_dict(details, orient="index")
+            if isinstance(details, pd.DataFrame):
+                df = details
+            elif isinstance(details, dict):
+                df = pd.DataFrame.from_dict(details, orient="index")
+            elif isinstance(details, list):
+                df = pd.DataFrame(details)
+            else:
+                df = pd.DataFrame([{"Value": str(details)}])
             df.index.name = "Column"
             parts.append(
                 "<div class='card'><h3>Dtype Drift</h3>"
@@ -130,11 +150,17 @@ def _render_validation_drilldowns(results: dict[str, Any]) -> str:
 
 
 def render_validation_dashboard(results: dict[str, Any], run_id: str) -> str:
-    checks = {k: v for k, v in results.items() if isinstance(v, dict) and "passed" in v}
+    checks = _extract_checks(results)
     total_checks = len(checks)
     passed_checks = sum(1 for check in checks.values() if check.get("passed"))
     failed_checks = total_checks - passed_checks
     coverage_pct = results.get("summary", {}).get("row_coverage_percent", "N/A")
+    coverage_display = (
+        f"{coverage_pct}%"
+        if isinstance(coverage_pct, (int, float))
+        or (isinstance(coverage_pct, str) and coverage_pct.replace(".", "", 1).isdigit())
+        else str(coverage_pct)
+    )
     decision_class = "pass" if failed_checks == 0 else "fail"
     failed_rule_pills = (
         "".join(
@@ -153,7 +179,7 @@ def render_validation_dashboard(results: dict[str, Any], run_id: str) -> str:
         f"<div class='cert-hero {decision_class}'>"
         "<div class='cert-kicker'>M02 Validation Gate</div>"
         f"<h2 class='cert-title'>{'Validation Passed' if failed_checks == 0 else 'Validation Requires Attention'}</h2>"
-        f"<p class='cert-copy'>Checks passed: {passed_checks}/{total_checks}. Row coverage: {coverage_pct}%. "
+        f"<p class='cert-copy'>Checks passed: {passed_checks}/{total_checks}. Row coverage: {coverage_display}. "
         + (
             "The current rule contract is satisfied."
             if failed_checks == 0
@@ -266,9 +292,11 @@ def _safe_summary_flag(summary_df: pd.DataFrame, metric_name: str) -> str:
 
 def _safe_metric_value(summary_df: pd.DataFrame, metric_name: str) -> int:
     try:
+        if "Metric" not in summary_df.columns or "Value" not in summary_df.columns:
+            return 0
         series = summary_df.loc[summary_df["Metric"] == metric_name, "Value"]
         return int(series.iloc[0]) if not series.empty else 0
-    except Exception:
+    except (ValueError, TypeError):
         return 0
 
 
@@ -280,7 +308,14 @@ def render_final_audit_dashboard(report: dict[str, Any], run_id: str) -> str:
         else pd.DataFrame()
     )
     status = str(status_row["Value"].iloc[0]) if not status_row.empty else "STATUS UNKNOWN"
-    ok = "CERTIFIED" in status and "❌" not in status
+    structured_ok = report.get("is_certified")
+    if structured_ok is None and isinstance(report.get("certification"), dict):
+        structured_ok = report["certification"].get("is_certified")
+    ok = (
+        bool(structured_ok)
+        if isinstance(structured_ok, bool)
+        else "CERTIFIED" in status and "❌" not in status
+    )
     cert_class = "pass" if ok else "fail"
     cert_title = "Healing Certificate Issued" if ok else "Certification Failed"
     cert_copy = (
@@ -358,8 +393,7 @@ def render_final_audit_dashboard(report: dict[str, Any], run_id: str) -> str:
                     "<div class='key'><strong>Resolution note</strong><ul>"
                     "<li>Each failed check is broken out below so the release blocker is explicit.</li>"
                     "<li>Use this section as the operator handoff for the final repair pass.</li>"
-                    "</ul></div></div>"
-                    + _render_final_audit_failures(report)
+                    "</ul></div></div>" + _render_final_audit_failures(report)
                 ),
                 open_by_default=True,
             )
@@ -382,8 +416,7 @@ def render_final_audit_dashboard(report: dict[str, Any], run_id: str) -> str:
                 "Final Data Profile",
                 (
                     "<div class='section-grid'>"
-                    "<div class='card'><h3>Data Lifecycle</h3>"
-                    f"{_render_df(lifecycle_df, full_preview=True)}"
+                    "<div class='card'><h3>Audit Remarks Key</h3>"
                     "<div class='key'><strong>Audit Remarks Key</strong><ul>"
                     "<li><strong>OK:</strong> Passed all configured quality checks.</li>"
                     "<li><strong>High Skew:</strong> Skewness exceeded threshold.</li>"

--- a/src/analyst_toolkit/m00_utils/dashboard_core.py
+++ b/src/analyst_toolkit/m00_utils/dashboard_core.py
@@ -1016,7 +1016,8 @@ def _assemble_page(
     toc_html = ""
     if toc_items:
         toc_links = "".join(
-            f"<a href='#{_slugify(anchor)}'>{html.escape(label)}</a>" for anchor, label in toc_items
+            f"<a href='#{html.escape(_slugify(anchor), quote=True)}'>{html.escape(label)}</a>"
+            for anchor, label in toc_items
         )
         toc_html = f"<div class='toc'><strong>Sections:</strong> {toc_links}</div>"
 
@@ -1024,6 +1025,7 @@ def _assemble_page(
     return (
         "<!DOCTYPE html><html><head>"
         "<meta charset='utf-8'>"
+        "<meta name='viewport' content='width=device-width, initial-scale=1'>"
         f"<title>{html.escape(page_title)} - {html.escape(run_id)}</title>"
         f"{_DASHBOARD_CSS}{_DASHBOARD_SCRIPT}</head><body><div class='page'>"
         "<div class='hero'>"

--- a/src/analyst_toolkit/m00_utils/dashboard_html.py
+++ b/src/analyst_toolkit/m00_utils/dashboard_html.py
@@ -40,6 +40,7 @@ from analyst_toolkit.m00_utils.dashboard_views import (
 _MAX_PREVIEW_ROWS = 50
 _SIZE_WARNING_THRESHOLD_MB = 25
 
+
 def _flatten_plot_paths(plot_paths: dict[str, Any] | None) -> list[tuple[str, str]]:
     items: list[tuple[str, str]] = []
     if not plot_paths:

--- a/src/analyst_toolkit/m00_utils/dashboard_shared.py
+++ b/src/analyst_toolkit/m00_utils/dashboard_shared.py
@@ -5,6 +5,22 @@ from __future__ import annotations
 import html
 from typing import Any
 
+STATUS_PASS_SET = frozenset(
+    {
+        "pass",
+        "passed",
+        "ok",
+        "available",
+        "ready",
+        "ready for final audit",
+        "healthy",
+        "certified",
+        "proceed",
+    }
+)
+STATUS_FAIL_SET = frozenset({"fail", "failed", "error", "blocked", "rejected", "repair"})
+STATUS_WARN_SET = frozenset({"warn", "warning", "missing", "disabled", "not_run"})
+
 
 def _slugify(value: str) -> str:
     return "".join(ch.lower() if ch.isalnum() else "-" for ch in value).strip("-")
@@ -22,26 +38,9 @@ def _metric_value(value: Any) -> str:
 
 def _status_tone_class(value: Any) -> str:
     normalized = str(value or "").strip().lower()
-    if normalized in {
-        "pass",
-        "passed",
-        "ok",
-        "available",
-        "ready",
-        "ready for final audit",
-        "healthy",
-        "certified",
-        "proceed",
-    }:
+    if normalized in STATUS_PASS_SET:
         return "pass"
-    if normalized in {
-        "fail",
-        "failed",
-        "error",
-        "blocked",
-        "rejected",
-        "repair",
-    }:
+    if normalized in STATUS_FAIL_SET:
         return "fail"
     if normalized:
         return "warn"
@@ -96,18 +95,16 @@ def _embed_reference_src(path_value: Any, url_value: Any) -> str:
     normalized_path = _normalize_reference_text(path_value)
     if normalized_url.startswith(("http://", "https://")):
         return normalized_url
-    if normalized_path.startswith("/exports/") or normalized_path.startswith(
-        ("http://", "https://")
-    ):
+    if normalized_path.startswith(("/exports/", "http://", "https://")):
         return normalized_path
     return ""
 
 
 def _module_badge(status: str) -> str:
     normalized = str(status or "unknown").lower()
-    if normalized in {"pass", "ok", "available"}:
+    if normalized in STATUS_PASS_SET:
         return f"<span class='badge-ok'>{html.escape(normalized.upper())}</span>"
-    if normalized in {"warn", "warning", "missing", "disabled", "not_run"}:
+    if normalized in STATUS_WARN_SET:
         return f"<span class='badge-warn'>{html.escape(normalized.upper())}</span>"
     return f"<span class='pill warn'>{html.escape(normalized.upper())}</span>"
 
@@ -123,9 +120,9 @@ def _status_chip(status: str) -> str:
     normalized = _tab_status_label(status).lower()
     chip_class = (
         "ok"
-        if normalized in {"pass", "available"}
+        if normalized in STATUS_PASS_SET
         else "fail"
-        if normalized in {"fail", "error"}
+        if normalized in STATUS_FAIL_SET
         else "warn"
     )
     return f"<span class='status-chip {chip_class}'>{html.escape(normalized.upper())}</span>"

--- a/src/analyst_toolkit/m00_utils/dashboard_tables.py
+++ b/src/analyst_toolkit/m00_utils/dashboard_tables.py
@@ -43,22 +43,13 @@ def _render_df(
         return "<p class='empty'>No data available.</p>"
 
     total_rows = len(df)
-    if full_preview:
-        working = _normalize_df_for_display(df)
-        if isinstance(working.columns, pd.MultiIndex):
-            working.columns = [
-                "__".join(str(part) for part in column if str(part)).strip("_")
-                for column in working.columns
-            ]
-        preview = working.copy()
-    else:
-        preview = _normalize_df_for_display(df.head(max_rows))
-        if isinstance(preview.columns, pd.MultiIndex):
-            preview.columns = [
-                "__".join(str(part) for part in column if str(part)).strip("_")
-                for column in preview.columns
-            ]
-        preview = preview.copy()
+    source = df if full_preview else df.head(max_rows)
+    preview = _normalize_df_for_display(source)
+    if isinstance(preview.columns, pd.MultiIndex):
+        preview.columns = [
+            "__".join(str(part) for part in column if str(part)).strip("_")
+            for column in preview.columns
+        ]
     safe_html_cols = allow_html_cols or set()
     for column in preview.columns:
         if str(column) in safe_html_cols:

--- a/src/analyst_toolkit/m00_utils/dashboard_views.py
+++ b/src/analyst_toolkit/m00_utils/dashboard_views.py
@@ -24,6 +24,21 @@ from analyst_toolkit.m00_utils.dashboard_tables import (
 )
 
 
+def _render_resource_inline_item(item: dict[str, Any], *, show_detail: bool = True) -> str:
+    detail_html = (
+        f"<p class='subtle'>{html.escape(str(item.get('Detail', '')))}</p>" if show_detail else ""
+    )
+    return (
+        "<div class='resource-inline-item'>"
+        f"<p class='resource-meta'>{html.escape(str(item.get('Kind', 'resource')).replace('_', ' ').title())}</p>"
+        f"<h4>{html.escape(str(item.get('Title', 'Untitled')))}</h4>"
+        f"{detail_html}"
+        "<p class='subtle'><strong>Open With</strong></p>"
+        f"{_render_reference_value(item.get('Reference', ''), empty_label='No reference recorded.')}"
+        "</div>"
+    )
+
+
 def _render_terminal_references(
     *,
     final_dashboard: Any,
@@ -202,6 +217,14 @@ def render_pipeline_dashboard(report: dict[str, Any], run_id: str) -> str:
     modules = report.get("modules", {})
     final_dashboard = report.get("final_dashboard_url") or report.get("final_dashboard_path")
     final_export = report.get("final_export_url")
+    module_ledger_rows = []
+    for name in module_order:
+        status = (modules.get(name) or {}).get("status", "unknown")
+        status_label = _tab_status_label(status)
+        module_ledger_rows.append(
+            {"Module": name, "Status": status_label, "Badge": _module_badge(status_label)}
+        )
+    module_ledger_df = pd.DataFrame(module_ledger_rows)
 
     banner_class = "ok" if failed_modules == 0 else "warn"
     banner = (
@@ -234,7 +257,7 @@ def render_pipeline_dashboard(report: dict[str, Any], run_id: str) -> str:
         "<div class='card'><h3>Final References</h3>"
         f"{_render_terminal_references(final_dashboard=final_dashboard, final_export=final_export, final_status=final_status, failed_modules=failed_modules, modules=modules, module_order=module_order)}"
         "</div>"
-        f"<div class='card'><h3>Module Status Ledger</h3>{_render_df(pd.DataFrame([{'Module': name, 'Status': _tab_status_label((modules.get(name) or {}).get('status', 'unknown')), 'Badge': _module_badge(_tab_status_label((modules.get(name) or {}).get('status', 'unknown')))} for name in module_order]), full_preview=True, allow_html_cols={'Badge'})}</div>"
+        f"<div class='card'><h3>Module Status Ledger</h3>{_render_df(module_ledger_df, full_preview=True, allow_html_cols={'Badge'})}</div>"
         "</div>"
         "</div>"
     )
@@ -444,15 +467,7 @@ def render_cockpit_dashboard(report: dict[str, Any], run_id: str) -> str:
             group_items = template_items
         items_html = []
         for item in group_items:
-            items_html.append(
-                "<div class='resource-inline-item'>"
-                f"<p class='resource-meta'>{html.escape(str(item.get('Kind', 'resource')).replace('_', ' ').title())}</p>"
-                f"<h4>{html.escape(str(item.get('Title', 'Untitled')))}</h4>"
-                f"<p class='subtle'>{html.escape(str(item.get('Detail', '')))}</p>"
-                "<p class='subtle'><strong>Open With</strong></p>"
-                f"{_render_reference_value(item.get('Reference', ''), empty_label='No reference recorded.')}"
-                "</div>"
-            )
+            items_html.append(_render_resource_inline_item(item, show_detail=True))
         grouped_resources.append(
             "<div class='readme-section'>"
             f"<h3>{html.escape(str(group.get('title', 'Resources')))}</h3>"
@@ -463,12 +478,7 @@ def render_cockpit_dashboard(report: dict[str, Any], run_id: str) -> str:
             "</div>"
         )
     all_resource_refs = "".join(
-        "<div class='resource-inline-item'>"
-        f"<p class='resource-meta'>{html.escape(str(item.get('Kind', 'resource')).replace('_', ' ').title())}</p>"
-        f"<h4>{html.escape(str(item.get('Title', 'Untitled')))}</h4>"
-        f"{_render_reference_value(item.get('Reference', ''), empty_label='No reference recorded.')}"
-        "</div>"
-        for item in reference_items
+        _render_resource_inline_item(item, show_detail=False) for item in reference_items
     )
     resources_panel = (
         "<div class='readme-grid'>"


### PR DESCRIPTION
## Summary
- extract shared dashboard helpers, page shell, tables, and view renderers out of dashboard_html.py
- preserve the existing generate_dashboard_html facade and report/notebook import paths
- move pipeline, cockpit, validation, and final-audit renderers into dedicated modules
- tighten shared renderer logic based on review feedback

## Validation
- ruff format --check on touched renderer files
- pytest tests/m00_utils/test_dashboard_html.py tests/mcp_server/test_rpc_tools.py tests/test_export_plot_wiring.py -q
- python -m py_compile on extracted renderer modules
