### PR TITLE
fix: harden MCP input registry idempotency semantics

### DIFF
--- a/src/analyst_toolkit/mcp_server/input/ingest.py
+++ b/src/analyst_toolkit/mcp_server/input/ingest.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
+import hashlib
 import mimetypes
 import uuid
-from dataclasses import replace
 from pathlib import Path
 
 import pandas as pd
@@ -22,7 +22,10 @@ from analyst_toolkit.mcp_server.input.storage import stage_uploaded_file
 from analyst_toolkit.mcp_server.state import StateStore
 
 
-def _new_input_id() -> str:
+def _new_input_id(stable_key: str | None = None) -> str:
+    if stable_key:
+        digest = hashlib.sha256(stable_key.encode("utf-8")).hexdigest()
+        return f"input_{digest[:12]}"
     return f"input_{uuid.uuid4().hex[:12]}"
 
 
@@ -38,10 +41,17 @@ def ingest_uploaded_bytes(
     session_id: str | None = None,
     run_id: str | None = None,
     load_into_session: bool = True,
+    idempotency_key: str | None = None,
 ) -> tuple[InputDescriptor, pd.DataFrame | None, str | None]:
+    """
+    Stage uploaded bytes into a canonical input reference.
+
+    Input identity is deterministic for repeated uploads of the same filename/content pair.
+    Full run/session idempotency still requires callers to provide stable session_id/run_id.
+    """
     staged_path, digest, size = stage_uploaded_file(filename=filename, payload=payload)
     descriptor = InputDescriptor(
-        input_id=_new_input_id(),
+        input_id=_new_input_id(idempotency_key or f"upload:{Path(filename).name}:{digest}"),
         source_type="upload",
         original_reference=filename,
         resolved_reference=str(staged_path),
@@ -57,7 +67,10 @@ def ingest_uploaded_bytes(
     if load_into_session:
         df = load_dataframe_from_descriptor(descriptor)
         effective_session_id = StateStore.save(df, session_id=session_id, run_id=run_id)
-        descriptor = replace(descriptor, session_id=effective_session_id)
+        descriptor = descriptor.with_runtime_binding(
+            session_id=effective_session_id,
+            run_id=run_id,
+        )
     descriptor = save_descriptor(descriptor)
     if load_into_session and effective_session_id is not None:
         bind_session_input(effective_session_id, descriptor.input_id)
@@ -71,12 +84,19 @@ def register_input_source(
     session_id: str | None = None,
     run_id: str | None = None,
     load_into_session: bool = True,
+    idempotency_key: str | None = None,
 ) -> tuple[InputDescriptor, pd.DataFrame | None, str | None]:
+    """
+    Register a canonical input source from a local server path or gs:// URI.
+
+    Retries are only input-idempotent when callers provide a stable idempotency_key.
+    Without one, the source is registered under a new input_id on each call.
+    """
     resolved_type, resolved_reference, display_name = resolve_source_reference(
         reference, source_type
     )
     descriptor = InputDescriptor(
-        input_id=_new_input_id(),
+        input_id=_new_input_id(idempotency_key),
         source_type=resolved_type,
         original_reference=reference,
         resolved_reference=resolved_reference,
@@ -90,7 +110,10 @@ def register_input_source(
     if load_into_session:
         df = load_dataframe_from_descriptor(descriptor)
         effective_session_id = StateStore.save(df, session_id=session_id, run_id=run_id)
-        descriptor = replace(descriptor, session_id=effective_session_id)
+        descriptor = descriptor.with_runtime_binding(
+            session_id=effective_session_id,
+            run_id=run_id,
+        )
     descriptor = save_descriptor(descriptor)
     if load_into_session and effective_session_id is not None:
         bind_session_input(effective_session_id, descriptor.input_id)

--- a/src/analyst_toolkit/mcp_server/input/ingest.py
+++ b/src/analyst_toolkit/mcp_server/input/ingest.py
@@ -89,14 +89,14 @@ def register_input_source(
     """
     Register a canonical input source from a local server path or gs:// URI.
 
-    Retries are only input-idempotent when callers provide a stable idempotency_key.
-    Without one, the source is registered under a new input_id on each call.
+    By default the same canonical resolved source reuses the same input_id. Callers may
+    provide a stable idempotency_key to control that identity explicitly across retries.
     """
     resolved_type, resolved_reference, display_name = resolve_source_reference(
         reference, source_type
     )
     descriptor = InputDescriptor(
-        input_id=_new_input_id(idempotency_key),
+        input_id=_new_input_id(idempotency_key or f"source:{resolved_reference}"),
         source_type=resolved_type,
         original_reference=reference,
         resolved_reference=resolved_reference,

--- a/src/analyst_toolkit/mcp_server/input/models.py
+++ b/src/analyst_toolkit/mcp_server/input/models.py
@@ -7,6 +7,7 @@ from types import MappingProxyType
 from typing import Any, Literal, Mapping
 
 InputSourceType = Literal["upload", "server_path", "gcs", "gdrive"]
+_UNSET = object()
 
 
 @dataclass(frozen=True)
@@ -42,13 +43,17 @@ class InputDescriptor:
     def with_runtime_binding(
         self,
         *,
-        session_id: str | None = None,
-        run_id: str | None = None,
+        session_id: str | None | object = _UNSET,
+        run_id: str | None | object = _UNSET,
     ) -> "InputDescriptor":
+        next_session_id: str | None = (
+            self.session_id if session_id is _UNSET else session_id  # type: ignore[assignment]
+        )
+        next_run_id: str | None = self.run_id if run_id is _UNSET else run_id  # type: ignore[assignment]
         return replace(
             self,
-            session_id=session_id if session_id is not None else self.session_id,
-            run_id=run_id if run_id is not None else self.run_id,
+            session_id=next_session_id,
+            run_id=next_run_id,
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/src/analyst_toolkit/mcp_server/input/models.py
+++ b/src/analyst_toolkit/mcp_server/input/models.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass, field
-from typing import Any, Literal
+from dataclasses import dataclass, field, replace
+from types import MappingProxyType
+from typing import Any, Literal, Mapping
 
 InputSourceType = Literal["upload", "server_path", "gcs", "gdrive"]
 
@@ -20,7 +21,47 @@ class InputDescriptor:
     sha256: str | None = None
     session_id: str | None = None
     run_id: str | None = None
-    metadata: dict[str, Any] = field(default_factory=dict)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
+
+    def same_canonical_input(self, other: "InputDescriptor") -> bool:
+        return (
+            self.input_id == other.input_id
+            and self.source_type == other.source_type
+            and self.original_reference == other.original_reference
+            and self.resolved_reference == other.resolved_reference
+            and self.display_name == other.display_name
+            and self.media_type == other.media_type
+            and self.file_size_bytes == other.file_size_bytes
+            and self.sha256 == other.sha256
+            and dict(self.metadata) == dict(other.metadata)
+        )
+
+    def with_runtime_binding(
+        self,
+        *,
+        session_id: str | None = None,
+        run_id: str | None = None,
+    ) -> "InputDescriptor":
+        return replace(
+            self,
+            session_id=session_id if session_id is not None else self.session_id,
+            run_id=run_id if run_id is not None else self.run_id,
+        )
 
     def to_dict(self) -> dict[str, Any]:
-        return asdict(self)
+        return {
+            "input_id": self.input_id,
+            "source_type": self.source_type,
+            "original_reference": self.original_reference,
+            "resolved_reference": self.resolved_reference,
+            "display_name": self.display_name,
+            "media_type": self.media_type,
+            "file_size_bytes": self.file_size_bytes,
+            "sha256": self.sha256,
+            "session_id": self.session_id,
+            "run_id": self.run_id,
+            "metadata": dict(self.metadata),
+        }

--- a/src/analyst_toolkit/mcp_server/input/registry.py
+++ b/src/analyst_toolkit/mcp_server/input/registry.py
@@ -39,6 +39,8 @@ def _env_float(name: str, default: float) -> float:
 
 _REGISTRY_MAX_ENTRIES = _env_int("ANALYST_MCP_INPUT_REGISTRY_MAX_ENTRIES", 512)
 _REGISTRY_TTL_SEC = _env_float("ANALYST_MCP_INPUT_REGISTRY_TTL_SEC", 21600.0)
+INPUT_DESCRIPTOR_CONFLICT_CODE = "INPUT_DESCRIPTOR_CONFLICT"
+INPUT_NOT_FOUND_CODE = "INPUT_NOT_FOUND"
 
 
 @dataclass
@@ -69,6 +71,10 @@ def _expires_at(now: float) -> float:
 
 def _remove_input_locked(input_id: str) -> None:
     _INPUTS.pop(input_id, None)
+    _cleanup_sessions_for_input_locked(input_id)
+
+
+def _cleanup_sessions_for_input_locked(input_id: str) -> None:
     stale_sessions = [
         session_id
         for session_id, binding in list(_SESSION_INPUTS.items())
@@ -78,7 +84,9 @@ def _remove_input_locked(input_id: str) -> None:
         _SESSION_INPUTS.pop(session_id, None)
 
 
-def _refresh_input_locked(input_id: str, descriptor: InputDescriptor, now: float) -> InputDescriptor:
+def _refresh_input_locked(
+    input_id: str, descriptor: InputDescriptor, now: float
+) -> InputDescriptor:
     _INPUTS[input_id] = _RegistryEntry(descriptor=descriptor, expires_at=_expires_at(now))
     _INPUTS.move_to_end(input_id)
     return descriptor
@@ -94,9 +102,7 @@ def _refresh_session_locked(session_id: str, input_id: str, now: float) -> None:
 
 def _prune_locked(now: float) -> None:
     expired_inputs = [
-        input_id
-        for input_id, entry in list(_INPUTS.items())
-        if entry.expires_at <= now
+        input_id for input_id, entry in list(_INPUTS.items()) if entry.expires_at <= now
     ]
     for input_id in expired_inputs:
         _remove_input_locked(input_id)
@@ -111,13 +117,7 @@ def _prune_locked(now: float) -> None:
 
     while len(_INPUTS) > _REGISTRY_MAX_ENTRIES:
         oldest_input_id, _ = _INPUTS.popitem(last=False)
-        stale_sessions = [
-            session_id
-            for session_id, binding in list(_SESSION_INPUTS.items())
-            if binding.input_id == oldest_input_id
-        ]
-        for session_id in stale_sessions:
-            _SESSION_INPUTS.pop(session_id, None)
+        _cleanup_sessions_for_input_locked(oldest_input_id)
 
 
 def save_descriptor(descriptor: InputDescriptor) -> InputDescriptor:
@@ -131,7 +131,8 @@ def save_descriptor(descriptor: InputDescriptor) -> InputDescriptor:
             existing_descriptor = existing_entry.descriptor
             if not existing_descriptor.same_canonical_input(descriptor):
                 raise ValueError(
-                    f"Conflicting descriptor for input_id '{descriptor.input_id}'."
+                    f"[{INPUT_DESCRIPTOR_CONFLICT_CODE}] Conflicting descriptor for input_id "
+                    f"'{descriptor.input_id}'."
                 )
             effective_descriptor = descriptor.with_runtime_binding(
                 session_id=descriptor.session_id or existing_descriptor.session_id,
@@ -149,7 +150,6 @@ def save_descriptor(descriptor: InputDescriptor) -> InputDescriptor:
                 effective_descriptor.input_id,
                 now,
             )
-        _prune_locked(now)
     return effective_descriptor
 
 
@@ -169,7 +169,7 @@ def bind_session_input(session_id: str, input_id: str) -> None:
         _prune_locked(now)
         entry = _INPUTS.get(input_id)
         if entry is None:
-            raise ValueError(f"input_id '{input_id}' not found in registry")
+            raise ValueError(f"[{INPUT_NOT_FOUND_CODE}] input_id '{input_id}' not found in registry")
         _refresh_input_locked(input_id, entry.descriptor, now)
         _refresh_session_locked(session_id, input_id, now)
 

--- a/src/analyst_toolkit/mcp_server/input/registry.py
+++ b/src/analyst_toolkit/mcp_server/input/registry.py
@@ -2,39 +2,209 @@
 
 from __future__ import annotations
 
+import os
 import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from math import inf
 from typing import Optional
 
 from analyst_toolkit.mcp_server.input.models import InputDescriptor
 
 _LOCK = threading.Lock()
-_INPUTS: dict[str, InputDescriptor] = {}
-_SESSION_INPUTS: dict[str, str] = {}
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _env_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        parsed = float(value)
+    except ValueError:
+        return default
+    return parsed if parsed > 0 else default
+
+
+_REGISTRY_MAX_ENTRIES = _env_int("ANALYST_MCP_INPUT_REGISTRY_MAX_ENTRIES", 512)
+_REGISTRY_TTL_SEC = _env_float("ANALYST_MCP_INPUT_REGISTRY_TTL_SEC", 21600.0)
+
+
+@dataclass
+class _RegistryEntry:
+    descriptor: InputDescriptor
+    expires_at: float
+
+
+@dataclass
+class _SessionBinding:
+    input_id: str
+    expires_at: float
+
+
+_INPUTS: OrderedDict[str, _RegistryEntry] = OrderedDict()
+_SESSION_INPUTS: OrderedDict[str, _SessionBinding] = OrderedDict()
+
+
+def _now() -> float:
+    return time.monotonic()
+
+
+def _expires_at(now: float) -> float:
+    if _REGISTRY_TTL_SEC <= 0:
+        return inf
+    return now + _REGISTRY_TTL_SEC
+
+
+def _remove_input_locked(input_id: str) -> None:
+    _INPUTS.pop(input_id, None)
+    stale_sessions = [
+        session_id
+        for session_id, binding in list(_SESSION_INPUTS.items())
+        if binding.input_id == input_id
+    ]
+    for session_id in stale_sessions:
+        _SESSION_INPUTS.pop(session_id, None)
+
+
+def _refresh_input_locked(input_id: str, descriptor: InputDescriptor, now: float) -> InputDescriptor:
+    _INPUTS[input_id] = _RegistryEntry(descriptor=descriptor, expires_at=_expires_at(now))
+    _INPUTS.move_to_end(input_id)
+    return descriptor
+
+
+def _refresh_session_locked(session_id: str, input_id: str, now: float) -> None:
+    _SESSION_INPUTS[session_id] = _SessionBinding(
+        input_id=input_id,
+        expires_at=_expires_at(now),
+    )
+    _SESSION_INPUTS.move_to_end(session_id)
+
+
+def _prune_locked(now: float) -> None:
+    expired_inputs = [
+        input_id
+        for input_id, entry in list(_INPUTS.items())
+        if entry.expires_at <= now
+    ]
+    for input_id in expired_inputs:
+        _remove_input_locked(input_id)
+
+    expired_sessions = [
+        session_id
+        for session_id, binding in list(_SESSION_INPUTS.items())
+        if binding.expires_at <= now or binding.input_id not in _INPUTS
+    ]
+    for session_id in expired_sessions:
+        _SESSION_INPUTS.pop(session_id, None)
+
+    while len(_INPUTS) > _REGISTRY_MAX_ENTRIES:
+        oldest_input_id, _ = _INPUTS.popitem(last=False)
+        stale_sessions = [
+            session_id
+            for session_id, binding in list(_SESSION_INPUTS.items())
+            if binding.input_id == oldest_input_id
+        ]
+        for session_id in stale_sessions:
+            _SESSION_INPUTS.pop(session_id, None)
 
 
 def save_descriptor(descriptor: InputDescriptor) -> InputDescriptor:
     with _LOCK:
-        _INPUTS[descriptor.input_id] = descriptor
-        if descriptor.session_id:
-            _SESSION_INPUTS[descriptor.session_id] = descriptor.input_id
-    return descriptor
+        now = _now()
+        _prune_locked(now)
+        existing_entry = _INPUTS.get(descriptor.input_id)
+
+        effective_descriptor = descriptor
+        if existing_entry is not None:
+            existing_descriptor = existing_entry.descriptor
+            if not existing_descriptor.same_canonical_input(descriptor):
+                raise ValueError(
+                    f"Conflicting descriptor for input_id '{descriptor.input_id}'."
+                )
+            effective_descriptor = descriptor.with_runtime_binding(
+                session_id=descriptor.session_id or existing_descriptor.session_id,
+                run_id=descriptor.run_id or existing_descriptor.run_id,
+            )
+
+        effective_descriptor = _refresh_input_locked(
+            effective_descriptor.input_id,
+            effective_descriptor,
+            now,
+        )
+        if effective_descriptor.session_id:
+            _refresh_session_locked(
+                effective_descriptor.session_id,
+                effective_descriptor.input_id,
+                now,
+            )
+        _prune_locked(now)
+    return effective_descriptor
 
 
 def get_descriptor(input_id: str) -> Optional[InputDescriptor]:
     with _LOCK:
-        return _INPUTS.get(input_id)
+        now = _now()
+        _prune_locked(now)
+        entry = _INPUTS.get(input_id)
+        if entry is None:
+            return None
+        return _refresh_input_locked(input_id, entry.descriptor, now)
 
 
 def bind_session_input(session_id: str, input_id: str) -> None:
     with _LOCK:
-        if input_id not in _INPUTS:
+        now = _now()
+        _prune_locked(now)
+        entry = _INPUTS.get(input_id)
+        if entry is None:
             raise ValueError(f"input_id '{input_id}' not found in registry")
-        _SESSION_INPUTS[session_id] = input_id
+        _refresh_input_locked(input_id, entry.descriptor, now)
+        _refresh_session_locked(session_id, input_id, now)
 
 
 def get_session_input_id(session_id: str) -> Optional[str]:
     with _LOCK:
-        return _SESSION_INPUTS.get(session_id)
+        now = _now()
+        _prune_locked(now)
+        binding = _SESSION_INPUTS.get(session_id)
+        if binding is None:
+            return None
+        if binding.input_id not in _INPUTS:
+            _SESSION_INPUTS.pop(session_id, None)
+            return None
+        _refresh_session_locked(session_id, binding.input_id, now)
+        entry = _INPUTS[binding.input_id]
+        _refresh_input_locked(binding.input_id, entry.descriptor, now)
+        return binding.input_id
+
+
+def remove_descriptor(input_id: str) -> None:
+    with _LOCK:
+        _remove_input_locked(input_id)
+
+
+def get_registry_stats() -> dict[str, float | int]:
+    with _LOCK:
+        now = _now()
+        _prune_locked(now)
+        return {
+            "input_count": len(_INPUTS),
+            "session_binding_count": len(_SESSION_INPUTS),
+            "max_entries": _REGISTRY_MAX_ENTRIES,
+            "ttl_sec": _REGISTRY_TTL_SEC,
+        }
 
 
 def clear() -> None:

--- a/src/analyst_toolkit/mcp_server/input/registry.py
+++ b/src/analyst_toolkit/mcp_server/input/registry.py
@@ -169,7 +169,9 @@ def bind_session_input(session_id: str, input_id: str) -> None:
         _prune_locked(now)
         entry = _INPUTS.get(input_id)
         if entry is None:
-            raise ValueError(f"[{INPUT_NOT_FOUND_CODE}] input_id '{input_id}' not found in registry")
+            raise ValueError(
+                f"[{INPUT_NOT_FOUND_CODE}] input_id '{input_id}' not found in registry"
+            )
         _refresh_input_locked(input_id, entry.descriptor, now)
         _refresh_session_locked(session_id, input_id, now)
 

--- a/src/analyst_toolkit/mcp_server/server.py
+++ b/src/analyst_toolkit/mcp_server/server.py
@@ -119,6 +119,7 @@ class RegisterInputRequest(BaseModel):
     source_type: InputSourceType | None = None
     session_id: str | None = None
     run_id: str | None = None
+    idempotency_key: str | None = None
     load_into_session: bool = True
 
 
@@ -331,6 +332,7 @@ async def upload_input(
     file: UploadFile = File(...),
     session_id: str | None = Form(default=None),
     run_id: str | None = Form(default=None),
+    idempotency_key: str | None = Form(default=None),
     load_into_session: bool = Form(default=True),
 ) -> JSONResponse:
     trace_id = _require_http_auth(request)
@@ -347,6 +349,7 @@ async def upload_input(
             media_type=file.content_type,
             session_id=session_id,
             run_id=run_id,
+            idempotency_key=idempotency_key,
             load_into_session=load_into_session,
         )
     except Exception as exc:
@@ -378,6 +381,7 @@ async def register_input(request: Request, payload: RegisterInputRequest) -> JSO
             source_type=payload.source_type,
             session_id=payload.session_id,
             run_id=payload.run_id,
+            idempotency_key=payload.idempotency_key,
             load_into_session=payload.load_into_session,
         )
     except NotImplementedError as exc:

--- a/src/analyst_toolkit/mcp_server/tools/input_ingest.py
+++ b/src/analyst_toolkit/mcp_server/tools/input_ingest.py
@@ -129,9 +129,12 @@ register_tool(
             },
             "idempotency_key": {
                 "type": "string",
+                "minLength": 1,
+                "pattern": "^.*\\S.*$",
                 "description": (
                     "Optional stable idempotency key. Provide this to reuse the same "
-                    "input_id across retries for the same logical source."
+                    "input_id across retries for the same logical source. Reusing the "
+                    "same key for a different canonical source is rejected as a conflict."
                 ),
             },
             "load_into_session": {

--- a/src/analyst_toolkit/mcp_server/tools/input_ingest.py
+++ b/src/analyst_toolkit/mcp_server/tools/input_ingest.py
@@ -18,6 +18,7 @@ async def _toolkit_register_input(
     source_type: InputSourceType | None = None,
     session_id: str | None = None,
     run_id: str | None = None,
+    idempotency_key: str | None = None,
     load_into_session: bool = True,
 ) -> dict:
     try:
@@ -30,6 +31,7 @@ async def _toolkit_register_input(
                 source_type=source_type,
                 session_id=session_id,
                 run_id=run_id,
+                idempotency_key=idempotency_key,
                 load_into_session=load_into_session,
             ),
         )
@@ -123,6 +125,13 @@ register_tool(
                 "description": (
                     "Optional run identifier. Provide a stable run_id if clients need "
                     "idempotent retries; omitted run_id values may create distinct runs."
+                ),
+            },
+            "idempotency_key": {
+                "type": "string",
+                "description": (
+                    "Optional stable idempotency key. Provide this to reuse the same "
+                    "input_id across retries for the same logical source."
                 ),
             },
             "load_into_session": {

--- a/tests/mcp_server/test_input_ingest.py
+++ b/tests/mcp_server/test_input_ingest.py
@@ -38,6 +38,32 @@ def test_inputs_upload_creates_session_and_descriptor(client, monkeypatch, tmp_p
     assert payload["summary"]["column_count"] == 2
 
 
+def test_inputs_upload_reuses_input_id_for_same_payload(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
+    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
+    StateStore.clear()
+    input_registry.clear()
+
+    response_one = client.post(
+        "/inputs/upload",
+        files={
+            "file": ("dirty_penguins.csv", b"species,bill_length_mm\nAdelie,39.1\n", "text/csv")
+        },
+        data={"load_into_session": "false"},
+    )
+    response_two = client.post(
+        "/inputs/upload",
+        files={
+            "file": ("dirty_penguins.csv", b"species,bill_length_mm\nAdelie,39.1\n", "text/csv")
+        },
+        data={"load_into_session": "false"},
+    )
+
+    assert response_one.status_code == 200
+    assert response_two.status_code == 200
+    assert response_one.json()["input"]["input_id"] == response_two.json()["input"]["input_id"]
+
+
 def test_inputs_register_server_path_loads_into_session(client, monkeypatch, tmp_path):
     monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
     monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
@@ -57,6 +83,39 @@ def test_inputs_register_server_path_loads_into_session(client, monkeypatch, tmp
     assert payload["input"]["source_type"] == "server_path"
     assert payload["session_id"].startswith("sess_")
     assert payload["summary"]["row_count"] == 2
+
+
+def test_inputs_register_reuses_input_id_with_stable_idempotency_key(
+    client, monkeypatch, tmp_path
+):
+    monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
+    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
+    StateStore.clear()
+    input_registry.clear()
+
+    source = tmp_path / "dirty_penguins.csv"
+    _write_sample_csv(source)
+
+    response_one = client.post(
+        "/inputs/register",
+        json={
+            "uri": str(source),
+            "load_into_session": False,
+            "idempotency_key": "stable-register-key",
+        },
+    )
+    response_two = client.post(
+        "/inputs/register",
+        json={
+            "uri": str(source),
+            "load_into_session": False,
+            "idempotency_key": "stable-register-key",
+        },
+    )
+
+    assert response_one.status_code == 200
+    assert response_two.status_code == 200
+    assert response_one.json()["input"]["input_id"] == response_two.json()["input"]["input_id"]
 
 
 def test_inputs_register_rejects_path_outside_allowed_roots(client, monkeypatch, tmp_path):

--- a/tests/mcp_server/test_input_ingest.py
+++ b/tests/mcp_server/test_input_ingest.py
@@ -61,6 +61,8 @@ def test_inputs_upload_reuses_input_id_for_same_payload(client, monkeypatch, tmp
 
     assert response_one.status_code == 200
     assert response_two.status_code == 200
+    assert response_one.json()["status"] == "pass"
+    assert response_two.json()["status"] == "pass"
     assert response_one.json()["input"]["input_id"] == response_two.json()["input"]["input_id"]
 
 
@@ -85,9 +87,7 @@ def test_inputs_register_server_path_loads_into_session(client, monkeypatch, tmp
     assert payload["summary"]["row_count"] == 2
 
 
-def test_inputs_register_reuses_input_id_with_stable_idempotency_key(
-    client, monkeypatch, tmp_path
-):
+def test_inputs_register_reuses_input_id_with_stable_idempotency_key(client, monkeypatch, tmp_path):
     monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
     monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
     StateStore.clear()
@@ -115,7 +115,44 @@ def test_inputs_register_reuses_input_id_with_stable_idempotency_key(
 
     assert response_one.status_code == 200
     assert response_two.status_code == 200
+    assert response_one.json()["status"] == "pass"
+    assert response_two.json()["status"] == "pass"
     assert response_one.json()["input"]["input_id"] == response_two.json()["input"]["input_id"]
+
+
+def test_inputs_register_uses_distinct_input_ids_for_distinct_idempotency_keys(
+    client, monkeypatch, tmp_path
+):
+    monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
+    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
+    StateStore.clear()
+    input_registry.clear()
+
+    source = tmp_path / "dirty_penguins.csv"
+    _write_sample_csv(source)
+
+    response_one = client.post(
+        "/inputs/register",
+        json={
+            "uri": str(source),
+            "load_into_session": False,
+            "idempotency_key": "stable-register-key-a",
+        },
+    )
+    response_two = client.post(
+        "/inputs/register",
+        json={
+            "uri": str(source),
+            "load_into_session": False,
+            "idempotency_key": "stable-register-key-b",
+        },
+    )
+
+    assert response_one.status_code == 200
+    assert response_two.status_code == 200
+    assert response_one.json()["status"] == "pass"
+    assert response_two.json()["status"] == "pass"
+    assert response_one.json()["input"]["input_id"] != response_two.json()["input"]["input_id"]
 
 
 def test_inputs_register_rejects_path_outside_allowed_roots(client, monkeypatch, tmp_path):

--- a/tests/mcp_server/test_input_registry.py
+++ b/tests/mcp_server/test_input_registry.py
@@ -1,3 +1,5 @@
+import pytest
+
 from analyst_toolkit.mcp_server.input import registry as input_registry
 from analyst_toolkit.mcp_server.input.models import InputDescriptor
 
@@ -49,12 +51,8 @@ def test_registry_rejects_conflicting_descriptor_reuse(monkeypatch):
 
     input_registry.save_descriptor(_descriptor("input_conflict", sha256="abc"))
 
-    try:
+    with pytest.raises(ValueError, match="Conflicting descriptor"):
         input_registry.save_descriptor(_descriptor("input_conflict", sha256="def"))
-    except ValueError as exc:
-        assert "Conflicting descriptor" in str(exc)
-    else:
-        raise AssertionError("Expected conflicting descriptor reuse to raise ValueError")
 
 
 def test_registry_evicts_oldest_entries_when_capacity_is_exceeded(monkeypatch):

--- a/tests/mcp_server/test_input_registry.py
+++ b/tests/mcp_server/test_input_registry.py
@@ -1,0 +1,89 @@
+from analyst_toolkit.mcp_server.input import registry as input_registry
+from analyst_toolkit.mcp_server.input.models import InputDescriptor
+
+
+def _descriptor(
+    input_id: str,
+    *,
+    session_id: str | None = None,
+    run_id: str | None = None,
+    sha256: str | None = None,
+) -> InputDescriptor:
+    return InputDescriptor(
+        input_id=input_id,
+        source_type="upload",
+        original_reference="dirty_penguins.csv",
+        resolved_reference="/tmp/dirty_penguins.csv",
+        display_name="dirty_penguins.csv",
+        media_type="text/csv",
+        file_size_bytes=42,
+        sha256=sha256,
+        session_id=session_id,
+        run_id=run_id,
+        metadata={"kind": "test"},
+    )
+
+
+def test_registry_save_is_idempotent_for_same_canonical_descriptor(monkeypatch):
+    monkeypatch.setattr(input_registry, "_REGISTRY_MAX_ENTRIES", 8)
+    monkeypatch.setattr(input_registry, "_REGISTRY_TTL_SEC", 3600.0)
+    input_registry.clear()
+
+    saved = input_registry.save_descriptor(
+        _descriptor("input_same", session_id="sess_a", run_id="run_a")
+    )
+    repeated = input_registry.save_descriptor(
+        _descriptor("input_same", session_id="sess_b", run_id="run_b")
+    )
+
+    assert saved.input_id == repeated.input_id
+    assert repeated.session_id == "sess_b"
+    assert input_registry.get_session_input_id("sess_a") == "input_same"
+    assert input_registry.get_session_input_id("sess_b") == "input_same"
+
+
+def test_registry_rejects_conflicting_descriptor_reuse(monkeypatch):
+    monkeypatch.setattr(input_registry, "_REGISTRY_MAX_ENTRIES", 8)
+    monkeypatch.setattr(input_registry, "_REGISTRY_TTL_SEC", 3600.0)
+    input_registry.clear()
+
+    input_registry.save_descriptor(_descriptor("input_conflict", sha256="abc"))
+
+    try:
+        input_registry.save_descriptor(_descriptor("input_conflict", sha256="def"))
+    except ValueError as exc:
+        assert "Conflicting descriptor" in str(exc)
+    else:
+        raise AssertionError("Expected conflicting descriptor reuse to raise ValueError")
+
+
+def test_registry_evicts_oldest_entries_when_capacity_is_exceeded(monkeypatch):
+    monkeypatch.setattr(input_registry, "_REGISTRY_MAX_ENTRIES", 2)
+    monkeypatch.setattr(input_registry, "_REGISTRY_TTL_SEC", 3600.0)
+    input_registry.clear()
+
+    input_registry.save_descriptor(_descriptor("input_a", session_id="sess_a"))
+    input_registry.save_descriptor(_descriptor("input_b", session_id="sess_b"))
+    input_registry.save_descriptor(_descriptor("input_c", session_id="sess_c"))
+
+    assert input_registry.get_descriptor("input_a") is None
+    assert input_registry.get_session_input_id("sess_a") is None
+    assert input_registry.get_descriptor("input_b") is not None
+    assert input_registry.get_descriptor("input_c") is not None
+
+
+def test_registry_expires_descriptors_and_session_bindings(monkeypatch):
+    clock = {"now": 1000.0}
+
+    monkeypatch.setattr(input_registry, "_REGISTRY_MAX_ENTRIES", 8)
+    monkeypatch.setattr(input_registry, "_REGISTRY_TTL_SEC", 5.0)
+    monkeypatch.setattr(input_registry, "_now", lambda: clock["now"])
+    input_registry.clear()
+
+    input_registry.save_descriptor(_descriptor("input_ttl", session_id="sess_ttl"))
+    assert input_registry.get_descriptor("input_ttl") is not None
+    assert input_registry.get_session_input_id("sess_ttl") == "input_ttl"
+
+    clock["now"] = 1006.0
+    assert input_registry.get_descriptor("input_ttl") is None
+    assert input_registry.get_session_input_id("sess_ttl") is None


### PR DESCRIPTION
## Summary
- harden the MCP input registry with bounded TTL/LRU behavior
- make canonical input descriptor saves explicitly idempotent and reject conflicting reuse
- add deterministic input identity for uploads and stable idempotency-key support for registered sources

## Changes
- add bounded in-memory registry behavior for input descriptors and session bindings
- prune stale entries with TTL semantics and clean up evicted bindings
- freeze descriptor metadata and add helper methods for canonical comparisons/runtime binding updates
- make upload input IDs deterministic from content and register input IDs deterministic from canonical source unless callers provide an explicit idempotency key
- expose optional `idempotency_key` on HTTP and MCP input registration surfaces
- expand ingest and registry regression coverage for idempotency, conflicts, TTL expiry, and eviction behavior

## Validation
- `ruff check src/analyst_toolkit/mcp_server/input src/analyst_toolkit/mcp_server/tools/input_ingest.py tests/mcp_server/test_input_ingest.py tests/mcp_server/test_input_registry.py`
- `mypy src/analyst_toolkit/mcp_server`
- `pytest tests/mcp_server/test_input_ingest.py tests/mcp_server/test_input_registry.py tests/mcp_server/test_http_auth_metrics.py tests/mcp_server/test_rpc_tools.py tests/test_mcp_tool_regressions.py -q`

Closes #75