### PR TITLE
fix: align data dictionary input schema

### DIFF
--- a/src/analyst_toolkit/mcp_server/tools/cockpit_schemas.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit_schemas.py
@@ -98,7 +98,7 @@ DATA_DICTIONARY_INPUT_SCHEMA = {
                 "This does not resolve the input source by itself; provide gcs_path, "
                 "session_id, or input_id."
             ),
-            "default": "mcp_run",
+            "default": "data_dictionary_prelaunch",
         },
         "runtime": {
             "type": "object",

--- a/src/analyst_toolkit/mcp_server/tools/cockpit_schemas.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit_schemas.py
@@ -1,5 +1,7 @@
 """Input schemas for cockpit MCP tools."""
 
+from analyst_toolkit.mcp_server.schemas import _GCS_PATH_PROP, _INPUT_ID_PROP, _RUN_ID_PROP
+
 CAPABILITY_CATALOG_INPUT_SCHEMA = {
     "type": "object",
     "properties": {
@@ -80,18 +82,13 @@ DATA_HEALTH_REPORT_INPUT_SCHEMA = {
 DATA_DICTIONARY_INPUT_SCHEMA = {
     "type": "object",
     "properties": {
-        "gcs_path": {
-            "type": "string",
-            "description": "Optional input dataset path when no session_id exists yet.",
-        },
+        **_GCS_PATH_PROP,
         "session_id": {
             "type": "string",
             "description": "Optional session scope when building from an existing run context.",
         },
-        "run_id": {
-            "type": "string",
-            "description": "Optional run identifier used for future artifact names.",
-        },
+        **_INPUT_ID_PROP,
+        **_RUN_ID_PROP,
         "runtime": {
             "type": "object",
             "description": "Optional runtime overlay for cross-cutting execution settings.",
@@ -111,6 +108,11 @@ DATA_DICTIONARY_INPUT_SCHEMA = {
             "description": "Reserve a prelaunch dictionary/readiness surface seeded from infer_configs.",
         },
     },
+    "anyOf": [
+        {"required": ["gcs_path"]},
+        {"required": ["session_id"]},
+        {"required": ["input_id"]},
+    ],
 }
 
 COCKPIT_DASHBOARD_INPUT_SCHEMA = {

--- a/src/analyst_toolkit/mcp_server/tools/cockpit_schemas.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit_schemas.py
@@ -85,10 +85,21 @@ DATA_DICTIONARY_INPUT_SCHEMA = {
         **_GCS_PATH_PROP,
         "session_id": {
             "type": "string",
-            "description": "Optional session scope when building from an existing run context.",
+            "description": (
+                "Optional in-memory session identifier to use as the primary input source "
+                "when building from an existing run context."
+            ),
         },
         **_INPUT_ID_PROP,
-        **_RUN_ID_PROP,
+        "run_id": {
+            "type": "string",
+            "description": (
+                "Optional run identifier used for output paths and artifact naming. "
+                "This does not resolve the input source by itself; provide gcs_path, "
+                "session_id, or input_id."
+            ),
+            "default": "mcp_run",
+        },
         "runtime": {
             "type": "object",
             "description": "Optional runtime overlay for cross-cutting execution settings.",

--- a/tests/mcp_server/test_rpc_tools.py
+++ b/tests/mcp_server/test_rpc_tools.py
@@ -52,6 +52,24 @@ def test_rpc_tools_list(client):
     assert "get_agent_instructions" not in tool_names
 
 
+def test_rpc_tools_list_exposes_data_dictionary_input_id_schema(client):
+    """Verify data_dictionary advertises the shared input_id and anyOf input contract."""
+    payload = {"jsonrpc": "2.0", "id": 33, "method": "tools/list", "params": {}}
+    response = client.post("/rpc", json=payload)
+    assert response.status_code == 200
+    tools = response.json()["result"]["tools"]
+    data_dictionary = next(tool for tool in tools if tool["name"] == "data_dictionary")
+    input_schema = data_dictionary["inputSchema"]
+
+    assert input_schema["properties"]["input_id"]["pattern"] == "^input_[a-f0-9]{12}$"
+    assert input_schema["properties"]["input_id"]["description"].endswith(
+        "If provided, gcs_path and session_id are ignored."
+    )
+    assert {"required": ["input_id"]} in input_schema["anyOf"]
+    assert {"required": ["gcs_path"]} in input_schema["anyOf"]
+    assert {"required": ["session_id"]} in input_schema["anyOf"]
+
+
 def test_rpc_capability_catalog_tool(client):
     """Verify capability catalog exposes editable knobs including fuzzy matching."""
     payload = {


### PR DESCRIPTION
## Summary
- add the shared input_id contract to the data_dictionary MCP schema
- align the schema anyOf requirements with other input-aware MCP tools
- clarify that session_id is a valid primary input source while run_id is naming context only

## Testing
- ruff check src/analyst_toolkit/mcp_server/tools/cockpit_schemas.py tests/mcp_server/test_rpc_tools.py
- pytest tests/mcp_server/test_rpc_tools.py -q