### PR TITLE
fix: harden MCP ingest trust boundaries and errors

### DIFF
--- a/src/analyst_toolkit/mcp_server/input/adapters.py
+++ b/src/analyst_toolkit/mcp_server/input/adapters.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from urllib.parse import urlparse
 
+from analyst_toolkit.mcp_server.input.errors import InputNotSupportedError
 from analyst_toolkit.mcp_server.input.models import InputSourceType
 from analyst_toolkit.mcp_server.input.storage import validate_server_visible_path
 
@@ -16,7 +17,7 @@ def detect_source_type(reference: str) -> InputSourceType:
     if parsed.scheme in {"gdrive", "drive"}:
         return "gdrive"
     if parsed.scheme:
-        raise ValueError(
+        raise InputNotSupportedError(
             f"Unsupported input scheme '{parsed.scheme}'. Use a server-visible path, gs:// URI, or upload."
         )
     return "server_path"
@@ -27,7 +28,7 @@ def resolve_source_reference(
 ) -> tuple[InputSourceType, str, str]:
     detected_type = detect_source_type(reference)
     if source_type is not None and source_type != detected_type:
-        raise ValueError(
+        raise InputNotSupportedError(
             f"Explicit source_type '{source_type}' does not match reference '{reference}'."
         )
     resolved_type = source_type or detected_type
@@ -35,7 +36,7 @@ def resolve_source_reference(
         filename = reference.rstrip("/").split("/")[-1] or reference
         return resolved_type, reference, filename
     if resolved_type == "gdrive":
-        raise NotImplementedError(
+        raise InputNotSupportedError(
             "Google Drive inputs are not implemented yet. Upload the file, use a server-visible path, or use gs://."
         )
     resolved_path = validate_server_visible_path(reference)

--- a/src/analyst_toolkit/mcp_server/input/errors.py
+++ b/src/analyst_toolkit/mcp_server/input/errors.py
@@ -1,0 +1,38 @@
+"""Domain errors for MCP input ingest and resolution."""
+
+from __future__ import annotations
+
+
+class InputError(Exception):
+    """Base error for input ingest and resolution surfaces."""
+
+    code = "INPUT_ERROR"
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = message
+
+
+class InputNotSupportedError(InputError):
+    code = "INPUT_NOT_SUPPORTED"
+
+
+class InputPathNotFoundError(InputError):
+    code = "INPUT_PATH_NOT_FOUND"
+
+
+class InputPathDeniedError(InputError):
+    code = "INPUT_PATH_DENIED"
+
+
+class InputPayloadTooLargeError(InputError):
+    code = "INPUT_PAYLOAD_TOO_LARGE"
+
+
+class InputConflictError(InputError):
+    code = "INPUT_CONFLICT"
+
+
+class InputNotFoundError(InputError):
+    code = "INPUT_NOT_FOUND"
+

--- a/src/analyst_toolkit/mcp_server/input/errors.py
+++ b/src/analyst_toolkit/mcp_server/input/errors.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
+from typing import Optional
+
 
 class InputError(Exception):
     """Base error for input ingest and resolution surfaces."""
 
-    code = "INPUT_ERROR"
+    code: str = "INPUT_ERROR"
 
-    def __init__(self, message: str):
+    def __init__(self, message: str, *, trace_id: Optional[str] = None):
         super().__init__(message)
         self.message = message
+        self.trace_id = trace_id
 
 
 class InputNotSupportedError(InputError):
@@ -35,4 +38,3 @@ class InputConflictError(InputError):
 
 class InputNotFoundError(InputError):
     code = "INPUT_NOT_FOUND"
-

--- a/src/analyst_toolkit/mcp_server/input/ingest.py
+++ b/src/analyst_toolkit/mcp_server/input/ingest.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import pandas as pd
 
 from analyst_toolkit.mcp_server.input.adapters import resolve_source_reference
+from analyst_toolkit.mcp_server.input.errors import InputNotFoundError
 from analyst_toolkit.mcp_server.input.loaders import load_dataframe_from_descriptor
 from analyst_toolkit.mcp_server.input.models import InputDescriptor, InputSourceType
 from analyst_toolkit.mcp_server.input.registry import (
@@ -141,7 +142,7 @@ def load_dataframe(
     if input_id:
         descriptor = get_descriptor(input_id)
         if descriptor is None:
-            raise FileNotFoundError(f"Input ID not found: '{input_id}'")
+            raise InputNotFoundError("Input descriptor not found.")
         return load_dataframe_from_descriptor(descriptor)
 
     if not path:

--- a/src/analyst_toolkit/mcp_server/input/ingest.py
+++ b/src/analyst_toolkit/mcp_server/input/ingest.py
@@ -142,7 +142,7 @@ def load_dataframe(
     if input_id:
         descriptor = get_descriptor(input_id)
         if descriptor is None:
-            raise InputNotFoundError("Input descriptor not found.")
+            raise InputNotFoundError(f"Input descriptor not found for input_id='{input_id}'.")
         return load_dataframe_from_descriptor(descriptor)
 
     if not path:

--- a/src/analyst_toolkit/mcp_server/input/loaders.py
+++ b/src/analyst_toolkit/mcp_server/input/loaders.py
@@ -6,14 +6,9 @@ from pathlib import Path
 
 import pandas as pd
 
+from analyst_toolkit.mcp_server.input.errors import InputNotSupportedError
 from analyst_toolkit.mcp_server.input.models import InputDescriptor
 from analyst_toolkit.mcp_server.io_storage import load_from_gcs
-
-
-class InputNotSupportedError(Exception):
-    """Raised when a descriptor references an unsupported input source or format."""
-
-    code = "INPUT_NOT_SUPPORTED"
 
 
 def load_dataframe_from_descriptor(descriptor: InputDescriptor) -> pd.DataFrame:

--- a/src/analyst_toolkit/mcp_server/input/models.py
+++ b/src/analyst_toolkit/mcp_server/input/models.py
@@ -28,6 +28,8 @@ class InputDescriptor:
         object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
 
     def same_canonical_input(self, other: "InputDescriptor") -> bool:
+        if not isinstance(other, InputDescriptor):
+            return False
         return (
             self.input_id == other.input_id
             and self.source_type == other.source_type

--- a/src/analyst_toolkit/mcp_server/input/registry.py
+++ b/src/analyst_toolkit/mcp_server/input/registry.py
@@ -35,11 +35,13 @@ def _env_float(name: str, default: float) -> float:
         parsed = float(value)
     except ValueError:
         return default
-    return parsed if parsed > 0 else default
+    return parsed if parsed >= 0 else default
 
 
 _REGISTRY_MAX_ENTRIES = _env_int("ANALYST_MCP_INPUT_REGISTRY_MAX_ENTRIES", 512)
 _REGISTRY_TTL_SEC = _env_float("ANALYST_MCP_INPUT_REGISTRY_TTL_SEC", 21600.0)
+
+
 @dataclass
 class _RegistryEntry:
     descriptor: InputDescriptor

--- a/src/analyst_toolkit/mcp_server/input/registry.py
+++ b/src/analyst_toolkit/mcp_server/input/registry.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from math import inf
 from typing import Optional
 
+from analyst_toolkit.mcp_server.input.errors import InputConflictError, InputNotFoundError
 from analyst_toolkit.mcp_server.input.models import InputDescriptor
 
 _LOCK = threading.Lock()
@@ -39,10 +40,6 @@ def _env_float(name: str, default: float) -> float:
 
 _REGISTRY_MAX_ENTRIES = _env_int("ANALYST_MCP_INPUT_REGISTRY_MAX_ENTRIES", 512)
 _REGISTRY_TTL_SEC = _env_float("ANALYST_MCP_INPUT_REGISTRY_TTL_SEC", 21600.0)
-INPUT_DESCRIPTOR_CONFLICT_CODE = "INPUT_DESCRIPTOR_CONFLICT"
-INPUT_NOT_FOUND_CODE = "INPUT_NOT_FOUND"
-
-
 @dataclass
 class _RegistryEntry:
     descriptor: InputDescriptor
@@ -101,6 +98,9 @@ def _refresh_session_locked(session_id: str, input_id: str, now: float) -> None:
 
 
 def _prune_locked(now: float) -> None:
+    # Full scans are intentional here because the registry is strictly bounded by
+    # _REGISTRY_MAX_ENTRIES. Revisit amortized or timer-based pruning only if the cap
+    # or request frequency grows enough for this O(n) pass to matter in practice.
     expired_inputs = [
         input_id for input_id, entry in list(_INPUTS.items()) if entry.expires_at <= now
     ]
@@ -130,9 +130,8 @@ def save_descriptor(descriptor: InputDescriptor) -> InputDescriptor:
         if existing_entry is not None:
             existing_descriptor = existing_entry.descriptor
             if not existing_descriptor.same_canonical_input(descriptor):
-                raise ValueError(
-                    f"[{INPUT_DESCRIPTOR_CONFLICT_CODE}] Conflicting descriptor for input_id "
-                    f"'{descriptor.input_id}'."
+                raise InputConflictError(
+                    f"Conflicting descriptor for input_id '{descriptor.input_id}'."
                 )
             effective_descriptor = descriptor.with_runtime_binding(
                 session_id=descriptor.session_id or existing_descriptor.session_id,
@@ -169,9 +168,7 @@ def bind_session_input(session_id: str, input_id: str) -> None:
         _prune_locked(now)
         entry = _INPUTS.get(input_id)
         if entry is None:
-            raise ValueError(
-                f"[{INPUT_NOT_FOUND_CODE}] input_id '{input_id}' not found in registry"
-            )
+            raise InputNotFoundError(f"input_id '{input_id}' not found in registry")
         _refresh_input_locked(input_id, entry.descriptor, now)
         _refresh_session_locked(session_id, input_id, now)
 

--- a/src/analyst_toolkit/mcp_server/input/storage.py
+++ b/src/analyst_toolkit/mcp_server/input/storage.py
@@ -5,11 +5,21 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+import tempfile
 from pathlib import Path
+
+from analyst_toolkit.mcp_server.input.errors import (
+    InputPathDeniedError,
+    InputPathNotFoundError,
+    InputPayloadTooLargeError,
+)
+
+_MAX_UPLOAD_BYTES = int(os.environ.get("ANALYST_MCP_MAX_UPLOAD_BYTES", 50 * 1024 * 1024))
 
 
 def _safe_name(name: str) -> str:
-    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", name.strip())
+    basename = Path(name).name
+    cleaned = re.sub(r"[^A-Za-z0-9._-]+", "_", basename.strip())
     return cleaned or "input.bin"
 
 
@@ -21,15 +31,12 @@ def input_root() -> Path:
 
 
 def allowed_server_input_roots() -> list[Path]:
+    """Return the explicit allowlist of server-visible local input roots."""
     configured = os.environ.get("ANALYST_MCP_ALLOWED_INPUT_ROOTS", "").strip()
     if configured:
         roots = [Path(item).expanduser().resolve() for item in configured.split(os.pathsep) if item]
     else:
-        roots = [
-            (Path.cwd() / "data").resolve(),
-            (Path.cwd() / "exports").resolve(),
-            input_root(),
-        ]
+        roots = [input_root()]
     unique: list[Path] = []
     seen: set[Path] = set()
     for root in roots:
@@ -44,28 +51,41 @@ def sha256_hex(payload: bytes) -> str:
 
 
 def stage_uploaded_file(*, filename: str, payload: bytes) -> tuple[Path, str, int]:
+    if len(payload) > _MAX_UPLOAD_BYTES:
+        raise InputPayloadTooLargeError(
+            f"Upload exceeds maximum allowed size ({_MAX_UPLOAD_BYTES} bytes)."
+        )
     digest = sha256_hex(payload)
     safe_name = _safe_name(filename)
     staged_dir = input_root() / digest[:2] / digest[2:4]
     staged_dir.mkdir(parents=True, exist_ok=True)
     staged_path = staged_dir / f"{digest}_{safe_name}"
     if not staged_path.exists():
-        staged_path.write_bytes(payload)
+        with tempfile.NamedTemporaryFile(dir=staged_dir, delete=False) as handle:
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+            tmp_path = Path(handle.name)
+        os.replace(tmp_path, staged_path)
     return staged_path.resolve(), digest, len(payload)
 
 
 def validate_server_visible_path(path_text: str) -> Path:
-    candidate = Path(path_text).expanduser().resolve(strict=False)
+    if path_text.startswith("~"):
+        raise InputPathDeniedError(
+            "Local path is not visible to the MCP runtime. Upload the file, mount the directory, or use gs://."
+        )
+    roots = allowed_server_input_roots()
+    candidate = Path(path_text).resolve(strict=False)
     if not candidate.exists():
-        raise FileNotFoundError(f"Input path not found: '{path_text}'")
-    for root in allowed_server_input_roots():
+        raise InputPathNotFoundError("Input path not found.")
+    for root in roots:
         try:
             candidate.relative_to(root)
             return candidate
         except ValueError:
             continue
-    allowed = ", ".join(str(root) for root in allowed_server_input_roots())
-    raise PermissionError(
+    raise InputPathDeniedError(
         "Local path is not visible to the MCP runtime. "
-        f"Allowed roots: {allowed}. Upload the file, mount the directory, or use gs://."
+        "Upload the file, mount the directory, or use gs://."
     )

--- a/src/analyst_toolkit/mcp_server/input/storage.py
+++ b/src/analyst_toolkit/mcp_server/input/storage.py
@@ -61,12 +61,18 @@ def stage_uploaded_file(*, filename: str, payload: bytes) -> tuple[Path, str, in
     staged_dir.mkdir(parents=True, exist_ok=True)
     staged_path = staged_dir / f"{digest}_{safe_name}"
     if not staged_path.exists():
-        with tempfile.NamedTemporaryFile(dir=staged_dir, delete=False) as handle:
-            handle.write(payload)
-            handle.flush()
-            os.fsync(handle.fileno())
-            tmp_path = Path(handle.name)
-        os.replace(tmp_path, staged_path)
+        tmp_path: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(dir=staged_dir, delete=False) as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+                tmp_path = Path(handle.name)
+            os.replace(tmp_path, staged_path)
+        except BaseException:
+            if tmp_path is not None and tmp_path.exists():
+                tmp_path.unlink()
+            raise
     return staged_path.resolve(), digest, len(payload)
 
 
@@ -77,11 +83,11 @@ def validate_server_visible_path(path_text: str) -> Path:
         )
     roots = allowed_server_input_roots()
     candidate = Path(path_text).resolve(strict=False)
-    if not candidate.exists():
-        raise InputPathNotFoundError("Input path not found.")
     for root in roots:
         try:
             candidate.relative_to(root)
+            if not candidate.exists():
+                raise InputPathNotFoundError("Input path not found.")
             return candidate
         except ValueError:
             continue

--- a/src/analyst_toolkit/mcp_server/server.py
+++ b/src/analyst_toolkit/mcp_server/server.py
@@ -35,6 +35,12 @@ from mcp.server.stdio import stdio_server
 from pydantic import BaseModel
 
 from analyst_toolkit.mcp_server.auth import is_authorized
+from analyst_toolkit.mcp_server.input.errors import (
+    InputConflictError,
+    InputError,
+    InputNotSupportedError,
+    InputPayloadTooLargeError,
+)
 from analyst_toolkit.mcp_server.input.ingest import (
     get_input_descriptor,
     ingest_uploaded_bytes,
@@ -121,6 +127,24 @@ class RegisterInputRequest(BaseModel):
     run_id: str | None = None
     idempotency_key: str | None = None
     load_into_session: bool = True
+
+
+def _input_error_http_status(exc: InputError) -> int:
+    if isinstance(exc, InputPayloadTooLargeError):
+        return 413
+    if isinstance(exc, InputNotSupportedError):
+        return 400
+    if isinstance(exc, InputConflictError):
+        return 409
+    return 400
+
+
+def _input_error_detail(exc: InputError, trace_id: str) -> dict[str, str]:
+    return {
+        "error": exc.message,
+        "code": exc.code,
+        "trace_id": trace_id,
+    }
 
 
 def _require_http_auth(request: Request) -> str:
@@ -340,7 +364,11 @@ async def upload_input(
     if not payload:
         raise HTTPException(
             status_code=400,
-            detail={"error": "Empty upload payload.", "trace_id": trace_id},
+            detail={
+                "error": "Empty upload payload.",
+                "code": "INPUT_EMPTY_UPLOAD",
+                "trace_id": trace_id,
+            },
         )
     try:
         descriptor, df, effective_session_id = ingest_uploaded_bytes(
@@ -352,10 +380,21 @@ async def upload_input(
             idempotency_key=idempotency_key,
             load_into_session=load_into_session,
         )
-    except Exception as exc:
+    except InputError as exc:
+        logger.warning("upload_input failed (trace_id=%s, code=%s)", trace_id, exc.code)
         raise HTTPException(
-            status_code=400,
-            detail={"error": str(exc), "trace_id": trace_id},
+            status_code=_input_error_http_status(exc),
+            detail=_input_error_detail(exc, trace_id),
+        ) from exc
+    except Exception as exc:
+        logger.exception("upload_input unexpected failure (trace_id=%s)", trace_id)
+        raise HTTPException(
+            status_code=500,
+            detail={
+                "error": "Internal server error.",
+                "code": "INTERNAL_ERROR",
+                "trace_id": trace_id,
+            },
         ) from exc
 
     summary = {}
@@ -384,15 +423,21 @@ async def register_input(request: Request, payload: RegisterInputRequest) -> JSO
             idempotency_key=payload.idempotency_key,
             load_into_session=payload.load_into_session,
         )
-    except NotImplementedError as exc:
+    except InputError as exc:
+        logger.warning("register_input failed (trace_id=%s, code=%s)", trace_id, exc.code)
         raise HTTPException(
-            status_code=501,
-            detail={"error": str(exc), "trace_id": trace_id},
+            status_code=_input_error_http_status(exc),
+            detail=_input_error_detail(exc, trace_id),
         ) from exc
     except Exception as exc:
+        logger.exception("register_input unexpected failure (trace_id=%s)", trace_id)
         raise HTTPException(
-            status_code=400,
-            detail={"error": str(exc), "trace_id": trace_id},
+            status_code=500,
+            detail={
+                "error": "Internal server error.",
+                "code": "INTERNAL_ERROR",
+                "trace_id": trace_id,
+            },
         ) from exc
 
     summary = {}

--- a/src/analyst_toolkit/mcp_server/tools/input_ingest.py
+++ b/src/analyst_toolkit/mcp_server/tools/input_ingest.py
@@ -4,8 +4,8 @@ import asyncio
 import logging
 from functools import partial
 
+from analyst_toolkit.mcp_server.input.errors import InputError
 from analyst_toolkit.mcp_server.input.ingest import get_input_descriptor, register_input_source
-from analyst_toolkit.mcp_server.input.loaders import InputNotSupportedError
 from analyst_toolkit.mcp_server.input.models import InputSourceType
 from analyst_toolkit.mcp_server.registry import register_tool
 from analyst_toolkit.mcp_server.response_utils import new_trace_id
@@ -35,14 +35,14 @@ async def _toolkit_register_input(
                 load_into_session=load_into_session,
             ),
         )
-    except InputNotSupportedError:
+    except InputError as exc:
         trace_id = new_trace_id()
-        logger.exception("Input source unsupported (trace_id=%s)", trace_id)
+        logger.exception("Input registration failed (trace_id=%s, code=%s)", trace_id, exc.code)
         return {
             "status": "error",
             "module": "register_input",
-            "code": "INPUT_SOURCE_UNSUPPORTED",
-            "message": "The specified input source is not supported.",
+            "code": exc.code,
+            "message": exc.message,
             "trace_id": trace_id,
         }
     except Exception:

--- a/src/analyst_toolkit/mcp_server/tools/input_ingest.py
+++ b/src/analyst_toolkit/mcp_server/tools/input_ingest.py
@@ -130,6 +130,7 @@ register_tool(
             "idempotency_key": {
                 "type": "string",
                 "minLength": 1,
+                "maxLength": 255,
                 "pattern": "^.*\\S.*$",
                 "description": (
                     "Optional stable idempotency key. Provide this to reuse the same "

--- a/tests/mcp_server/test_input_ingest.py
+++ b/tests/mcp_server/test_input_ingest.py
@@ -38,6 +38,28 @@ def test_inputs_upload_creates_session_and_descriptor(client, monkeypatch, tmp_p
     assert payload["summary"]["column_count"] == 2
 
 
+def test_inputs_upload_rejects_payload_over_limit(client, monkeypatch, tmp_path):
+    monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
+    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
+    monkeypatch.setattr(
+        "analyst_toolkit.mcp_server.input.storage._MAX_UPLOAD_BYTES",
+        8,
+    )
+    StateStore.clear()
+    input_registry.clear()
+
+    response = client.post(
+        "/inputs/upload",
+        files={"file": ("dirty_penguins.csv", b"species,bill_length_mm\n", "text/csv")},
+        data={"load_into_session": "false"},
+    )
+
+    assert response.status_code == 413
+    detail = response.json()["detail"]
+    assert detail["code"] == "INPUT_PAYLOAD_TOO_LARGE"
+    assert isinstance(detail["trace_id"], str)
+
+
 def test_inputs_upload_reuses_input_id_for_same_payload(client, monkeypatch, tmp_path):
     monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
     monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
@@ -170,6 +192,43 @@ def test_inputs_register_rejects_path_outside_allowed_roots(client, monkeypatch,
     )
     assert response.status_code == 400
     assert "not visible to the MCP runtime" in response.json()["detail"]["error"]
+
+
+def test_inputs_register_returns_conflict_for_descriptor_reuse_mismatch(
+    client, monkeypatch, tmp_path
+):
+    monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
+    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
+    StateStore.clear()
+    input_registry.clear()
+
+    source_one = tmp_path / "dirty_penguins.csv"
+    source_two = tmp_path / "clean_penguins.csv"
+    _write_sample_csv(source_one)
+    _write_sample_csv(source_two)
+
+    first = client.post(
+        "/inputs/register",
+        json={
+            "uri": str(source_one),
+            "load_into_session": False,
+            "idempotency_key": "shared-key",
+        },
+    )
+    second = client.post(
+        "/inputs/register",
+        json={
+            "uri": str(source_two),
+            "load_into_session": False,
+            "idempotency_key": "shared-key",
+        },
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 409
+    detail = second.json()["detail"]
+    assert detail["code"] == "INPUT_CONFLICT"
+    assert isinstance(detail["trace_id"], str)
 
 
 def test_register_input_tool_and_diagnostics_input_id_flow(client, monkeypatch, mocker, tmp_path):

--- a/tests/mcp_server/test_input_ingest.py
+++ b/tests/mcp_server/test_input_ingest.py
@@ -1,10 +1,20 @@
 from pathlib import Path
 
 import pandas as pd
+import pytest
 
 from analyst_toolkit.mcp_server.input import registry as input_registry
 from analyst_toolkit.mcp_server.state import StateStore
 from analyst_toolkit.mcp_server.tools import diagnostics as diagnostics_tool
+
+
+@pytest.fixture
+def clean_input_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
+    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
+    StateStore.clear()
+    input_registry.clear()
+    return tmp_path
 
 
 def _write_sample_csv(path: Path) -> None:
@@ -16,12 +26,7 @@ def _write_sample_csv(path: Path) -> None:
     ).to_csv(path, index=False)
 
 
-def test_inputs_upload_creates_session_and_descriptor(client, monkeypatch, tmp_path):
-    monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
-    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
-    StateStore.clear()
-    input_registry.clear()
-
+def test_inputs_upload_creates_session_and_descriptor(client, clean_input_env):
     response = client.post(
         "/inputs/upload",
         files={
@@ -38,15 +43,11 @@ def test_inputs_upload_creates_session_and_descriptor(client, monkeypatch, tmp_p
     assert payload["summary"]["column_count"] == 2
 
 
-def test_inputs_upload_rejects_payload_over_limit(client, monkeypatch, tmp_path):
-    monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
-    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
+def test_inputs_upload_rejects_payload_over_limit(client, monkeypatch, clean_input_env):
     monkeypatch.setattr(
         "analyst_toolkit.mcp_server.input.storage._MAX_UPLOAD_BYTES",
         8,
     )
-    StateStore.clear()
-    input_registry.clear()
 
     response = client.post(
         "/inputs/upload",
@@ -60,12 +61,7 @@ def test_inputs_upload_rejects_payload_over_limit(client, monkeypatch, tmp_path)
     assert isinstance(detail["trace_id"], str)
 
 
-def test_inputs_upload_reuses_input_id_for_same_payload(client, monkeypatch, tmp_path):
-    monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
-    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
-    StateStore.clear()
-    input_registry.clear()
-
+def test_inputs_upload_reuses_input_id_for_same_payload(client, clean_input_env):
     response_one = client.post(
         "/inputs/upload",
         files={
@@ -88,11 +84,8 @@ def test_inputs_upload_reuses_input_id_for_same_payload(client, monkeypatch, tmp
     assert response_one.json()["input"]["input_id"] == response_two.json()["input"]["input_id"]
 
 
-def test_inputs_register_server_path_loads_into_session(client, monkeypatch, tmp_path):
-    monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
-    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
-    StateStore.clear()
-    input_registry.clear()
+def test_inputs_register_server_path_loads_into_session(client, clean_input_env):
+    tmp_path = clean_input_env
 
     source = tmp_path / "dirty_penguins.csv"
     _write_sample_csv(source)
@@ -109,11 +102,8 @@ def test_inputs_register_server_path_loads_into_session(client, monkeypatch, tmp
     assert payload["summary"]["row_count"] == 2
 
 
-def test_inputs_register_reuses_input_id_with_stable_idempotency_key(client, monkeypatch, tmp_path):
-    monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
-    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
-    StateStore.clear()
-    input_registry.clear()
+def test_inputs_register_reuses_input_id_with_stable_idempotency_key(client, clean_input_env):
+    tmp_path = clean_input_env
 
     source = tmp_path / "dirty_penguins.csv"
     _write_sample_csv(source)
@@ -143,12 +133,9 @@ def test_inputs_register_reuses_input_id_with_stable_idempotency_key(client, mon
 
 
 def test_inputs_register_uses_distinct_input_ids_for_distinct_idempotency_keys(
-    client, monkeypatch, tmp_path
+    client, clean_input_env
 ):
-    monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
-    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
-    StateStore.clear()
-    input_registry.clear()
+    tmp_path = clean_input_env
 
     source = tmp_path / "dirty_penguins.csv"
     _write_sample_csv(source)
@@ -177,11 +164,9 @@ def test_inputs_register_uses_distinct_input_ids_for_distinct_idempotency_keys(
     assert response_one.json()["input"]["input_id"] != response_two.json()["input"]["input_id"]
 
 
-def test_inputs_register_rejects_path_outside_allowed_roots(client, monkeypatch, tmp_path):
-    monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
+def test_inputs_register_rejects_path_outside_allowed_roots(client, monkeypatch, clean_input_env):
+    tmp_path = clean_input_env
     monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path / "allowed"))
-    StateStore.clear()
-    input_registry.clear()
 
     source = tmp_path / "dirty_penguins.csv"
     _write_sample_csv(source)
@@ -194,13 +179,8 @@ def test_inputs_register_rejects_path_outside_allowed_roots(client, monkeypatch,
     assert "not visible to the MCP runtime" in response.json()["detail"]["error"]
 
 
-def test_inputs_register_returns_conflict_for_descriptor_reuse_mismatch(
-    client, monkeypatch, tmp_path
-):
-    monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
-    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
-    StateStore.clear()
-    input_registry.clear()
+def test_inputs_register_returns_conflict_for_descriptor_reuse_mismatch(client, clean_input_env):
+    tmp_path = clean_input_env
 
     source_one = tmp_path / "dirty_penguins.csv"
     source_two = tmp_path / "clean_penguins.csv"
@@ -231,11 +211,8 @@ def test_inputs_register_returns_conflict_for_descriptor_reuse_mismatch(
     assert isinstance(detail["trace_id"], str)
 
 
-def test_register_input_tool_and_diagnostics_input_id_flow(client, monkeypatch, mocker, tmp_path):
-    monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
-    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path))
-    StateStore.clear()
-    input_registry.clear()
+def test_register_input_tool_and_diagnostics_input_id_flow(client, mocker, clean_input_env):
+    tmp_path = clean_input_env
     mocker.patch.object(diagnostics_tool, "run_diag_pipeline", return_value=None)
     mocker.patch.object(diagnostics_tool, "save_output", return_value="gs://dummy/diagnostics.csv")
     mocker.patch.object(diagnostics_tool, "append_to_run_history", return_value=None)

--- a/tests/mcp_server/test_input_registry.py
+++ b/tests/mcp_server/test_input_registry.py
@@ -5,6 +5,15 @@ from analyst_toolkit.mcp_server.input.errors import InputConflictError
 from analyst_toolkit.mcp_server.input.models import InputDescriptor
 
 
+@pytest.fixture
+def clean_registry(monkeypatch):
+    monkeypatch.setattr(input_registry, "_REGISTRY_MAX_ENTRIES", 8)
+    monkeypatch.setattr(input_registry, "_REGISTRY_TTL_SEC", 3600.0)
+    input_registry.clear()
+    yield
+    input_registry.clear()
+
+
 def _descriptor(
     input_id: str,
     *,
@@ -27,11 +36,7 @@ def _descriptor(
     )
 
 
-def test_registry_save_is_idempotent_for_same_canonical_descriptor(monkeypatch):
-    monkeypatch.setattr(input_registry, "_REGISTRY_MAX_ENTRIES", 8)
-    monkeypatch.setattr(input_registry, "_REGISTRY_TTL_SEC", 3600.0)
-    input_registry.clear()
-
+def test_registry_save_is_idempotent_for_same_canonical_descriptor(clean_registry):
     saved = input_registry.save_descriptor(
         _descriptor("input_same", session_id="sess_a", run_id="run_a")
     )
@@ -45,15 +50,15 @@ def test_registry_save_is_idempotent_for_same_canonical_descriptor(monkeypatch):
     assert input_registry.get_session_input_id("sess_b") == "input_same"
 
 
-def test_registry_rejects_conflicting_descriptor_reuse(monkeypatch):
-    monkeypatch.setattr(input_registry, "_REGISTRY_MAX_ENTRIES", 8)
-    monkeypatch.setattr(input_registry, "_REGISTRY_TTL_SEC", 3600.0)
-    input_registry.clear()
-
+def test_registry_rejects_conflicting_descriptor_reuse(clean_registry):
     input_registry.save_descriptor(_descriptor("input_conflict", sha256="abc"))
 
     with pytest.raises(InputConflictError, match="Conflicting descriptor"):
         input_registry.save_descriptor(_descriptor("input_conflict", sha256="def"))
+
+    original = input_registry.get_descriptor("input_conflict")
+    assert original is not None
+    assert original.sha256 == "abc"
 
 
 def test_registry_evicts_oldest_entries_when_capacity_is_exceeded(monkeypatch):
@@ -88,11 +93,7 @@ def test_registry_expires_descriptors_and_session_bindings(monkeypatch):
     assert input_registry.get_session_input_id("sess_ttl") is None
 
 
-def test_remove_descriptor_cleans_up_session_bindings(monkeypatch):
-    monkeypatch.setattr(input_registry, "_REGISTRY_MAX_ENTRIES", 8)
-    monkeypatch.setattr(input_registry, "_REGISTRY_TTL_SEC", 3600.0)
-    input_registry.clear()
-
+def test_remove_descriptor_cleans_up_session_bindings(clean_registry):
     input_registry.save_descriptor(_descriptor("input_remove", session_id="sess_remove"))
     input_registry.remove_descriptor("input_remove")
 
@@ -100,11 +101,7 @@ def test_remove_descriptor_cleans_up_session_bindings(monkeypatch):
     assert input_registry.get_session_input_id("sess_remove") is None
 
 
-def test_get_registry_stats_reports_current_counts(monkeypatch):
-    monkeypatch.setattr(input_registry, "_REGISTRY_MAX_ENTRIES", 8)
-    monkeypatch.setattr(input_registry, "_REGISTRY_TTL_SEC", 3600.0)
-    input_registry.clear()
-
+def test_get_registry_stats_reports_current_counts(clean_registry):
     input_registry.save_descriptor(_descriptor("input_stats", session_id="sess_stats"))
     stats = input_registry.get_registry_stats()
 

--- a/tests/mcp_server/test_input_registry.py
+++ b/tests/mcp_server/test_input_registry.py
@@ -1,6 +1,7 @@
 import pytest
 
 from analyst_toolkit.mcp_server.input import registry as input_registry
+from analyst_toolkit.mcp_server.input.errors import InputConflictError
 from analyst_toolkit.mcp_server.input.models import InputDescriptor
 
 
@@ -51,7 +52,7 @@ def test_registry_rejects_conflicting_descriptor_reuse(monkeypatch):
 
     input_registry.save_descriptor(_descriptor("input_conflict", sha256="abc"))
 
-    with pytest.raises(ValueError, match="Conflicting descriptor"):
+    with pytest.raises(InputConflictError, match="Conflicting descriptor"):
         input_registry.save_descriptor(_descriptor("input_conflict", sha256="def"))
 
 
@@ -85,3 +86,29 @@ def test_registry_expires_descriptors_and_session_bindings(monkeypatch):
     clock["now"] = 1006.0
     assert input_registry.get_descriptor("input_ttl") is None
     assert input_registry.get_session_input_id("sess_ttl") is None
+
+
+def test_remove_descriptor_cleans_up_session_bindings(monkeypatch):
+    monkeypatch.setattr(input_registry, "_REGISTRY_MAX_ENTRIES", 8)
+    monkeypatch.setattr(input_registry, "_REGISTRY_TTL_SEC", 3600.0)
+    input_registry.clear()
+
+    input_registry.save_descriptor(_descriptor("input_remove", session_id="sess_remove"))
+    input_registry.remove_descriptor("input_remove")
+
+    assert input_registry.get_descriptor("input_remove") is None
+    assert input_registry.get_session_input_id("sess_remove") is None
+
+
+def test_get_registry_stats_reports_current_counts(monkeypatch):
+    monkeypatch.setattr(input_registry, "_REGISTRY_MAX_ENTRIES", 8)
+    monkeypatch.setattr(input_registry, "_REGISTRY_TTL_SEC", 3600.0)
+    input_registry.clear()
+
+    input_registry.save_descriptor(_descriptor("input_stats", session_id="sess_stats"))
+    stats = input_registry.get_registry_stats()
+
+    assert stats["input_count"] == 1
+    assert stats["session_binding_count"] == 1
+    assert stats["max_entries"] == 8
+    assert stats["ttl_sec"] == 3600.0


### PR DESCRIPTION
## Summary
- harden MCP input upload/register trust boundaries and client-safe error handling
- add safer staging/path validation and conflict/status contract coverage
- tighten registry and ingest follow-up tests plus formatting-clean branch state

## Testing
- pre-commit run --all-files -v
- ruff check src/ tests/
- mypy src/analyst_toolkit/mcp_server
- pytest tests/mcp_server/test_input_ingest.py tests/mcp_server/test_input_registry.py tests/mcp_server/test_http_auth_metrics.py tests/mcp_server/test_rpc_tools.py tests/test_mcp_tool_regressions.py -q