### PR TITLE
feat: add MCP input ingest subsystem

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,6 +16,8 @@ reviews:
     enabled: true
     drafts: true
     auto_incremental_review: true
+    base_branches:
+      - "dev"
   path_filters:
     - "src/**"
     - "tests/**"

--- a/.github/workflows/analyst-toolkit-mcp-ci.yml
+++ b/.github/workflows/analyst-toolkit-mcp-ci.yml
@@ -2,10 +2,10 @@ name: Analyst Toolkit MCP CI
 
 on:
   push:
-    branches: [main, master]
+    branches: [dev, main, master]
     tags: ["v*"]
   pull_request:
-    branches: [main, master]
+    branches: [dev, main, master]
 
 jobs:
   secret-scan:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ mcp = [
   "mcp>=1.2.1",
   "pyarrow>=14.0",
   "google-cloud-storage>=2.14",
+  "python-multipart>=0.0.9",
   "pydantic>=2.0",
 ]
 dev = [

--- a/src/analyst_toolkit/mcp_server/config_models.py
+++ b/src/analyst_toolkit/mcp_server/config_models.py
@@ -206,6 +206,9 @@ class RuntimeRunConfig(BaseModel):
     session_id: Optional[str] = Field(
         None, description="Optional existing session_id for runtime-scoped execution."
     )
+    input_id: Optional[str] = Field(
+        None, description="Optional canonical input reference returned by the ingest subsystem."
+    )
     input_path: Optional[str] = Field(None, description="Optional runtime input path override.")
 
 

--- a/src/analyst_toolkit/mcp_server/input/__init__.py
+++ b/src/analyst_toolkit/mcp_server/input/__init__.py
@@ -1,0 +1,15 @@
+"""Input ingest subsystem for MCP data sources."""
+
+from analyst_toolkit.mcp_server.input.ingest import (
+    get_input_descriptor,
+    ingest_uploaded_bytes,
+    load_dataframe,
+    register_input_source,
+)
+
+__all__ = [
+    "get_input_descriptor",
+    "ingest_uploaded_bytes",
+    "load_dataframe",
+    "register_input_source",
+]

--- a/src/analyst_toolkit/mcp_server/input/adapters.py
+++ b/src/analyst_toolkit/mcp_server/input/adapters.py
@@ -15,15 +15,25 @@ def detect_source_type(reference: str) -> InputSourceType:
         return "gcs"
     if parsed.scheme in {"gdrive", "drive"}:
         return "gdrive"
+    if parsed.scheme:
+        raise ValueError(
+            f"Unsupported input scheme '{parsed.scheme}'. Use a server-visible path, gs:// URI, or upload."
+        )
     return "server_path"
 
 
 def resolve_source_reference(
     reference: str, source_type: InputSourceType | None = None
 ) -> tuple[InputSourceType, str, str]:
-    resolved_type = source_type or detect_source_type(reference)
+    detected_type = detect_source_type(reference)
+    if source_type is not None and source_type != detected_type:
+        raise ValueError(
+            f"Explicit source_type '{source_type}' does not match reference '{reference}'."
+        )
+    resolved_type = source_type or detected_type
     if resolved_type == "gcs":
-        return resolved_type, reference, Path(reference).name or reference
+        filename = reference.rstrip("/").split("/")[-1] or reference
+        return resolved_type, reference, filename
     if resolved_type == "gdrive":
         raise NotImplementedError(
             "Google Drive inputs are not implemented yet. Upload the file, use a server-visible path, or use gs://."

--- a/src/analyst_toolkit/mcp_server/input/adapters.py
+++ b/src/analyst_toolkit/mcp_server/input/adapters.py
@@ -1,0 +1,30 @@
+"""Source adapters for MCP input ingestion."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from urllib.parse import urlparse
+
+from analyst_toolkit.mcp_server.input.models import InputSourceType
+from analyst_toolkit.mcp_server.input.storage import validate_server_visible_path
+
+
+def detect_source_type(reference: str) -> InputSourceType:
+    parsed = urlparse(reference)
+    if parsed.scheme == "gs":
+        return "gcs"
+    if parsed.scheme in {"gdrive", "drive"}:
+        return "gdrive"
+    return "server_path"
+
+
+def resolve_source_reference(reference: str, source_type: InputSourceType | None = None) -> tuple[InputSourceType, str, str]:
+    resolved_type = source_type or detect_source_type(reference)
+    if resolved_type == "gcs":
+        return resolved_type, reference, Path(reference).name or reference
+    if resolved_type == "gdrive":
+        raise NotImplementedError(
+            "Google Drive inputs are not implemented yet. Upload the file, use a server-visible path, or use gs://."
+        )
+    resolved_path = validate_server_visible_path(reference)
+    return resolved_type, str(resolved_path), resolved_path.name

--- a/src/analyst_toolkit/mcp_server/input/adapters.py
+++ b/src/analyst_toolkit/mcp_server/input/adapters.py
@@ -18,7 +18,9 @@ def detect_source_type(reference: str) -> InputSourceType:
     return "server_path"
 
 
-def resolve_source_reference(reference: str, source_type: InputSourceType | None = None) -> tuple[InputSourceType, str, str]:
+def resolve_source_reference(
+    reference: str, source_type: InputSourceType | None = None
+) -> tuple[InputSourceType, str, str]:
     resolved_type = source_type or detect_source_type(reference)
     if resolved_type == "gcs":
         return resolved_type, reference, Path(reference).name or reference

--- a/src/analyst_toolkit/mcp_server/input/ingest.py
+++ b/src/analyst_toolkit/mcp_server/input/ingest.py
@@ -1,0 +1,130 @@
+"""Input ingest orchestration for the MCP server."""
+
+from __future__ import annotations
+
+import mimetypes
+import uuid
+from pathlib import Path
+
+import pandas as pd
+
+from analyst_toolkit.mcp_server.input.adapters import resolve_source_reference
+from analyst_toolkit.mcp_server.input.loaders import load_dataframe_from_descriptor
+from analyst_toolkit.mcp_server.input.models import InputDescriptor, InputSourceType
+from analyst_toolkit.mcp_server.input.registry import (
+    bind_session_input,
+    get_descriptor,
+    get_session_input_id,
+    save_descriptor,
+)
+from analyst_toolkit.mcp_server.input.storage import stage_uploaded_file
+from analyst_toolkit.mcp_server.state import StateStore
+
+
+def _new_input_id() -> str:
+    return f"input_{uuid.uuid4().hex[:12]}"
+
+
+def get_input_descriptor(input_id: str) -> InputDescriptor | None:
+    return get_descriptor(input_id)
+
+
+def ingest_uploaded_bytes(
+    *,
+    filename: str,
+    payload: bytes,
+    media_type: str | None,
+    session_id: str | None = None,
+    run_id: str | None = None,
+    load_into_session: bool = True,
+) -> tuple[InputDescriptor, pd.DataFrame | None, str | None]:
+    staged_path, digest, size = stage_uploaded_file(filename=filename, payload=payload)
+    descriptor = InputDescriptor(
+        input_id=_new_input_id(),
+        source_type="upload",
+        original_reference=filename,
+        resolved_reference=str(staged_path),
+        display_name=Path(filename).name,
+        media_type=media_type or mimetypes.guess_type(filename)[0] or "application/octet-stream",
+        file_size_bytes=size,
+        sha256=digest,
+        session_id=session_id,
+        run_id=run_id,
+    )
+    descriptor = save_descriptor(descriptor)
+    df: pd.DataFrame | None = None
+    effective_session_id = session_id
+    if load_into_session:
+        df = load_dataframe_from_descriptor(descriptor)
+        effective_session_id = StateStore.save(df, session_id=session_id, run_id=run_id)
+        bind_session_input(effective_session_id, descriptor.input_id)
+        descriptor = InputDescriptor(**{**descriptor.to_dict(), "session_id": effective_session_id})
+        descriptor = save_descriptor(descriptor)
+    return descriptor, df, effective_session_id
+
+
+def register_input_source(
+    *,
+    reference: str,
+    source_type: InputSourceType | None = None,
+    session_id: str | None = None,
+    run_id: str | None = None,
+    load_into_session: bool = True,
+) -> tuple[InputDescriptor, pd.DataFrame | None, str | None]:
+    resolved_type, resolved_reference, display_name = resolve_source_reference(reference, source_type)
+    descriptor = InputDescriptor(
+        input_id=_new_input_id(),
+        source_type=resolved_type,
+        original_reference=reference,
+        resolved_reference=resolved_reference,
+        display_name=display_name,
+        media_type=mimetypes.guess_type(display_name)[0] or "application/octet-stream",
+        session_id=session_id,
+        run_id=run_id,
+    )
+    descriptor = save_descriptor(descriptor)
+    df: pd.DataFrame | None = None
+    effective_session_id = session_id
+    if load_into_session:
+        df = load_dataframe_from_descriptor(descriptor)
+        effective_session_id = StateStore.save(df, session_id=session_id, run_id=run_id)
+        bind_session_input(effective_session_id, descriptor.input_id)
+        descriptor = InputDescriptor(**{**descriptor.to_dict(), "session_id": effective_session_id})
+        descriptor = save_descriptor(descriptor)
+    return descriptor, df, effective_session_id
+
+
+def load_dataframe(
+    *,
+    path: str | None = None,
+    session_id: str | None = None,
+    input_id: str | None = None,
+) -> pd.DataFrame:
+    if session_id:
+        df = StateStore.get(session_id)
+        if df is not None:
+            return df
+        bound_input_id = get_session_input_id(session_id)
+        if bound_input_id:
+            descriptor = get_descriptor(bound_input_id)
+            if descriptor is not None:
+                return load_dataframe_from_descriptor(descriptor)
+        if not path and not input_id:
+            raise ValueError(f"Session {session_id} not found and no input reference provided.")
+
+    if input_id:
+        descriptor = get_descriptor(input_id)
+        if descriptor is None:
+            raise FileNotFoundError(f"Input ID not found: '{input_id}'")
+        return load_dataframe_from_descriptor(descriptor)
+
+    if not path:
+        raise ValueError("One of 'path', 'session_id', or 'input_id' must be provided.")
+
+    descriptor, df, _effective_session = register_input_source(
+        reference=path,
+        load_into_session=False,
+    )
+    if df is not None:
+        return df
+    return load_dataframe_from_descriptor(descriptor)

--- a/src/analyst_toolkit/mcp_server/input/ingest.py
+++ b/src/analyst_toolkit/mcp_server/input/ingest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import mimetypes
 import uuid
+from dataclasses import replace
 from pathlib import Path
 
 import pandas as pd
@@ -51,15 +52,15 @@ def ingest_uploaded_bytes(
         session_id=session_id,
         run_id=run_id,
     )
-    descriptor = save_descriptor(descriptor)
     df: pd.DataFrame | None = None
     effective_session_id = session_id
     if load_into_session:
         df = load_dataframe_from_descriptor(descriptor)
         effective_session_id = StateStore.save(df, session_id=session_id, run_id=run_id)
+        descriptor = replace(descriptor, session_id=effective_session_id)
+    descriptor = save_descriptor(descriptor)
+    if load_into_session and effective_session_id is not None:
         bind_session_input(effective_session_id, descriptor.input_id)
-        descriptor = InputDescriptor(**{**descriptor.to_dict(), "session_id": effective_session_id})
-        descriptor = save_descriptor(descriptor)
     return descriptor, df, effective_session_id
 
 
@@ -84,15 +85,15 @@ def register_input_source(
         session_id=session_id,
         run_id=run_id,
     )
-    descriptor = save_descriptor(descriptor)
     df: pd.DataFrame | None = None
     effective_session_id = session_id
     if load_into_session:
         df = load_dataframe_from_descriptor(descriptor)
         effective_session_id = StateStore.save(df, session_id=session_id, run_id=run_id)
+        descriptor = replace(descriptor, session_id=effective_session_id)
+    descriptor = save_descriptor(descriptor)
+    if load_into_session and effective_session_id is not None:
         bind_session_input(effective_session_id, descriptor.input_id)
-        descriptor = InputDescriptor(**{**descriptor.to_dict(), "session_id": effective_session_id})
-        descriptor = save_descriptor(descriptor)
     return descriptor, df, effective_session_id
 
 
@@ -127,6 +128,4 @@ def load_dataframe(
         reference=path,
         load_into_session=False,
     )
-    if df is not None:
-        return df
     return load_dataframe_from_descriptor(descriptor)

--- a/src/analyst_toolkit/mcp_server/input/ingest.py
+++ b/src/analyst_toolkit/mcp_server/input/ingest.py
@@ -71,7 +71,9 @@ def register_input_source(
     run_id: str | None = None,
     load_into_session: bool = True,
 ) -> tuple[InputDescriptor, pd.DataFrame | None, str | None]:
-    resolved_type, resolved_reference, display_name = resolve_source_reference(reference, source_type)
+    resolved_type, resolved_reference, display_name = resolve_source_reference(
+        reference, source_type
+    )
     descriptor = InputDescriptor(
         input_id=_new_input_id(),
         source_type=resolved_type,

--- a/src/analyst_toolkit/mcp_server/input/loaders.py
+++ b/src/analyst_toolkit/mcp_server/input/loaders.py
@@ -10,15 +10,25 @@ from analyst_toolkit.mcp_server.input.models import InputDescriptor
 from analyst_toolkit.mcp_server.io_storage import load_from_gcs
 
 
+class InputNotSupportedError(Exception):
+    """Raised when a descriptor references an unsupported input source or format."""
+
+    code = "INPUT_NOT_SUPPORTED"
+
+
 def load_dataframe_from_descriptor(descriptor: InputDescriptor) -> pd.DataFrame:
     if descriptor.source_type == "gcs":
         return load_from_gcs(descriptor.resolved_reference)
     if descriptor.source_type == "gdrive":
-        raise NotImplementedError(
+        raise InputNotSupportedError(
             "Google Drive inputs are not implemented yet. Upload the file, use a server-visible path, or use gs://."
         )
 
     path = Path(descriptor.resolved_reference)
     if path.suffix == ".parquet":
         return pd.read_parquet(path)
-    return pd.read_csv(path, low_memory=False)
+    if path.suffix == ".csv":
+        return pd.read_csv(path, low_memory=False)
+    raise InputNotSupportedError(
+        f"Unsupported file format: {path.suffix or '<none>'}. Supported formats are .csv and .parquet."
+    )

--- a/src/analyst_toolkit/mcp_server/input/loaders.py
+++ b/src/analyst_toolkit/mcp_server/input/loaders.py
@@ -1,0 +1,24 @@
+"""DataFrame loaders for canonical input descriptors."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from analyst_toolkit.mcp_server.input.models import InputDescriptor
+from analyst_toolkit.mcp_server.io_storage import load_from_gcs
+
+
+def load_dataframe_from_descriptor(descriptor: InputDescriptor) -> pd.DataFrame:
+    if descriptor.source_type == "gcs":
+        return load_from_gcs(descriptor.resolved_reference)
+    if descriptor.source_type == "gdrive":
+        raise NotImplementedError(
+            "Google Drive inputs are not implemented yet. Upload the file, use a server-visible path, or use gs://."
+        )
+
+    path = Path(descriptor.resolved_reference)
+    if path.suffix == ".parquet":
+        return pd.read_parquet(path)
+    return pd.read_csv(path, low_memory=False)

--- a/src/analyst_toolkit/mcp_server/input/loaders.py
+++ b/src/analyst_toolkit/mcp_server/input/loaders.py
@@ -23,8 +23,12 @@ def load_dataframe_from_descriptor(descriptor: InputDescriptor) -> pd.DataFrame:
         raise InputNotSupportedError(
             "Google Drive inputs are not implemented yet. Upload the file, use a server-visible path, or use gs://."
         )
+    if descriptor.source_type not in {"upload", "server_path"}:
+        raise InputNotSupportedError(
+            f"Unsupported source type: {descriptor.source_type}. Supported source types are upload, server_path, and gcs."
+        )
 
-    path = Path(descriptor.resolved_reference)
+    path = Path(descriptor.resolved_reference).resolve(strict=False)
     if path.suffix == ".parquet":
         return pd.read_parquet(path)
     if path.suffix == ".csv":

--- a/src/analyst_toolkit/mcp_server/input/models.py
+++ b/src/analyst_toolkit/mcp_server/input/models.py
@@ -1,0 +1,26 @@
+"""Canonical models for MCP input ingestion and resolution."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal
+
+InputSourceType = Literal["upload", "server_path", "gcs", "gdrive"]
+
+
+@dataclass(frozen=True)
+class InputDescriptor:
+    input_id: str
+    source_type: InputSourceType
+    original_reference: str
+    resolved_reference: str
+    display_name: str
+    media_type: str
+    file_size_bytes: int | None = None
+    sha256: str | None = None
+    session_id: str | None = None
+    run_id: str | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)

--- a/src/analyst_toolkit/mcp_server/input/registry.py
+++ b/src/analyst_toolkit/mcp_server/input/registry.py
@@ -1,0 +1,41 @@
+"""In-memory registry for ingested and registered inputs."""
+
+from __future__ import annotations
+
+import threading
+from typing import Optional
+
+from analyst_toolkit.mcp_server.input.models import InputDescriptor
+
+_LOCK = threading.Lock()
+_INPUTS: dict[str, InputDescriptor] = {}
+_SESSION_INPUTS: dict[str, str] = {}
+
+
+def save_descriptor(descriptor: InputDescriptor) -> InputDescriptor:
+    with _LOCK:
+        _INPUTS[descriptor.input_id] = descriptor
+        if descriptor.session_id:
+            _SESSION_INPUTS[descriptor.session_id] = descriptor.input_id
+    return descriptor
+
+
+def get_descriptor(input_id: str) -> Optional[InputDescriptor]:
+    with _LOCK:
+        return _INPUTS.get(input_id)
+
+
+def bind_session_input(session_id: str, input_id: str) -> None:
+    with _LOCK:
+        _SESSION_INPUTS[session_id] = input_id
+
+
+def get_session_input_id(session_id: str) -> Optional[str]:
+    with _LOCK:
+        return _SESSION_INPUTS.get(session_id)
+
+
+def clear() -> None:
+    with _LOCK:
+        _INPUTS.clear()
+        _SESSION_INPUTS.clear()

--- a/src/analyst_toolkit/mcp_server/input/registry.py
+++ b/src/analyst_toolkit/mcp_server/input/registry.py
@@ -27,6 +27,8 @@ def get_descriptor(input_id: str) -> Optional[InputDescriptor]:
 
 def bind_session_input(session_id: str, input_id: str) -> None:
     with _LOCK:
+        if input_id not in _INPUTS:
+            raise ValueError(f"input_id '{input_id}' not found in registry")
         _SESSION_INPUTS[session_id] = input_id
 
 

--- a/src/analyst_toolkit/mcp_server/input/storage.py
+++ b/src/analyst_toolkit/mcp_server/input/storage.py
@@ -1,0 +1,71 @@
+"""Storage helpers for staged ingest inputs."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+from pathlib import Path
+
+
+def _safe_name(name: str) -> str:
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", name.strip())
+    return cleaned or "input.bin"
+
+
+def input_root() -> Path:
+    configured = os.environ.get("ANALYST_MCP_INPUT_ROOT", "").strip()
+    root = Path(configured).expanduser() if configured else (Path.cwd() / "exports" / "inputs")
+    root.mkdir(parents=True, exist_ok=True)
+    return root.resolve()
+
+
+def allowed_server_input_roots() -> list[Path]:
+    configured = os.environ.get("ANALYST_MCP_ALLOWED_INPUT_ROOTS", "").strip()
+    if configured:
+        roots = [Path(item).expanduser().resolve() for item in configured.split(os.pathsep) if item]
+    else:
+        roots = [
+            (Path.cwd() / "data").resolve(),
+            (Path.cwd() / "exports").resolve(),
+            input_root(),
+        ]
+    unique: list[Path] = []
+    seen: set[Path] = set()
+    for root in roots:
+        if root not in seen:
+            seen.add(root)
+            unique.append(root)
+    return unique
+
+
+def sha256_hex(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def stage_uploaded_file(*, filename: str, payload: bytes) -> tuple[Path, str, int]:
+    digest = sha256_hex(payload)
+    safe_name = _safe_name(filename)
+    staged_dir = input_root() / digest[:2] / digest[2:4]
+    staged_dir.mkdir(parents=True, exist_ok=True)
+    staged_path = staged_dir / f"{digest}_{safe_name}"
+    if not staged_path.exists():
+        staged_path.write_bytes(payload)
+    return staged_path.resolve(), digest, len(payload)
+
+
+def validate_server_visible_path(path_text: str) -> Path:
+    candidate = Path(path_text).expanduser().resolve(strict=False)
+    if not candidate.exists():
+        raise FileNotFoundError(f"Input path not found: '{path_text}'")
+    for root in allowed_server_input_roots():
+        try:
+            candidate.relative_to(root)
+            return candidate
+        except ValueError:
+            continue
+    allowed = ", ".join(str(root) for root in allowed_server_input_roots())
+    raise PermissionError(
+        "Local path is not visible to the MCP runtime. "
+        f"Allowed roots: {allowed}. Upload the file, mount the directory, or use gs://."
+    )

--- a/src/analyst_toolkit/mcp_server/io.py
+++ b/src/analyst_toolkit/mcp_server/io.py
@@ -193,12 +193,19 @@ def load_input(
         if path_warning:
             logger.warning(path_warning)
         if _looks_like_bucket_path(normalized_path):
-            raise FileNotFoundError(
-                f"Input path not found: '{normalized_path}'. Did you mean 'gs://{normalized_path}'?"
+            raise ValueError(
+                f"[INVALID_PATH_FORMAT] Path '{normalized_path}' looks like a bucket path "
+                f"but is missing the scheme. Did you mean 'gs://{normalized_path}'?"
             )
 
+    session_data_available = (
+        session_id is not None
+        and not normalized_path
+        and not input_id
+        and StateStore.get(session_id) is not None
+    )
     df = _load_input_dataframe(path=normalized_path, session_id=session_id, input_id=input_id)
-    if session_id and not normalized_path and not input_id and StateStore.get(session_id) is not None:
+    if session_data_available:
         logger.info(f"Loaded from session: {session_id}")
     return df
 

--- a/src/analyst_toolkit/mcp_server/io.py
+++ b/src/analyst_toolkit/mcp_server/io.py
@@ -198,7 +198,7 @@ def load_input(
             )
 
     df = _load_input_dataframe(path=normalized_path, session_id=session_id, input_id=input_id)
-    if session_id and StateStore.get(session_id) is not None:
+    if session_id and not normalized_path and not input_id and StateStore.get(session_id) is not None:
         logger.info(f"Loaded from session: {session_id}")
     return df
 

--- a/src/analyst_toolkit/mcp_server/io.py
+++ b/src/analyst_toolkit/mcp_server/io.py
@@ -22,6 +22,7 @@ from analyst_toolkit.mcp_server.destination_routing import (
 from analyst_toolkit.mcp_server.destination_routing import (
     split_artifact_reference as _split_artifact_reference,
 )
+from analyst_toolkit.mcp_server.input.ingest import load_dataframe as _load_input_dataframe
 from analyst_toolkit.mcp_server.io_history_files import (
     read_history_file_safe as _read_history_file_safe,
 )
@@ -39,14 +40,8 @@ from analyst_toolkit.mcp_server.io_serialization import (
     fold_status_with_artifacts,
     make_json_safe,
 )
-from analyst_toolkit.mcp_server.io_storage import (
-    load_from_gcs,
-    save_output,
-    should_export_html,
-)
-from analyst_toolkit.mcp_server.io_storage import (
-    upload_artifact as _upload_artifact,
-)
+from analyst_toolkit.mcp_server.io_storage import save_output, should_export_html
+from analyst_toolkit.mcp_server.io_storage import upload_artifact as _upload_artifact
 from analyst_toolkit.mcp_server.state import StateStore
 
 logger = logging.getLogger(__name__)
@@ -186,34 +181,26 @@ def resolve_run_context(
     return effective_run_id, lifecycle
 
 
-def load_input(path: Optional[str] = None, session_id: Optional[str] = None) -> pd.DataFrame:
-    """Load data from GCS, local file, or in-memory session."""
-    if session_id:
-        df = StateStore.get(session_id)
-        if df is not None:
-            logger.info(f"Loaded from session: {session_id}")
-            return df
-        elif not path:
-            raise ValueError(f"Session {session_id} not found and no path provided.")
+def load_input(
+    path: Optional[str] = None,
+    session_id: Optional[str] = None,
+    input_id: Optional[str] = None,
+) -> pd.DataFrame:
+    """Load data from a canonical input reference, GCS, local file, or in-memory session."""
+    normalized_path = path
+    if normalized_path:
+        normalized_path, path_warning = _normalize_input_path(normalized_path)
+        if path_warning:
+            logger.warning(path_warning)
+        if _looks_like_bucket_path(normalized_path):
+            raise FileNotFoundError(
+                f"Input path not found: '{normalized_path}'. Did you mean 'gs://{normalized_path}'?"
+            )
 
-    if not path:
-        raise ValueError("Either 'path' (gcs_path) or 'session_id' must be provided.")
-
-    path, path_warning = _normalize_input_path(path)
-    if path_warning:
-        logger.warning(path_warning)
-
-    if path.startswith("gs://"):
-        return load_from_gcs(path)
-    if path.endswith(".parquet"):
-        return pd.read_parquet(path)
-    if Path(path).exists():
-        return pd.read_csv(path, low_memory=False)
-
-    if _looks_like_bucket_path(path):
-        raise FileNotFoundError(f"Input path not found: '{path}'. Did you mean 'gs://{path}'?")
-
-    raise FileNotFoundError(f"Input path not found: '{path}'")
+    df = _load_input_dataframe(path=normalized_path, session_id=session_id, input_id=input_id)
+    if session_id and StateStore.get(session_id) is not None:
+        logger.info(f"Loaded from session: {session_id}")
+    return df
 
 
 def save_to_session(

--- a/src/analyst_toolkit/mcp_server/runtime_overlay.py
+++ b/src/analyst_toolkit/mcp_server/runtime_overlay.py
@@ -25,7 +25,7 @@ class RuntimeOverlayError(ValueError):
 
 _RUNTIME_ALLOWED_KEYS: dict[str | None, set[str]] = {
     None: {"run", "artifacts", "destinations", "paths", "execution"},
-    "run": {"run_id", "session_id", "input_path"},
+    "run": {"run_id", "session_id", "input_id", "input_path"},
     "artifacts": {
         "export_html",
         "export_xlsx",
@@ -262,6 +262,8 @@ def runtime_to_tool_overrides(runtime: dict[str, Any]) -> dict[str, Any]:
             overrides["run_id"] = run_cfg["run_id"]
         if run_cfg.get("session_id"):
             overrides["session_id"] = run_cfg["session_id"]
+        if run_cfg.get("input_id"):
+            overrides["input_id"] = run_cfg["input_id"]
         if run_cfg.get("input_path"):
             overrides["gcs_path"] = run_cfg["input_path"]
 

--- a/src/analyst_toolkit/mcp_server/schemas.py
+++ b/src/analyst_toolkit/mcp_server/schemas.py
@@ -38,6 +38,7 @@ _SESSION_ID_PROP = {
 _INPUT_ID_PROP = {
     "input_id": {
         "type": "string",
+        "pattern": "^input_[a-f0-9]{12}$",
         "description": (
             "Optional: Canonical server-managed input reference returned by input "
             "ingest/register flows. If provided, gcs_path and session_id are ignored."

--- a/src/analyst_toolkit/mcp_server/schemas.py
+++ b/src/analyst_toolkit/mcp_server/schemas.py
@@ -38,7 +38,10 @@ _SESSION_ID_PROP = {
 _INPUT_ID_PROP = {
     "input_id": {
         "type": "string",
-        "description": "Optional: Canonical server-managed input reference returned by input ingest/register flows.",
+        "description": (
+            "Optional: Canonical server-managed input reference returned by input "
+            "ingest/register flows. If provided, gcs_path and session_id are ignored."
+        ),
     }
 }
 

--- a/src/analyst_toolkit/mcp_server/schemas.py
+++ b/src/analyst_toolkit/mcp_server/schemas.py
@@ -35,6 +35,13 @@ _SESSION_ID_PROP = {
     }
 }
 
+_INPUT_ID_PROP = {
+    "input_id": {
+        "type": "string",
+        "description": "Optional: Canonical server-managed input reference returned by input ingest/register flows.",
+    }
+}
+
 _CONFIG_PROP = {
     "config": {
         "type": "object",
@@ -83,6 +90,7 @@ def base_input_schema(extra_props: dict | None = None) -> dict:
     props = {
         **_GCS_PATH_PROP,
         **_SESSION_ID_PROP,
+        **_INPUT_ID_PROP,
         **_CONFIG_PROP,
         **_RUNTIME_PROP,
         **_RUN_ID_PROP,
@@ -96,6 +104,7 @@ def base_input_schema(extra_props: dict | None = None) -> dict:
         "anyOf": [
             {"required": ["gcs_path"]},
             {"required": ["session_id"]},
+            {"required": ["input_id"]},
         ],
     }
 

--- a/src/analyst_toolkit/mcp_server/server.py
+++ b/src/analyst_toolkit/mcp_server/server.py
@@ -26,14 +26,21 @@ from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
 import mcp.types as types
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import JSONResponse
 from mcp.server import NotificationOptions, Server
 from mcp.server.lowlevel.helper_types import ReadResourceContents
 from mcp.server.models import InitializationOptions
 from mcp.server.stdio import stdio_server
+from pydantic import BaseModel
 
 from analyst_toolkit.mcp_server.auth import is_authorized
+from analyst_toolkit.mcp_server.input.ingest import (
+    get_input_descriptor,
+    ingest_uploaded_bytes,
+    register_input_source,
+)
+from analyst_toolkit.mcp_server.input.models import InputSourceType
 from analyst_toolkit.mcp_server.observability import RuntimeMetrics, log_rpc_event
 from analyst_toolkit.mcp_server.registry import TOOL_REGISTRY
 from analyst_toolkit.mcp_server.resources import list_mcp_resources, read_mcp_resource
@@ -105,6 +112,21 @@ def _log_rpc_event(level: int, event: str, **fields: Any) -> None:
 
 def _is_authorized(request: Request) -> bool:
     return is_authorized(request, AUTH_TOKEN)
+
+
+class RegisterInputRequest(BaseModel):
+    uri: str
+    source_type: InputSourceType | None = None
+    session_id: str | None = None
+    run_id: str | None = None
+    load_into_session: bool = True
+
+
+def _require_http_auth(request: Request) -> str:
+    trace_id = new_trace_id()
+    if not _is_authorized(request):
+        raise HTTPException(status_code=401, detail={"error": "Unauthorized", "trace_id": trace_id})
+    return trace_id
 
 
 @mcp_server.list_tools()
@@ -303,6 +325,95 @@ async def rpc_handler(request: Request) -> JSONResponse:
     )
 
 
+@app.post("/inputs/upload")
+async def upload_input(
+    request: Request,
+    file: UploadFile = File(...),
+    session_id: str | None = Form(default=None),
+    run_id: str | None = Form(default=None),
+    load_into_session: bool = Form(default=True),
+) -> JSONResponse:
+    trace_id = _require_http_auth(request)
+    payload = await file.read()
+    if not payload:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "Empty upload payload.", "trace_id": trace_id},
+        )
+    try:
+        descriptor, df, effective_session_id = ingest_uploaded_bytes(
+            filename=file.filename or "upload.csv",
+            payload=payload,
+            media_type=file.content_type,
+            session_id=session_id,
+            run_id=run_id,
+            load_into_session=load_into_session,
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": str(exc), "trace_id": trace_id},
+        ) from exc
+
+    summary = {}
+    if df is not None:
+        summary = {"row_count": int(df.shape[0]), "column_count": int(df.shape[1])}
+    return JSONResponse(
+        {
+            "status": "pass",
+            "trace_id": trace_id,
+            "input": descriptor.to_dict(),
+            "session_id": effective_session_id or "",
+            "summary": summary,
+        }
+    )
+
+
+@app.post("/inputs/register")
+async def register_input(request: Request, payload: RegisterInputRequest) -> JSONResponse:
+    trace_id = _require_http_auth(request)
+    try:
+        descriptor, df, effective_session_id = register_input_source(
+            reference=payload.uri,
+            source_type=payload.source_type,
+            session_id=payload.session_id,
+            run_id=payload.run_id,
+            load_into_session=payload.load_into_session,
+        )
+    except NotImplementedError as exc:
+        raise HTTPException(
+            status_code=501,
+            detail={"error": str(exc), "trace_id": trace_id},
+        ) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": str(exc), "trace_id": trace_id},
+        ) from exc
+
+    summary = {}
+    if df is not None:
+        summary = {"row_count": int(df.shape[0]), "column_count": int(df.shape[1])}
+    return JSONResponse(
+        {
+            "status": "pass",
+            "trace_id": trace_id,
+            "input": descriptor.to_dict(),
+            "session_id": effective_session_id or "",
+            "summary": summary,
+        }
+    )
+
+
+@app.get("/inputs/{input_id}")
+async def read_input_descriptor(input_id: str, request: Request) -> JSONResponse:
+    trace_id = _require_http_auth(request)
+    descriptor = get_input_descriptor(input_id)
+    if descriptor is None:
+        raise HTTPException(status_code=404, detail={"error": "Input not found.", "trace_id": trace_id})
+    return JSONResponse({"status": "pass", "trace_id": trace_id, "input": descriptor.to_dict()})
+
+
 @app.get("/health")
 async def health(request: Request) -> Any:
     if not _is_authorized(request):
@@ -343,6 +454,7 @@ from analyst_toolkit.mcp_server.tools import (  # noqa: F401, E402
     final_audit,
     imputation,
     infer_configs,
+    input_ingest,
     jobs,
     normalization,
     outliers,

--- a/src/analyst_toolkit/mcp_server/server.py
+++ b/src/analyst_toolkit/mcp_server/server.py
@@ -410,7 +410,9 @@ async def read_input_descriptor(input_id: str, request: Request) -> JSONResponse
     trace_id = _require_http_auth(request)
     descriptor = get_input_descriptor(input_id)
     if descriptor is None:
-        raise HTTPException(status_code=404, detail={"error": "Input not found.", "trace_id": trace_id})
+        raise HTTPException(
+            status_code=404, detail={"error": "Input not found.", "trace_id": trace_id}
+        )
     return JSONResponse({"status": "pass", "trace_id": trace_id, "input": descriptor.to_dict()})
 
 

--- a/src/analyst_toolkit/mcp_server/tools/auto_heal.py
+++ b/src/analyst_toolkit/mcp_server/tools/auto_heal.py
@@ -367,7 +367,12 @@ async def _toolkit_auto_heal(
         try:
             asyncio.create_task(
                 _auto_heal_worker(
-                    job_id, gcs_path, session_id, normalized_runtime, run_id, input_id
+                    job_id=job_id,
+                    gcs_path=gcs_path,
+                    session_id=session_id,
+                    runtime=normalized_runtime,
+                    run_id=run_id,
+                    input_id=input_id,
                 )
             )
         except Exception as exc:

--- a/src/analyst_toolkit/mcp_server/tools/auto_heal.py
+++ b/src/analyst_toolkit/mcp_server/tools/auto_heal.py
@@ -366,7 +366,9 @@ async def _toolkit_auto_heal(
         )
         try:
             asyncio.create_task(
-                _auto_heal_worker(job_id, gcs_path, session_id, normalized_runtime, run_id, input_id)
+                _auto_heal_worker(
+                    job_id, gcs_path, session_id, normalized_runtime, run_id, input_id
+                )
             )
         except Exception as exc:
             JobStore.mark_failed(

--- a/src/analyst_toolkit/mcp_server/tools/auto_heal.py
+++ b/src/analyst_toolkit/mcp_server/tools/auto_heal.py
@@ -52,6 +52,7 @@ def _sanitize_dashboard_step_summary(summary: dict | None) -> dict:
 async def _run_auto_heal_pipeline(
     gcs_path: str | None = None,
     session_id: str | None = None,
+    input_id: str | None = None,
     runtime: dict | str | None = None,
     run_id: str | None = None,
 ) -> dict:
@@ -64,6 +65,7 @@ async def _run_auto_heal_pipeline(
     runtime_applied = bool(runtime_cfg)
     gcs_path = gcs_path or runtime_overrides.get("gcs_path")
     session_id = session_id or runtime_overrides.get("session_id")
+    input_id = input_id or runtime_overrides.get("input_id")
     run_id = run_id or runtime_overrides.get("run_id")
     run_id, lifecycle = resolve_run_context(run_id, session_id)
 
@@ -71,6 +73,7 @@ async def _run_auto_heal_pipeline(
     infer_res = await _toolkit_infer_configs(
         gcs_path=gcs_path,
         session_id=session_id,
+        input_id=input_id,
         runtime=runtime_cfg,
         run_id=run_id,
         modules=["normalization", "imputation"],
@@ -296,12 +299,14 @@ async def _auto_heal_worker(
     session_id: str | None,
     runtime: dict | str | None,
     run_id: str,
+    input_id: str | None,
 ):
     JobStore.mark_running(job_id)
     try:
         result = await _run_auto_heal_pipeline(
             gcs_path=gcs_path,
             session_id=session_id,
+            input_id=input_id,
             runtime=runtime,
             run_id=run_id,
         )
@@ -330,6 +335,7 @@ async def _auto_heal_worker(
 async def _toolkit_auto_heal(
     gcs_path: str | None = None,
     session_id: str | None = None,
+    input_id: str | None = None,
     runtime: dict | str | None = None,
     run_id: str | None = None,
     async_mode: bool = False,
@@ -342,6 +348,7 @@ async def _toolkit_auto_heal(
     normalized_runtime = runtime_cfg if runtime_cfg else runtime
     gcs_path = gcs_path or runtime_overrides.get("gcs_path")
     session_id = session_id or runtime_overrides.get("session_id")
+    input_id = input_id or runtime_overrides.get("input_id")
     run_id = run_id or runtime_overrides.get("run_id")
     run_id, lifecycle = resolve_run_context(run_id, session_id)
 
@@ -352,13 +359,14 @@ async def _toolkit_auto_heal(
             inputs={
                 "gcs_path": gcs_path,
                 "session_id": session_id,
+                "input_id": input_id,
                 "runtime": normalized_runtime,
                 "run_id": run_id,
             },
         )
         try:
             asyncio.create_task(
-                _auto_heal_worker(job_id, gcs_path, session_id, normalized_runtime, run_id)
+                _auto_heal_worker(job_id, gcs_path, session_id, normalized_runtime, run_id, input_id)
             )
         except Exception as exc:
             JobStore.mark_failed(
@@ -391,6 +399,7 @@ async def _toolkit_auto_heal(
     return await _run_auto_heal_pipeline(
         gcs_path=gcs_path,
         session_id=session_id,
+        input_id=input_id,
         runtime=normalized_runtime,
         run_id=run_id,
     )
@@ -406,6 +415,10 @@ _INPUT_SCHEMA = {
         "session_id": {
             "type": "string",
             "description": "Optional: In-memory session identifier.",
+        },
+        "input_id": {
+            "type": "string",
+            "description": "Optional: Canonical server-managed input reference returned by ingest/register flows.",
         },
         "run_id": {
             "type": "string",
@@ -428,6 +441,7 @@ _INPUT_SCHEMA = {
     "anyOf": [
         {"required": ["gcs_path"]},
         {"required": ["session_id"]},
+        {"required": ["input_id"]},
     ],
 }
 

--- a/src/analyst_toolkit/mcp_server/tools/data_dictionary.py
+++ b/src/analyst_toolkit/mcp_server/tools/data_dictionary.py
@@ -80,6 +80,7 @@ def _build_cockpit_preview(report: dict[str, Any]) -> dict[str, Any]:
 async def _toolkit_data_dictionary(
     gcs_path: str | None = None,
     session_id: str | None = None,
+    input_id: str | None = None,
     run_id: str | None = None,
     runtime: dict | str | None = None,
     profile_depth: str = "standard",
@@ -93,6 +94,7 @@ async def _toolkit_data_dictionary(
         runtime_applied = bool(runtime_cfg)
         gcs_path = gcs_path or runtime_overrides.get("gcs_path")
         session_id = session_id or runtime_overrides.get("session_id")
+        input_id = input_id or runtime_overrides.get("input_id")
         run_id = run_id or runtime_overrides.get("run_id") or "data_dictionary_prelaunch"
 
         delivery_config = {
@@ -108,7 +110,7 @@ async def _toolkit_data_dictionary(
         }
 
         run_id, lifecycle = resolve_run_context(run_id, session_id)
-        df = load_input(gcs_path, session_id=session_id)
+        df = load_input(gcs_path, session_id=session_id, input_id=input_id)
 
         if not session_id:
             session_id = save_to_session(df, run_id=run_id)

--- a/src/analyst_toolkit/mcp_server/tools/diagnostics.py
+++ b/src/analyst_toolkit/mcp_server/tools/diagnostics.py
@@ -37,6 +37,7 @@ from analyst_toolkit.mcp_server.schemas import base_input_schema
 async def _toolkit_diagnostics(
     gcs_path: str | None = None,
     session_id: str | None = None,
+    input_id: str | None = None,
     config: dict | None = None,
     runtime: dict | str | None = None,
     run_id: str | None = None,
@@ -48,6 +49,7 @@ async def _toolkit_diagnostics(
     runtime_applied = bool(runtime_cfg)
     gcs_path = gcs_path or runtime_overrides.get("gcs_path")
     session_id = session_id or runtime_overrides.get("session_id")
+    input_id = input_id or runtime_overrides.get("input_id")
     run_id = run_id or runtime_overrides.get("run_id")
     for key in (
         "output_bucket",
@@ -65,7 +67,7 @@ async def _toolkit_diagnostics(
         provided=config,
         explicit=runtime_to_config_overlay(runtime_cfg),
     )
-    df = load_input(gcs_path, session_id=session_id)
+    df = load_input(gcs_path, session_id=session_id, input_id=input_id)
 
     # If it came from a path, save it to a session
     if not session_id:

--- a/src/analyst_toolkit/mcp_server/tools/duplicates.py
+++ b/src/analyst_toolkit/mcp_server/tools/duplicates.py
@@ -41,6 +41,7 @@ def _normalize_mode(mode: str) -> str:
 async def _toolkit_duplicates(
     gcs_path: str | None = None,
     session_id: str | None = None,
+    input_id: str | None = None,
     config: dict | None = None,
     runtime: dict | str | None = None,
     run_id: str | None = None,
@@ -53,6 +54,7 @@ async def _toolkit_duplicates(
     runtime_applied = bool(runtime_cfg)
     gcs_path = gcs_path or runtime_overrides.get("gcs_path")
     session_id = session_id or runtime_overrides.get("session_id")
+    input_id = input_id or runtime_overrides.get("input_id")
     run_id = run_id or runtime_overrides.get("run_id")
     for key in (
         "output_bucket",
@@ -70,7 +72,7 @@ async def _toolkit_duplicates(
         provided=config,
         explicit=runtime_to_config_overlay(runtime_cfg),
     )
-    df = load_input(gcs_path, session_id=session_id)
+    df = load_input(gcs_path, session_id=session_id, input_id=input_id)
 
     base_cfg = config.get("duplicates", config)
     subset_cols = subset_columns or base_cfg.get("subset_columns")

--- a/src/analyst_toolkit/mcp_server/tools/final_audit.py
+++ b/src/analyst_toolkit/mcp_server/tools/final_audit.py
@@ -57,6 +57,7 @@ def _has_effective_certification_rules(rules: dict) -> bool:
 async def _toolkit_final_audit(
     gcs_path: str | None = None,
     session_id: str | None = None,
+    input_id: str | None = None,
     config: dict | None = None,
     runtime: dict | str | None = None,
     run_id: str | None = None,
@@ -71,6 +72,7 @@ async def _toolkit_final_audit(
     runtime_applied = bool(runtime_cfg)
     gcs_path = gcs_path or runtime_overrides.get("gcs_path")
     session_id = session_id or runtime_overrides.get("session_id")
+    input_id = input_id or runtime_overrides.get("input_id")
     run_id = run_id or runtime_overrides.get("run_id")
     for key in (
         "output_bucket",
@@ -89,7 +91,7 @@ async def _toolkit_final_audit(
         explicit=runtime_to_config_overlay(runtime_cfg),
     )
     base_cfg = normalize_final_audit_config(config)
-    df = load_input(gcs_path, session_id=session_id)
+    df = load_input(gcs_path, session_id=session_id, input_id=input_id)
 
     # The M10 pipeline requires a raw_data_path to compute before/after row counts.
     # Write the current df to a temp CSV as the "raw" snapshot if not provided.

--- a/src/analyst_toolkit/mcp_server/tools/imputation.py
+++ b/src/analyst_toolkit/mcp_server/tools/imputation.py
@@ -45,6 +45,7 @@ def _column_null_count(df: pd.DataFrame, column: str) -> int:
 async def _toolkit_imputation(
     gcs_path: str | None = None,
     session_id: str | None = None,
+    input_id: str | None = None,
     config: dict | None = None,
     runtime: dict | str | None = None,
     run_id: str | None = None,
@@ -56,6 +57,7 @@ async def _toolkit_imputation(
     runtime_applied = bool(runtime_cfg)
     gcs_path = gcs_path or runtime_overrides.get("gcs_path")
     session_id = session_id or runtime_overrides.get("session_id")
+    input_id = input_id or runtime_overrides.get("input_id")
     run_id = run_id or runtime_overrides.get("run_id")
     for key in (
         "output_bucket",
@@ -73,7 +75,7 @@ async def _toolkit_imputation(
         provided=config,
         explicit=runtime_to_config_overlay(runtime_cfg),
     )
-    df = load_input(gcs_path, session_id=session_id)
+    df = load_input(gcs_path, session_id=session_id, input_id=input_id)
 
     base_cfg = config.get("imputation", config)
 

--- a/src/analyst_toolkit/mcp_server/tools/infer_configs.py
+++ b/src/analyst_toolkit/mcp_server/tools/infer_configs.py
@@ -148,6 +148,7 @@ _INPUT_SCHEMA = {
         "input_id": {
             "type": "string",
             "description": "Optional: Canonical server-managed input reference returned by ingest/register flows.",
+            "pattern": "^input_[a-f0-9]{12}$",
         },
         "runtime": {
             "type": ["object", "string"],

--- a/src/analyst_toolkit/mcp_server/tools/infer_configs.py
+++ b/src/analyst_toolkit/mcp_server/tools/infer_configs.py
@@ -14,6 +14,7 @@ from analyst_toolkit.mcp_server.runtime_overlay import (
 async def _toolkit_infer_configs(
     gcs_path: str | None = None,
     session_id: str | None = None,
+    input_id: str | None = None,
     runtime: dict | str | None = None,
     options: dict | None = None,
     modules: list[str] | None = None,
@@ -30,10 +31,11 @@ async def _toolkit_infer_configs(
     runtime_applied = bool(runtime_cfg)
     gcs_path = gcs_path or runtime_overrides.get("gcs_path")
     session_id = session_id or runtime_overrides.get("session_id")
+    input_id = input_id or runtime_overrides.get("input_id")
     run_id = run_id or runtime_overrides.get("run_id")
     run_id, _lifecycle = resolve_run_context(run_id, session_id)
     options = options or {}
-    df = load_input(gcs_path, session_id=session_id)
+    df = load_input(gcs_path, session_id=session_id, input_id=input_id)
 
     # If it came from a path and we don't have a session, start one
     if not session_id:
@@ -143,6 +145,10 @@ _INPUT_SCHEMA = {
             "type": "string",
             "description": "Optional: In-memory session identifier from a previous tool run.",
         },
+        "input_id": {
+            "type": "string",
+            "description": "Optional: Canonical server-managed input reference returned by ingest/register flows.",
+        },
         "runtime": {
             "type": ["object", "string"],
             "description": (
@@ -180,6 +186,7 @@ _INPUT_SCHEMA = {
     "anyOf": [
         {"required": ["gcs_path"]},
         {"required": ["session_id"]},
+        {"required": ["input_id"]},
         {"required": ["runtime"]},
     ],
 }

--- a/src/analyst_toolkit/mcp_server/tools/infer_configs.py
+++ b/src/analyst_toolkit/mcp_server/tools/infer_configs.py
@@ -35,6 +35,15 @@ async def _toolkit_infer_configs(
     run_id = run_id or runtime_overrides.get("run_id")
     run_id, _lifecycle = resolve_run_context(run_id, session_id)
     options = options or {}
+    provided_inputs = [gcs_path is not None, session_id is not None, input_id is not None]
+    if sum(provided_inputs) > 1:
+        return {
+            "status": "error",
+            "module": "infer_configs",
+            "error": "Provide exactly one of gcs_path, session_id, or input_id.",
+            "error_code": "AMBIGUOUS_INPUT_SOURCE",
+            "config_yaml": "",
+        }
     df = load_input(gcs_path, session_id=session_id, input_id=input_id)
 
     # If it came from a path and we don't have a session, start one
@@ -147,7 +156,10 @@ _INPUT_SCHEMA = {
         },
         "input_id": {
             "type": "string",
-            "description": "Optional: Canonical server-managed input reference returned by ingest/register flows.",
+            "description": (
+                "Optional: Canonical server-managed input reference returned by ingest/register "
+                "flows. If provided, gcs_path and session_id are ignored."
+            ),
             "pattern": "^input_[a-f0-9]{12}$",
         },
         "runtime": {

--- a/src/analyst_toolkit/mcp_server/tools/input_ingest.py
+++ b/src/analyst_toolkit/mcp_server/tools/input_ingest.py
@@ -1,0 +1,107 @@
+"""MCP tools for registering and inspecting canonical input sources."""
+
+from analyst_toolkit.mcp_server.input.ingest import get_input_descriptor, register_input_source
+from analyst_toolkit.mcp_server.registry import register_tool
+
+
+async def _toolkit_register_input(
+    uri: str,
+    source_type: str | None = None,
+    session_id: str | None = None,
+    run_id: str | None = None,
+    load_into_session: bool = True,
+) -> dict:
+    try:
+        descriptor, df, effective_session_id = register_input_source(
+            reference=uri,
+            source_type=source_type,  # type: ignore[arg-type]
+            session_id=session_id,
+            run_id=run_id,
+            load_into_session=load_into_session,
+        )
+    except NotImplementedError as exc:
+        return {
+            "status": "error",
+            "module": "register_input",
+            "code": "INPUT_SOURCE_UNSUPPORTED",
+            "message": str(exc),
+        }
+    except Exception as exc:
+        return {
+            "status": "error",
+            "module": "register_input",
+            "code": "INPUT_REGISTER_FAILED",
+            "message": str(exc),
+        }
+
+    summary = {}
+    if df is not None:
+        summary = {"row_count": int(df.shape[0]), "column_count": int(df.shape[1])}
+    return {
+        "status": "pass",
+        "module": "register_input",
+        "input": descriptor.to_dict(),
+        "session_id": effective_session_id or "",
+        "summary": summary,
+    }
+
+
+async def _toolkit_get_input_descriptor(input_id: str) -> dict:
+    descriptor = get_input_descriptor(input_id)
+    if descriptor is None:
+        return {
+            "status": "error",
+            "module": "get_input_descriptor",
+            "code": "INPUT_NOT_FOUND",
+            "message": f"Input not found: {input_id}",
+        }
+    return {
+        "status": "pass",
+        "module": "get_input_descriptor",
+        "input": descriptor.to_dict(),
+    }
+
+
+register_tool(
+    name="register_input",
+    fn=_toolkit_register_input,
+    description=(
+        "Register a server-visible local path or gs:// URI as a canonical input reference "
+        "and optionally bind it into a session."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "uri": {"type": "string", "description": "Server-visible local path or gs:// URI."},
+            "source_type": {
+                "type": "string",
+                "enum": ["server_path", "gcs", "gdrive"],
+                "description": "Optional explicit source type. Omit to auto-detect.",
+            },
+            "session_id": {
+                "type": "string",
+                "description": "Optional session to bind the registered input to.",
+            },
+            "run_id": {"type": "string", "description": "Optional run identifier."},
+            "load_into_session": {
+                "type": "boolean",
+                "description": "If true, load the input and save it into the session store.",
+                "default": True,
+            },
+        },
+        "required": ["uri"],
+    },
+)
+
+register_tool(
+    name="get_input_descriptor",
+    fn=_toolkit_get_input_descriptor,
+    description="Fetch metadata for a canonical input reference by input_id.",
+    input_schema={
+        "type": "object",
+        "properties": {
+            "input_id": {"type": "string", "description": "Canonical input reference identifier."}
+        },
+        "required": ["input_id"],
+    },
+)

--- a/src/analyst_toolkit/mcp_server/tools/input_ingest.py
+++ b/src/analyst_toolkit/mcp_server/tools/input_ingest.py
@@ -1,37 +1,57 @@
 """MCP tools for registering and inspecting canonical input sources."""
 
+import asyncio
+import logging
+from functools import partial
+
 from analyst_toolkit.mcp_server.input.ingest import get_input_descriptor, register_input_source
+from analyst_toolkit.mcp_server.input.loaders import InputNotSupportedError
+from analyst_toolkit.mcp_server.input.models import InputSourceType
 from analyst_toolkit.mcp_server.registry import register_tool
+from analyst_toolkit.mcp_server.response_utils import new_trace_id
+
+logger = logging.getLogger("analyst_toolkit.mcp_server.input_ingest")
 
 
 async def _toolkit_register_input(
     uri: str,
-    source_type: str | None = None,
+    source_type: InputSourceType | None = None,
     session_id: str | None = None,
     run_id: str | None = None,
     load_into_session: bool = True,
 ) -> dict:
     try:
-        descriptor, df, effective_session_id = register_input_source(
-            reference=uri,
-            source_type=source_type,  # type: ignore[arg-type]
-            session_id=session_id,
-            run_id=run_id,
-            load_into_session=load_into_session,
+        loop = asyncio.get_running_loop()
+        descriptor, df, effective_session_id = await loop.run_in_executor(
+            None,
+            partial(
+                register_input_source,
+                reference=uri,
+                source_type=source_type,
+                session_id=session_id,
+                run_id=run_id,
+                load_into_session=load_into_session,
+            ),
         )
-    except NotImplementedError as exc:
+    except InputNotSupportedError:
+        trace_id = new_trace_id()
+        logger.exception("Input source unsupported (trace_id=%s)", trace_id)
         return {
             "status": "error",
             "module": "register_input",
             "code": "INPUT_SOURCE_UNSUPPORTED",
-            "message": str(exc),
+            "message": "The specified input source is not supported.",
+            "trace_id": trace_id,
         }
-    except Exception as exc:
+    except Exception:
+        trace_id = new_trace_id()
+        logger.exception("Failed to register input (trace_id=%s)", trace_id)
         return {
             "status": "error",
             "module": "register_input",
             "code": "INPUT_REGISTER_FAILED",
-            "message": str(exc),
+            "message": "Failed to register input source.",
+            "trace_id": trace_id,
         }
 
     summary = {}
@@ -47,13 +67,16 @@ async def _toolkit_register_input(
 
 
 async def _toolkit_get_input_descriptor(input_id: str) -> dict:
-    descriptor = get_input_descriptor(input_id)
+    loop = asyncio.get_running_loop()
+    descriptor = await loop.run_in_executor(None, get_input_descriptor, input_id)
     if descriptor is None:
+        trace_id = new_trace_id()
         return {
             "status": "error",
             "module": "get_input_descriptor",
             "code": "INPUT_NOT_FOUND",
-            "message": f"Input not found: {input_id}",
+            "message": "Input descriptor not found.",
+            "trace_id": trace_id,
         }
     return {
         "status": "pass",
@@ -66,8 +89,9 @@ register_tool(
     name="register_input",
     fn=_toolkit_register_input,
     description=(
-        "Register a server-visible local path or gs:// URI as a canonical input reference "
-        "and optionally bind it into a session."
+        "Register a canonical input reference from a server-visible local path or gs:// URI "
+        "and optionally bind it into a session. Local server_path access is restricted to "
+        "server-configured allowlisted roots."
     ),
     input_schema={
         "type": "object",
@@ -82,7 +106,13 @@ register_tool(
                 "type": "string",
                 "description": "Optional session to bind the registered input to.",
             },
-            "run_id": {"type": "string", "description": "Optional run identifier."},
+            "run_id": {
+                "type": "string",
+                "description": (
+                    "Optional run identifier. Provide a stable run_id if clients need "
+                    "idempotent retries; omitted run_id values may create distinct runs."
+                ),
+            },
             "load_into_session": {
                 "type": "boolean",
                 "description": "If true, load the input and save it into the session store.",

--- a/src/analyst_toolkit/mcp_server/tools/input_ingest.py
+++ b/src/analyst_toolkit/mcp_server/tools/input_ingest.py
@@ -61,27 +61,39 @@ async def _toolkit_register_input(
         "status": "pass",
         "module": "register_input",
         "input": descriptor.to_dict(),
-        "session_id": effective_session_id or "",
+        "session_id": effective_session_id,
         "summary": summary,
     }
 
 
 async def _toolkit_get_input_descriptor(input_id: str) -> dict:
-    loop = asyncio.get_running_loop()
-    descriptor = await loop.run_in_executor(None, get_input_descriptor, input_id)
-    if descriptor is None:
+    try:
+        loop = asyncio.get_running_loop()
+        descriptor = await loop.run_in_executor(None, get_input_descriptor, input_id)
+        if descriptor is None:
+            trace_id = new_trace_id()
+            return {
+                "status": "error",
+                "module": "get_input_descriptor",
+                "code": "INPUT_NOT_FOUND",
+                "message": "Input descriptor not found.",
+                "trace_id": trace_id,
+            }
+        descriptor_payload = descriptor.to_dict()
+    except Exception:
         trace_id = new_trace_id()
+        logger.exception("Failed to retrieve input descriptor (trace_id=%s)", trace_id)
         return {
             "status": "error",
             "module": "get_input_descriptor",
-            "code": "INPUT_NOT_FOUND",
-            "message": "Input descriptor not found.",
+            "code": "INTERNAL_ERROR",
+            "message": "Internal server error.",
             "trace_id": trace_id,
         }
     return {
         "status": "pass",
         "module": "get_input_descriptor",
-        "input": descriptor.to_dict(),
+        "input": descriptor_payload,
     }
 
 

--- a/src/analyst_toolkit/mcp_server/tools/normalization.py
+++ b/src/analyst_toolkit/mcp_server/tools/normalization.py
@@ -36,6 +36,7 @@ from analyst_toolkit.mcp_server.schemas import base_input_schema
 async def _toolkit_normalization(
     gcs_path: str | None = None,
     session_id: str | None = None,
+    input_id: str | None = None,
     config: dict | None = None,
     runtime: dict | str | None = None,
     run_id: str | None = None,
@@ -47,6 +48,7 @@ async def _toolkit_normalization(
     runtime_applied = bool(runtime_cfg)
     gcs_path = gcs_path or runtime_overrides.get("gcs_path")
     session_id = session_id or runtime_overrides.get("session_id")
+    input_id = input_id or runtime_overrides.get("input_id")
     run_id = run_id or runtime_overrides.get("run_id")
     for key in (
         "output_bucket",
@@ -64,7 +66,7 @@ async def _toolkit_normalization(
         provided=config,
         explicit=runtime_to_config_overlay(runtime_cfg),
     )
-    df = load_input(gcs_path, session_id=session_id)
+    df = load_input(gcs_path, session_id=session_id, input_id=input_id)
 
     base_cfg = config.get("normalization", config)
 

--- a/src/analyst_toolkit/mcp_server/tools/outliers.py
+++ b/src/analyst_toolkit/mcp_server/tools/outliers.py
@@ -37,6 +37,7 @@ from analyst_toolkit.mcp_server.schemas import base_input_schema
 async def _toolkit_outliers(
     gcs_path: str | None = None,
     session_id: str | None = None,
+    input_id: str | None = None,
     config: dict | None = None,
     runtime: dict | str | None = None,
     run_id: str | None = None,
@@ -48,6 +49,7 @@ async def _toolkit_outliers(
     runtime_applied = bool(runtime_cfg)
     gcs_path = gcs_path or runtime_overrides.get("gcs_path")
     session_id = session_id or runtime_overrides.get("session_id")
+    input_id = input_id or runtime_overrides.get("input_id")
     run_id = run_id or runtime_overrides.get("run_id")
     for key in (
         "output_bucket",
@@ -67,7 +69,7 @@ async def _toolkit_outliers(
         provided=config,
         explicit=runtime_to_config_overlay(runtime_cfg),
     )
-    df = load_input(gcs_path, session_id=session_id)
+    df = load_input(gcs_path, session_id=session_id, input_id=input_id)
 
     base_cfg = normalize_outliers_config(config.get("outlier_detection", config))
 

--- a/src/analyst_toolkit/mcp_server/tools/validation.py
+++ b/src/analyst_toolkit/mcp_server/tools/validation.py
@@ -42,6 +42,7 @@ from analyst_toolkit.mcp_server.schemas import base_input_schema
 async def _toolkit_validation(
     gcs_path: str | None = None,
     session_id: str | None = None,
+    input_id: str | None = None,
     config: dict | None = None,
     runtime: dict | str | None = None,
     run_id: str | None = None,
@@ -53,6 +54,7 @@ async def _toolkit_validation(
     runtime_applied = bool(runtime_cfg)
     gcs_path = gcs_path or runtime_overrides.get("gcs_path")
     session_id = session_id or runtime_overrides.get("session_id")
+    input_id = input_id or runtime_overrides.get("input_id")
     run_id = run_id or runtime_overrides.get("run_id")
     for key in (
         "output_bucket",
@@ -71,7 +73,7 @@ async def _toolkit_validation(
         explicit=runtime_to_config_overlay(runtime_cfg),
     )
     base_cfg = normalize_validation_config(config)
-    df = load_input(gcs_path, session_id=session_id)
+    df = load_input(gcs_path, session_id=session_id, input_id=input_id)
 
     # Ensure it's in a session for the pipeline
     if not session_id:

--- a/tests/hardening/test_config_and_upload.py
+++ b/tests/hardening/test_config_and_upload.py
@@ -215,7 +215,7 @@ def test_load_input_auto_normalizes_bucket_like_path(monkeypatch):
 
     expected = pd.DataFrame({"a": [1]})
     monkeypatch.setattr(
-        "analyst_toolkit.mcp_server.io.load_from_gcs",
+        "analyst_toolkit.mcp_server.input.loaders.load_from_gcs",
         lambda gcs_path: expected if gcs_path == "gs://my-bucket/path/file.csv" else None,
     )
     out = load_input("my-bucket/path/file.csv")

--- a/tests/mcp_server/test_http_auth_metrics.py
+++ b/tests/mcp_server/test_http_auth_metrics.py
@@ -93,3 +93,14 @@ def test_auth_mode_allows_bearer_token(client, monkeypatch):
     rpc_response = client.post("/rpc", json=rpc_payload, headers=headers)
     assert rpc_response.status_code == 200
     assert rpc_response.json()["result"]["serverInfo"]["name"] == "analyst-toolkit"
+
+
+def test_auth_mode_rejects_unauthorized_input_register(client, monkeypatch, tmp_path):
+    monkeypatch.setattr(server_module, "AUTH_TOKEN", "test-token")
+    source = tmp_path / "dirty_penguins.csv"
+    source.write_text("species,bill_length_mm\nAdelie,39.1\n")
+
+    response = client.post("/inputs/register", json={"uri": str(source), "load_into_session": False})
+    assert response.status_code == 401
+    assert response.json()["detail"]["error"] == "Unauthorized"
+    assert isinstance(response.json()["detail"]["trace_id"], str)

--- a/tests/mcp_server/test_http_auth_metrics.py
+++ b/tests/mcp_server/test_http_auth_metrics.py
@@ -96,6 +96,7 @@ def test_auth_mode_allows_bearer_token(client, monkeypatch):
 
 
 def test_auth_mode_rejects_unauthorized_input_register(client, monkeypatch, tmp_path):
+    """Verify token auth mode blocks unauthenticated input registration."""
     monkeypatch.setattr(server_module, "AUTH_TOKEN", "test-token")
     source = tmp_path / "dirty_penguins.csv"
     source.write_text("species,bill_length_mm\nAdelie,39.1\n")
@@ -106,3 +107,23 @@ def test_auth_mode_rejects_unauthorized_input_register(client, monkeypatch, tmp_
     assert response.status_code == 401
     assert response.json()["detail"]["error"] == "Unauthorized"
     assert isinstance(response.json()["detail"]["trace_id"], str)
+
+
+def test_auth_mode_allows_authorized_input_register(client, monkeypatch, tmp_path):
+    """Verify token auth mode allows authorized input registration."""
+    monkeypatch.setattr(server_module, "AUTH_TOKEN", "test-token")
+    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
+    headers = {"Authorization": "Bearer test-token"}
+    source = tmp_path / "dirty_penguins.csv"
+    source.write_text("species,bill_length_mm\nAdelie,39.1\n")
+
+    response = client.post(
+        "/inputs/register",
+        json={"uri": str(source), "load_into_session": False},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "pass"
+    assert isinstance(payload["trace_id"], str)
+    assert payload["input"]["resolved_reference"] == str(source.resolve())

--- a/tests/mcp_server/test_http_auth_metrics.py
+++ b/tests/mcp_server/test_http_auth_metrics.py
@@ -100,7 +100,9 @@ def test_auth_mode_rejects_unauthorized_input_register(client, monkeypatch, tmp_
     source = tmp_path / "dirty_penguins.csv"
     source.write_text("species,bill_length_mm\nAdelie,39.1\n")
 
-    response = client.post("/inputs/register", json={"uri": str(source), "load_into_session": False})
+    response = client.post(
+        "/inputs/register", json={"uri": str(source), "load_into_session": False}
+    )
     assert response.status_code == 401
     assert response.json()["detail"]["error"] == "Unauthorized"
     assert isinstance(response.json()["detail"]["trace_id"], str)

--- a/tests/mcp_server/test_input_ingest.py
+++ b/tests/mcp_server/test_input_ingest.py
@@ -1,0 +1,122 @@
+from pathlib import Path
+
+import pandas as pd
+
+from analyst_toolkit.mcp_server.input import registry as input_registry
+from analyst_toolkit.mcp_server.state import StateStore
+from analyst_toolkit.mcp_server.tools import diagnostics as diagnostics_tool
+
+
+def _write_sample_csv(path: Path) -> None:
+    pd.DataFrame(
+        {
+            "species": ["Adelie", "Gentoo"],
+            "bill_length_mm": [39.1, 46.5],
+        }
+    ).to_csv(path, index=False)
+
+
+def test_inputs_upload_creates_session_and_descriptor(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
+    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
+    StateStore.clear()
+    input_registry.clear()
+
+    response = client.post(
+        "/inputs/upload",
+        files={"file": ("dirty_penguins.csv", b"species,bill_length_mm\nAdelie,39.1\n", "text/csv")},
+        data={"load_into_session": "true"},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "pass"
+    assert payload["session_id"].startswith("sess_")
+    assert payload["input"]["source_type"] == "upload"
+    assert payload["summary"]["row_count"] == 1
+    assert payload["summary"]["column_count"] == 2
+
+
+def test_inputs_register_server_path_loads_into_session(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
+    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
+    StateStore.clear()
+    input_registry.clear()
+
+    source = tmp_path / "dirty_penguins.csv"
+    _write_sample_csv(source)
+
+    response = client.post(
+        "/inputs/register",
+        json={"uri": str(source), "load_into_session": True},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "pass"
+    assert payload["input"]["source_type"] == "server_path"
+    assert payload["session_id"].startswith("sess_")
+    assert payload["summary"]["row_count"] == 2
+
+
+def test_inputs_register_rejects_path_outside_allowed_roots(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
+    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path / "allowed"))
+    StateStore.clear()
+    input_registry.clear()
+
+    source = tmp_path / "dirty_penguins.csv"
+    _write_sample_csv(source)
+
+    response = client.post(
+        "/inputs/register",
+        json={"uri": str(source), "load_into_session": True},
+    )
+    assert response.status_code == 400
+    assert "not visible to the MCP runtime" in response.json()["detail"]["error"]
+
+
+def test_register_input_tool_and_diagnostics_input_id_flow(client, monkeypatch, mocker, tmp_path):
+    monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
+    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
+    StateStore.clear()
+    input_registry.clear()
+    mocker.patch.object(diagnostics_tool, "run_diag_pipeline", return_value=None)
+    mocker.patch.object(diagnostics_tool, "save_output", return_value="gs://dummy/diagnostics.csv")
+    mocker.patch.object(diagnostics_tool, "append_to_run_history", return_value=None)
+    mocker.patch.object(diagnostics_tool, "should_export_html", return_value=False)
+
+    source = tmp_path / "dirty_penguins.csv"
+    _write_sample_csv(source)
+
+    register_payload = {
+        "jsonrpc": "2.0",
+        "id": 901,
+        "method": "tools/call",
+        "params": {
+            "name": "register_input",
+            "arguments": {"uri": str(source), "load_into_session": True},
+        },
+    }
+    register_response = client.post("/rpc", json=register_payload)
+    assert register_response.status_code == 200
+    register_result = register_response.json()["result"]
+    assert register_result["status"] == "pass"
+    input_id = register_result["input"]["input_id"]
+
+    diagnostics_payload = {
+        "jsonrpc": "2.0",
+        "id": 902,
+        "method": "tools/call",
+        "params": {
+            "name": "diagnostics",
+            "arguments": {
+                "input_id": input_id,
+                "export_path": str(tmp_path / "diagnostics.csv"),
+            },
+        },
+    }
+    diagnostics_response = client.post("/rpc", json=diagnostics_payload)
+    assert diagnostics_response.status_code == 200
+    diagnostics_result = diagnostics_response.json()["result"]
+    assert diagnostics_result["status"] in {"pass", "warn"}
+    assert diagnostics_result["module"] == "diagnostics"
+    assert diagnostics_result["summary"]["row_count"] == 2

--- a/tests/mcp_server/test_input_ingest.py
+++ b/tests/mcp_server/test_input_ingest.py
@@ -24,7 +24,9 @@ def test_inputs_upload_creates_session_and_descriptor(client, monkeypatch, tmp_p
 
     response = client.post(
         "/inputs/upload",
-        files={"file": ("dirty_penguins.csv", b"species,bill_length_mm\nAdelie,39.1\n", "text/csv")},
+        files={
+            "file": ("dirty_penguins.csv", b"species,bill_length_mm\nAdelie,39.1\n", "text/csv")
+        },
         data={"load_into_session": "true"},
     )
     assert response.status_code == 200

--- a/tests/mcp_server/test_rpc_tools.py
+++ b/tests/mcp_server/test_rpc_tools.py
@@ -43,6 +43,8 @@ def test_rpc_tools_list(client):
     assert "get_pipeline_dashboard" in tool_names
     assert "ensure_artifact_server" in tool_names
     assert "data_dictionary" in tool_names
+    assert "register_input" in tool_names
+    assert "get_input_descriptor" in tool_names
     assert "preflight_config" in tool_names
     assert "get_job_status" in tool_names
     assert "list_jobs" in tool_names
@@ -611,7 +613,7 @@ def test_rpc_data_dictionary_tool(client, mocker, tmp_path):
     assert result["cockpit_preview"]["overview"]["expected_columns"] == 3
     assert result["cockpit_preview"]["expected_schema_preview"][0]["Column"] == "customer_id"
     assert result["next_actions"][0]["tool"] == "get_cockpit_dashboard"
-    load_input.assert_called_once_with("gs://bucket/data.csv", session_id=None)
+    load_input.assert_called_once_with("gs://bucket/data.csv", session_id=None, input_id=None)
     save_to_session.assert_called_once_with(dataframe, run_id="dictionary_prelaunch_001")
     infer_configs.assert_awaited_once_with(
         gcs_path="gs://bucket/data.csv",

--- a/tests/mcp_server/test_rpc_tools.py
+++ b/tests/mcp_server/test_rpc_tools.py
@@ -634,6 +634,64 @@ def test_rpc_data_dictionary_tool(client, mocker, tmp_path):
     )
 
 
+def test_rpc_data_dictionary_tool_passes_explicit_input_id(client, mocker, tmp_path):
+    dataframe = pd.DataFrame(
+        {
+            "customer_id": [1, 2],
+            "status": ["new", "done"],
+            "amount": [10.5, 12.0],
+        }
+    )
+    load_input = mocker.patch.object(data_dictionary_tool, "load_input", return_value=dataframe)
+    mocker.patch.object(data_dictionary_tool, "save_to_session", return_value="sess_dictionary")
+    mocker.patch.object(data_dictionary_tool, "append_to_run_history", return_value=None)
+    mocker.patch.object(data_dictionary_tool, "export_dataframes", return_value=None)
+    mocker.patch.object(
+        data_dictionary_tool,
+        "export_html_report",
+        return_value=str(tmp_path / "dictionary.html"),
+    )
+    mocker.patch.object(
+        data_dictionary_tool,
+        "deliver_artifact",
+        side_effect=lambda local_path, *args, **kwargs: {
+            "reference": local_path,
+            "local_path": local_path,
+            "url": "" if local_path.endswith(".xlsx") else "https://example.com/dictionary.html",
+            "warnings": [],
+            "destinations": {},
+        },
+    )
+    mocker.patch.object(
+        data_dictionary_tool,
+        "_toolkit_infer_configs",
+        mocker.AsyncMock(return_value={"status": "pass", "configs": {}, "warnings": []}),
+    )
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 42,
+        "method": "tools/call",
+        "params": {
+            "name": "data_dictionary",
+            "arguments": {
+                "gcs_path": "gs://bucket/data.csv",
+                "input_id": "input_deadbeefcafe",
+                "run_id": "dictionary_prelaunch_002",
+            },
+        },
+    }
+    response = client.post("/rpc", json=payload)
+    assert response.status_code == 200
+    result = response.json()["result"]
+    assert result["status"] in {"pass", "warn"}
+    load_input.assert_called_once_with(
+        "gs://bucket/data.csv",
+        session_id=None,
+        input_id="input_deadbeefcafe",
+    )
+
+
 @pytest.mark.asyncio
 async def test_rpc_tool_invocation_structure(mocker):
     """

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -175,7 +175,7 @@ async def test_toolkit_diagnostics_accepts_runtime_overrides(mocker):
     df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
     captured = {}
 
-    def fake_load_input(path=None, session_id=None):
+    def fake_load_input(path=None, session_id=None, input_id=None):
         captured["input_path"] = path
         captured["input_session_id"] = session_id
         return df
@@ -255,7 +255,7 @@ async def test_toolkit_infer_configs_accepts_runtime_overrides(monkeypatch, mock
     df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
     captured = {}
 
-    def fake_load_input(path=None, session_id=None):
+    def fake_load_input(path=None, session_id=None, input_id=None):
         captured["input_path"] = path
         captured["input_session_id"] = session_id
         return df
@@ -469,7 +469,7 @@ async def test_auto_heal_worker_marks_failed_when_result_status_is_error(mocker)
         return_value={"status": "error", "module": "auto_heal"},
     )
 
-    await auto_heal_tool._auto_heal_worker(job_id, None, "sess_test", None, "run_auto")
+    await auto_heal_tool._auto_heal_worker(job_id, None, "sess_test", None, "run_auto", None)
     job = auto_heal_tool.JobStore.get(job_id)
 
     assert job is not None
@@ -680,7 +680,7 @@ async def test_toolkit_duplicates_runtime_can_override_input_and_html(mocker):
     df = pd.DataFrame({"id": [1, 1], "value": [10, 10]})
     captured = {}
 
-    def fake_load_input(path=None, session_id=None):
+    def fake_load_input(path=None, session_id=None, input_id=None):
         captured["input_path"] = path
         return df
 
@@ -714,7 +714,7 @@ async def test_toolkit_final_audit_runtime_can_override_input_path(mocker, monke
     df = pd.DataFrame({"value": [1]})
     captured = {}
 
-    def fake_load_input(path=None, session_id=None):
+    def fake_load_input(path=None, session_id=None, input_id=None):
         captured["input_path"] = path
         return df
 

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -178,6 +178,7 @@ async def test_toolkit_diagnostics_accepts_runtime_overrides(mocker):
     def fake_load_input(path=None, session_id=None, input_id=None):
         captured["input_path"] = path
         captured["input_session_id"] = session_id
+        captured["input_id"] = input_id
         return df
 
     mocker.patch.object(diagnostics_tool, "load_input", side_effect=fake_load_input)
@@ -258,6 +259,7 @@ async def test_toolkit_infer_configs_accepts_runtime_overrides(monkeypatch, mock
     def fake_load_input(path=None, session_id=None, input_id=None):
         captured["input_path"] = path
         captured["input_session_id"] = session_id
+        captured["input_id"] = input_id
         return df
 
     mocker.patch.object(infer_configs_tool, "load_input", side_effect=fake_load_input)
@@ -469,7 +471,14 @@ async def test_auto_heal_worker_marks_failed_when_result_status_is_error(mocker)
         return_value={"status": "error", "module": "auto_heal"},
     )
 
-    await auto_heal_tool._auto_heal_worker(job_id, None, "sess_test", None, "run_auto", None)
+    await auto_heal_tool._auto_heal_worker(
+        job_id=job_id,
+        gcs_path=None,
+        session_id="sess_test",
+        runtime=None,
+        run_id="run_auto",
+        input_id=None,
+    )
     job = auto_heal_tool.JobStore.get(job_id)
 
     assert job is not None

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -216,6 +216,7 @@ async def test_toolkit_diagnostics_accepts_runtime_overrides(mocker):
     assert result["run_id"] == "diag_runtime"
     assert result["runtime_applied"] is True
     assert captured["input_path"] == "gs://bucket/runtime.csv"
+    assert captured["input_id"] is None
     assert result["artifact_path"].endswith("diag_runtime_diagnostics_report.html")
 
 
@@ -282,6 +283,7 @@ async def test_toolkit_infer_configs_accepts_runtime_overrides(monkeypatch, mock
     assert result["runtime_applied"] is True
     assert result["run_id"] == "infer_runtime"
     assert captured["input_path"] == "gs://bucket/runtime.csv"
+    assert captured["input_id"] is None
 
 
 @pytest.mark.asyncio
@@ -691,6 +693,7 @@ async def test_toolkit_duplicates_runtime_can_override_input_and_html(mocker):
 
     def fake_load_input(path=None, session_id=None, input_id=None):
         captured["input_path"] = path
+        captured["input_id"] = input_id
         return df
 
     mocker.patch.object(duplicates_tool, "load_input", side_effect=fake_load_input)
@@ -715,6 +718,7 @@ async def test_toolkit_duplicates_runtime_can_override_input_and_html(mocker):
     assert result["runtime_applied"] is True
     assert result["run_id"] == "dup_runtime"
     assert captured["input_path"] == "gs://bucket/dup.csv"
+    assert captured["input_id"] is None
     assert result["artifact_matrix"]["html_report"]["status"] == "disabled"
 
 
@@ -725,6 +729,7 @@ async def test_toolkit_final_audit_runtime_can_override_input_path(mocker, monke
 
     def fake_load_input(path=None, session_id=None, input_id=None):
         captured["input_path"] = path
+        captured["input_id"] = input_id
         return df
 
     mocker.patch.object(final_audit_tool, "load_input", side_effect=fake_load_input)
@@ -759,6 +764,7 @@ async def test_toolkit_final_audit_runtime_can_override_input_path(mocker, monke
     assert result["runtime_applied"] is True
     assert result["run_id"] == "final_runtime"
     assert captured["input_path"] == "gs://bucket/final.csv"
+    assert captured["input_id"] is None
     assert "final_runtime" in result["artifact_path"]
 
 


### PR DESCRIPTION
## Summary
- add a first-class MCP input ingest subsystem under 
- add HTTP ingest endpoints for upload, register, and descriptor lookup
- add MCP tools for input registration and descriptor lookup
- wire canonical  support through schemas, runtime overlays, and major data tools

## Why
The Dockerized MCP server could only resolve server-visible local paths. Live client testing exposed the missing contract for client-local data. This PR makes ingestion server-owned and client-agnostic instead of relying on shared filesystem assumptions.

## What changed
- new canonical input descriptor, registry, storage, adapter, loader, and ingest orchestration layers
- 
- 
- 
- new MCP tools:
  - 
  - 
-  support in deep-merge runtime overlays
- major data tools now accept  in addition to  and 
- new ingest and MCP regression coverage

## Validation
- All checks passed!
- Success: no issues found in 50 source files
- ......................................................                   [100%]
54 passed in 0.13s
- ..................................................                       [100%]
50 passed in 0.76s

## Live validation
Ran the branch server over real HTTP and verified:
- 
- 
- 
-  with 
- 
-  with 

That produced a canonical , returned descriptor metadata, and completed a real diagnostics run from the ingested input.

## Notes
-  still supports  and server-visible local paths
-  is the new future-proof path for uploaded/staged/registered inputs
- Google Drive is modeled explicitly but still returns a clear not-implemented error rather than pretending to work