### PR TITLE
fix: follow up normalization dashboard polish

### DIFF
--- a/src/analyst_toolkit/m00_utils/dashboard_data_prep.py
+++ b/src/analyst_toolkit/m00_utils/dashboard_data_prep.py
@@ -399,16 +399,23 @@ def render_normalization_dashboard(report: dict[str, Any], run_id: str) -> str:
         )
         toc.append(("Scalar Changelog Notes", "Scalar Changelog Notes"))
 
-    if isinstance(column_changes_df, pd.DataFrame) and not column_changes_df.empty:
+    has_column_changes = isinstance(column_changes_df, pd.DataFrame) and not column_changes_df.empty
+    has_column_value_analysis = isinstance(column_value_analysis, dict) and bool(column_value_analysis)
+    if has_column_changes or has_column_value_analysis:
+        column_change_summary_html = (
+            "<div class='card wide'>"
+            "<h3>Column Change Summary</h3>"
+            "<p class='subtle'>This shows which columns absorbed the most normalization changes in this run.</p>"
+            f"{_render_df(column_changes_df, full_preview=True, wide_layout=True)}"
+            "</div>"
+            if has_column_changes
+            else ""
+        )
         sections.append(
             _render_section(
                 "Column Value Analysis",
                 (
-                    "<div class='card wide'>"
-                    "<h3>Column Change Summary</h3>"
-                    "<p class='subtle'>This shows which columns absorbed the most normalization changes in this run.</p>"
-                    f"{_render_df(column_changes_df, full_preview=True, wide_layout=True)}"
-                    "</div>"
+                    f"{column_change_summary_html}"
                     f"{_render_normalization_column_value_analysis(column_value_analysis)}"
                 ),
                 open_by_default=True,

--- a/src/analyst_toolkit/m00_utils/dashboard_data_prep.py
+++ b/src/analyst_toolkit/m00_utils/dashboard_data_prep.py
@@ -400,7 +400,9 @@ def render_normalization_dashboard(report: dict[str, Any], run_id: str) -> str:
         toc.append(("Scalar Changelog Notes", "Scalar Changelog Notes"))
 
     has_column_changes = isinstance(column_changes_df, pd.DataFrame) and not column_changes_df.empty
-    has_column_value_analysis = isinstance(column_value_analysis, dict) and bool(column_value_analysis)
+    has_column_value_analysis = isinstance(column_value_analysis, dict) and bool(
+        column_value_analysis
+    )
     if has_column_changes or has_column_value_analysis:
         column_change_summary_html = (
             "<div class='card wide'>"

--- a/src/analyst_toolkit/m00_utils/report_tables.py
+++ b/src/analyst_toolkit/m00_utils/report_tables.py
@@ -6,19 +6,26 @@ from typing import Any
 import pandas as pd
 
 
-def _lookup_original_column_name(changelog: dict[str, Any], normalized_col: str) -> str:
+def _resolve_preview_column_pair(
+    changelog: dict[str, Any], preview_column: str
+) -> tuple[str, str]:
     renamed_columns = changelog.get("renamed_columns")
     if (
         isinstance(renamed_columns, pd.DataFrame)
         and not renamed_columns.empty
         and {"Original Name", "New Name"}.issubset(renamed_columns.columns)
     ):
-        matched = renamed_columns.loc[
-            renamed_columns["New Name"] == normalized_col, "Original Name"
+        matched_new = renamed_columns.loc[
+            renamed_columns["New Name"] == preview_column, "Original Name"
         ]
-        if not matched.empty:
-            return str(matched.iloc[0])
-    return normalized_col
+        if not matched_new.empty:
+            return str(matched_new.iloc[0]), preview_column
+        matched_original = renamed_columns.loc[
+            renamed_columns["Original Name"] == preview_column, "New Name"
+        ]
+        if not matched_original.empty:
+            return preview_column, str(matched_original.iloc[0])
+    return preview_column, preview_column
 
 
 def _build_column_value_analysis(
@@ -29,12 +36,12 @@ def _build_column_value_analysis(
 ) -> dict[str, dict[str, pd.DataFrame]]:
     analysis: dict[str, dict[str, pd.DataFrame]] = {}
     for column in preview_columns:
-        original_col = _lookup_original_column_name(changelog, column)
-        if original_col not in df_original.columns or column not in df_transformed.columns:
+        original_col, transformed_col = _resolve_preview_column_pair(changelog, column)
+        if original_col not in df_original.columns or transformed_col not in df_transformed.columns:
             continue
 
         before_counts = df_original[original_col].value_counts(dropna=False)
-        after_counts = df_transformed[column].value_counts(dropna=False)
+        after_counts = df_transformed[transformed_col].value_counts(dropna=False)
         normalized_values = (
             pd.DataFrame({"Value": after_counts.index, "Count": after_counts.values})
             .sort_values(by="Count", ascending=False)
@@ -52,7 +59,7 @@ def _build_column_value_analysis(
             .sort_values(by=["Original Count", "Normalized Count"], ascending=False)
             .reset_index(drop=True)
         )
-        analysis[column] = {
+        analysis[transformed_col] = {
             "normalized_values": normalized_values,
             "value_audit": audit_df,
         }

--- a/src/analyst_toolkit/m00_utils/report_tables.py
+++ b/src/analyst_toolkit/m00_utils/report_tables.py
@@ -6,9 +6,7 @@ from typing import Any
 import pandas as pd
 
 
-def _resolve_preview_column_pair(
-    changelog: dict[str, Any], preview_column: str
-) -> tuple[str, str]:
+def _resolve_preview_column_pair(changelog: dict[str, Any], preview_column: str) -> tuple[str, str]:
     renamed_columns = changelog.get("renamed_columns")
     if (
         isinstance(renamed_columns, pd.DataFrame)

--- a/tests/m00_utils/test_dashboard_html.py
+++ b/tests/m00_utils/test_dashboard_html.py
@@ -321,7 +321,14 @@ def test_generate_normalization_dashboard_renders_transform_story():
 def test_generate_normalization_dashboard_renders_column_value_analysis_without_summary_table():
     report = {
         "row_change_summary": pd.DataFrame(
-            [{"rows_total": 3, "rows_changed": 1, "rows_unchanged": 2, "rows_changed_percent": 33.33}]
+            [
+                {
+                    "rows_total": 3,
+                    "rows_changed": 1,
+                    "rows_unchanged": 2,
+                    "rows_changed_percent": 33.33,
+                }
+            ]
         ),
         "column_changes_summary": pd.DataFrame(),
         "changed_rows_preview": pd.DataFrame(),

--- a/tests/m00_utils/test_dashboard_html.py
+++ b/tests/m00_utils/test_dashboard_html.py
@@ -318,6 +318,44 @@ def test_generate_normalization_dashboard_renders_transform_story():
     assert "MALE" in html
 
 
+def test_generate_normalization_dashboard_renders_column_value_analysis_without_summary_table():
+    report = {
+        "row_change_summary": pd.DataFrame(
+            [{"rows_total": 3, "rows_changed": 1, "rows_unchanged": 2, "rows_changed_percent": 33.33}]
+        ),
+        "column_changes_summary": pd.DataFrame(),
+        "changed_rows_preview": pd.DataFrame(),
+        "column_value_analysis": {
+            "gender": {
+                "normalized_values": pd.DataFrame([{"Value": "MALE", "Count": 1}]),
+                "value_audit": pd.DataFrame(
+                    [{"Value": "male", "Original Count": 1, "Normalized Count": 0}]
+                ),
+            }
+        },
+        "changelog": {
+            "values_mapped": pd.DataFrame([{"Column": "gender", "Mappings Applied": 1}]),
+        },
+        "meta_info": pd.DataFrame(
+            [
+                {
+                    "module": "normalization",
+                    "run_id": "run-norm-002",
+                    "timestamp": "2026-03-15T00:00:00+00:00",
+                    "original_shape": "(3, 2)",
+                    "transformed_shape": "(3, 2)",
+                }
+            ]
+        ),
+    }
+
+    html = generate_html_report(report, "Normalization", "run-norm-002")
+
+    assert "Column Value Analysis" in html
+    assert "Column Value Audit: gender" in html
+    assert "Column Change Summary" not in html
+
+
 def test_generate_duplicates_dashboard_renders_mode_criteria_and_plots(tmp_path):
     plot_path = tmp_path / "duplicates.png"
     plot_path.write_bytes(_ONE_PIXEL_PNG)

--- a/tests/m00_utils/test_report_tables.py
+++ b/tests/m00_utils/test_report_tables.py
@@ -1,0 +1,32 @@
+import pandas as pd
+
+from analyst_toolkit.m00_utils.report_tables import generate_transformation_report
+
+
+def test_generate_transformation_report_resolves_renamed_preview_columns():
+    df_original = pd.DataFrame({"sex": ["male", "female"], "bill_length_mm": [39.1, 40.3]})
+    df_transformed = pd.DataFrame(
+        {"gender": ["MALE", "FEMALE"], "bill_length_mm": [39.1, 40.3]}
+    )
+    changelog = {
+        "renamed_columns": pd.DataFrame([{"Original Name": "sex", "New Name": "gender"}]),
+        "values_mapped": pd.DataFrame([{"Column": "gender", "Mappings Applied": 2}]),
+    }
+
+    report = generate_transformation_report(
+        df_original=df_original,
+        df_transformed=df_transformed,
+        changelog=changelog,
+        module_name="normalization",
+        run_id="run-norm-report",
+        export_config={},
+        preview_columns=["sex"],
+    )
+
+    column_value_analysis = report.get("column_value_analysis", {})
+    assert isinstance(column_value_analysis, dict)
+    assert "gender" in column_value_analysis
+
+    value_audit = column_value_analysis["gender"]["value_audit"]
+    assert isinstance(value_audit, pd.DataFrame)
+    assert set(value_audit.columns) == {"Value", "Original Count", "Normalized Count"}

--- a/tests/m00_utils/test_report_tables.py
+++ b/tests/m00_utils/test_report_tables.py
@@ -5,9 +5,7 @@ from analyst_toolkit.m00_utils.report_tables import generate_transformation_repo
 
 def test_generate_transformation_report_resolves_renamed_preview_columns():
     df_original = pd.DataFrame({"sex": ["male", "female"], "bill_length_mm": [39.1, 40.3]})
-    df_transformed = pd.DataFrame(
-        {"gender": ["MALE", "FEMALE"], "bill_length_mm": [39.1, 40.3]}
-    )
+    df_transformed = pd.DataFrame({"gender": ["MALE", "FEMALE"], "bill_length_mm": [39.1, 40.3]})
     changelog = {
         "renamed_columns": pd.DataFrame([{"Original Name": "sex", "New Name": "gender"}]),
         "values_mapped": pd.DataFrame([{"Column": "gender", "Mappings Applied": 2}]),


### PR DESCRIPTION
## Summary
- bring over the normalization dashboard polish commits that were pushed after PR #49 merged
- preserve the notebook-inspired per-column audits and the related hardening fixes
- keep the follow-up scoped to the missed normalization dashboard changes only

## Validation
- ruff check on touched normalization files
- pytest tests/m00_utils/test_dashboard_html.py tests/m00_utils/test_report_tables.py -q
