### PR TITLE
chore: clean up public repo surfaces

### DIFF
--- a/resource_hub/config_guide.md
+++ b/resource_hub/config_guide.md
@@ -6,7 +6,11 @@
 <p align="center">
   <img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue">
   <img alt="Status" src="https://img.shields.io/badge/status-stable-brightgreen">
-  <img alt="Version" src="https://img.shields.io/badge/version-v0.4.0-blueviolet">
+  <img alt="Version" src="https://img.shields.io/badge/version-v0.4.4-blueviolet">
+  <a href="https://github.com/G-Schumacher44/analyst_toolkit/actions/workflows/analyst-toolkit-mcp-ci.yml">
+    <img alt="CI" src="https://github.com/G-Schumacher44/analyst_toolkit/actions/workflows/analyst-toolkit-mcp-ci.yml/badge.svg">
+  </a>
+  <img alt="GHCR" src="https://img.shields.io/badge/ghcr.io-analyst--toolkit--mcp-blue?logo=docker">
 </p>
 
 ---
@@ -16,6 +20,8 @@
 The Analyst Toolkit is governed entirely by modular YAML configuration files. These configs define the behavior of each module — from data validation and profiling to outlier handling and certification testing.
 
 Each YAML configuration file serves a specific purpose and is passed to the pipeline via CLI or notebook workflows.
+
+For MCP-specific template/resource exposure and remote tool usage, see the [MCP Server Guide](mcp_server_guide.md).
 
 ### Downloadable YAML Templates
 

--- a/resource_hub/mcp_server_guide.md
+++ b/resource_hub/mcp_server_guide.md
@@ -7,6 +7,10 @@
   <img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue">
   <img alt="Status" src="https://img.shields.io/badge/status-stable-brightgreen">
   <img alt="Version" src="https://img.shields.io/badge/version-v0.4.4-blueviolet">
+  <a href="https://github.com/G-Schumacher44/analyst_toolkit/actions/workflows/analyst-toolkit-mcp-ci.yml">
+    <img alt="CI" src="https://github.com/G-Schumacher44/analyst_toolkit/actions/workflows/analyst-toolkit-mcp-ci.yml/badge.svg">
+  </a>
+  <img alt="GHCR" src="https://img.shields.io/badge/ghcr.io-analyst--toolkit--mcp-blue?logo=docker">
 </p>
 
 ---

--- a/resource_hub/notebook_usage_guide.md
+++ b/resource_hub/notebook_usage_guide.md
@@ -6,7 +6,11 @@
 <p align="center">
   <img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue">
   <img alt="Status" src="https://img.shields.io/badge/status-stable-brightgreen">
-  <img alt="Version" src="https://img.shields.io/badge/version-v0.4.0-blueviolet">
+  <img alt="Version" src="https://img.shields.io/badge/version-v0.4.4-blueviolet">
+  <a href="https://github.com/G-Schumacher44/analyst_toolkit/actions/workflows/analyst-toolkit-mcp-ci.yml">
+    <img alt="CI" src="https://github.com/G-Schumacher44/analyst_toolkit/actions/workflows/analyst-toolkit-mcp-ci.yml/badge.svg">
+  </a>
+  <img alt="GHCR" src="https://img.shields.io/badge/ghcr.io-analyst--toolkit--mcp-blue?logo=docker">
 </p>
 
 

--- a/resource_hub/usage_guide.md
+++ b/resource_hub/usage_guide.md
@@ -7,6 +7,10 @@
   <img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue">
   <img alt="Status" src="https://img.shields.io/badge/status-stable-brightgreen">
   <img alt="Version" src="https://img.shields.io/badge/version-v0.4.4-blueviolet">
+  <a href="https://github.com/G-Schumacher44/analyst_toolkit/actions/workflows/analyst-toolkit-mcp-ci.yml">
+    <img alt="CI" src="https://github.com/G-Schumacher44/analyst_toolkit/actions/workflows/analyst-toolkit-mcp-ci.yml/badge.svg">
+  </a>
+  <img alt="GHCR" src="https://img.shields.io/badge/ghcr.io-analyst--toolkit--mcp-blue?logo=docker">
 </p>
 
 


### PR DESCRIPTION
## Summary
- clean up public-facing repo docs, dependency metadata, and MCP packaging surfaces
- remove the tracked deployment wheel and unused dev requirements files
- refresh README assets, sample dashboards, changelog generation, and environment/docker docs
- align release metadata and resource-hub badges for 0.4.4

## Validation
- pytest tests/test_mcp_tool_regressions.py -q
- python -m py_compile src/analyst_toolkit/mcp_server/tools/infer_configs.py
- python -m py_compile scripts/generate_changelog.py
- python -m build --wheel --no-isolation
- yamllint environment.yaml
- yamllint .github/workflows .coderabbit.yaml
- ruff check src/ tests/
