### PR TITLE
chore: standardize input_id schema validation

### DIFF
--- a/src/analyst_toolkit/mcp_server/schemas.py
+++ b/src/analyst_toolkit/mcp_server/schemas.py
@@ -35,7 +35,7 @@ _SESSION_ID_PROP = {
     }
 }
 
-_INPUT_ID_PROP = {
+INPUT_ID_PROP = {
     "input_id": {
         "type": "string",
         "pattern": "^input_[a-f0-9]{12}$",
@@ -94,7 +94,7 @@ def base_input_schema(extra_props: dict | None = None) -> dict:
     props = {
         **_GCS_PATH_PROP,
         **_SESSION_ID_PROP,
-        **_INPUT_ID_PROP,
+        **INPUT_ID_PROP,
         **_CONFIG_PROP,
         **_RUNTIME_PROP,
         **_RUN_ID_PROP,

--- a/src/analyst_toolkit/mcp_server/tools/auto_heal.py
+++ b/src/analyst_toolkit/mcp_server/tools/auto_heal.py
@@ -26,7 +26,7 @@ from analyst_toolkit.mcp_server.runtime_overlay import (
     normalize_runtime_overlay,
     runtime_to_tool_overrides,
 )
-from analyst_toolkit.mcp_server.schemas import _INPUT_ID_PROP
+from analyst_toolkit.mcp_server.schemas import INPUT_ID_PROP
 from analyst_toolkit.mcp_server.tools.imputation import _toolkit_imputation
 from analyst_toolkit.mcp_server.tools.infer_configs import _toolkit_infer_configs
 from analyst_toolkit.mcp_server.tools.normalization import _toolkit_normalization
@@ -424,7 +424,7 @@ _INPUT_SCHEMA = {
             "type": "string",
             "description": "Optional: In-memory session identifier.",
         },
-        **_INPUT_ID_PROP,
+        **INPUT_ID_PROP,
         "run_id": {
             "type": "string",
             "description": "Optional run identifier.",

--- a/src/analyst_toolkit/mcp_server/tools/auto_heal.py
+++ b/src/analyst_toolkit/mcp_server/tools/auto_heal.py
@@ -26,6 +26,7 @@ from analyst_toolkit.mcp_server.runtime_overlay import (
     normalize_runtime_overlay,
     runtime_to_tool_overrides,
 )
+from analyst_toolkit.mcp_server.schemas import _INPUT_ID_PROP
 from analyst_toolkit.mcp_server.tools.imputation import _toolkit_imputation
 from analyst_toolkit.mcp_server.tools.infer_configs import _toolkit_infer_configs
 from analyst_toolkit.mcp_server.tools.normalization import _toolkit_normalization
@@ -423,10 +424,7 @@ _INPUT_SCHEMA = {
             "type": "string",
             "description": "Optional: In-memory session identifier.",
         },
-        "input_id": {
-            "type": "string",
-            "description": "Optional: Canonical server-managed input reference returned by ingest/register flows.",
-        },
+        **_INPUT_ID_PROP,
         "run_id": {
             "type": "string",
             "description": "Optional run identifier.",

--- a/src/analyst_toolkit/mcp_server/tools/cockpit_schemas.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit_schemas.py
@@ -1,6 +1,6 @@
 """Input schemas for cockpit MCP tools."""
 
-from analyst_toolkit.mcp_server.schemas import _GCS_PATH_PROP, _INPUT_ID_PROP, _RUN_ID_PROP
+from analyst_toolkit.mcp_server.schemas import _GCS_PATH_PROP, _RUN_ID_PROP, INPUT_ID_PROP
 
 CAPABILITY_CATALOG_INPUT_SCHEMA = {
     "type": "object",
@@ -90,7 +90,7 @@ DATA_DICTIONARY_INPUT_SCHEMA = {
                 "when building from an existing run context."
             ),
         },
-        **_INPUT_ID_PROP,
+        **INPUT_ID_PROP,
         "run_id": {
             "type": "string",
             "description": (

--- a/src/analyst_toolkit/mcp_server/tools/infer_configs.py
+++ b/src/analyst_toolkit/mcp_server/tools/infer_configs.py
@@ -9,6 +9,7 @@ from analyst_toolkit.mcp_server.runtime_overlay import (
     normalize_runtime_overlay,
     runtime_to_tool_overrides,
 )
+from analyst_toolkit.mcp_server.schemas import _INPUT_ID_PROP
 
 
 async def _toolkit_infer_configs(
@@ -154,14 +155,7 @@ _INPUT_SCHEMA = {
             "type": "string",
             "description": "Optional: In-memory session identifier from a previous tool run.",
         },
-        "input_id": {
-            "type": "string",
-            "description": (
-                "Optional: Canonical server-managed input reference returned by ingest/register "
-                "flows. If provided, gcs_path and session_id are ignored."
-            ),
-            "pattern": "^input_[a-f0-9]{12}$",
-        },
+        **_INPUT_ID_PROP,
         "runtime": {
             "type": ["object", "string"],
             "description": (

--- a/src/analyst_toolkit/mcp_server/tools/infer_configs.py
+++ b/src/analyst_toolkit/mcp_server/tools/infer_configs.py
@@ -9,7 +9,7 @@ from analyst_toolkit.mcp_server.runtime_overlay import (
     normalize_runtime_overlay,
     runtime_to_tool_overrides,
 )
-from analyst_toolkit.mcp_server.schemas import _INPUT_ID_PROP
+from analyst_toolkit.mcp_server.schemas import INPUT_ID_PROP
 
 
 async def _toolkit_infer_configs(
@@ -155,7 +155,7 @@ _INPUT_SCHEMA = {
             "type": "string",
             "description": "Optional: In-memory session identifier from a previous tool run.",
         },
-        **_INPUT_ID_PROP,
+        **INPUT_ID_PROP,
         "runtime": {
             "type": ["object", "string"],
             "description": (

--- a/src/analyst_toolkit/mcp_server/tools/input_ingest.py
+++ b/src/analyst_toolkit/mcp_server/tools/input_ingest.py
@@ -9,6 +9,7 @@ from analyst_toolkit.mcp_server.input.ingest import get_input_descriptor, regist
 from analyst_toolkit.mcp_server.input.models import InputSourceType
 from analyst_toolkit.mcp_server.registry import register_tool
 from analyst_toolkit.mcp_server.response_utils import new_trace_id
+from analyst_toolkit.mcp_server.schemas import _INPUT_ID_PROP
 
 logger = logging.getLogger("analyst_toolkit.mcp_server.input_ingest")
 
@@ -154,9 +155,7 @@ register_tool(
     description="Fetch metadata for a canonical input reference by input_id.",
     input_schema={
         "type": "object",
-        "properties": {
-            "input_id": {"type": "string", "description": "Canonical input reference identifier."}
-        },
+        "properties": {**_INPUT_ID_PROP},
         "required": ["input_id"],
     },
 )

--- a/src/analyst_toolkit/mcp_server/tools/input_ingest.py
+++ b/src/analyst_toolkit/mcp_server/tools/input_ingest.py
@@ -9,7 +9,7 @@ from analyst_toolkit.mcp_server.input.ingest import get_input_descriptor, regist
 from analyst_toolkit.mcp_server.input.models import InputSourceType
 from analyst_toolkit.mcp_server.registry import register_tool
 from analyst_toolkit.mcp_server.response_utils import new_trace_id
-from analyst_toolkit.mcp_server.schemas import _INPUT_ID_PROP
+from analyst_toolkit.mcp_server.schemas import INPUT_ID_PROP
 
 logger = logging.getLogger("analyst_toolkit.mcp_server.input_ingest")
 
@@ -155,7 +155,7 @@ register_tool(
     description="Fetch metadata for a canonical input reference by input_id.",
     input_schema={
         "type": "object",
-        "properties": {**_INPUT_ID_PROP},
+        "properties": {**INPUT_ID_PROP},
         "required": ["input_id"],
     },
 )

--- a/tests/mcp_server/test_rpc_tools.py
+++ b/tests/mcp_server/test_rpc_tools.py
@@ -78,6 +78,7 @@ def test_rpc_tools_list_standardizes_input_id_pattern_across_tool_schemas(client
     tools = {tool["name"]: tool for tool in response.json()["result"]["tools"]}
 
     for tool_name in ("infer_configs", "auto_heal", "get_input_descriptor"):
+        assert tool_name in tools, f"Expected tool '{tool_name}' not found in tools/list response"
         input_id_schema = tools[tool_name]["inputSchema"]["properties"]["input_id"]
         assert input_id_schema["pattern"] == "^input_[a-f0-9]{12}$"
         assert "Canonical server-managed input reference" in input_id_schema["description"]

--- a/tests/mcp_server/test_rpc_tools.py
+++ b/tests/mcp_server/test_rpc_tools.py
@@ -70,6 +70,19 @@ def test_rpc_tools_list_exposes_data_dictionary_input_id_schema(client):
     assert {"required": ["session_id"]} in input_schema["anyOf"]
 
 
+def test_rpc_tools_list_standardizes_input_id_pattern_across_tool_schemas(client):
+    """Verify all remaining bespoke tool schemas reuse the shared input_id contract."""
+    payload = {"jsonrpc": "2.0", "id": 34, "method": "tools/list", "params": {}}
+    response = client.post("/rpc", json=payload)
+    assert response.status_code == 200
+    tools = {tool["name"]: tool for tool in response.json()["result"]["tools"]}
+
+    for tool_name in ("infer_configs", "auto_heal", "get_input_descriptor"):
+        input_id_schema = tools[tool_name]["inputSchema"]["properties"]["input_id"]
+        assert input_id_schema["pattern"] == "^input_[a-f0-9]{12}$"
+        assert "Canonical server-managed input reference" in input_id_schema["description"]
+
+
 def test_rpc_capability_catalog_tool(client):
     """Verify capability catalog exposes editable knobs including fuzzy matching."""
     payload = {


### PR DESCRIPTION
## Summary
- standardize remaining MCP tool schemas on the shared input_id schema fragment
- publish the shared fragment as INPUT_ID_PROP for explicit cross-module reuse
- add tools/list regression coverage for consistent advertised input_id validation

## Testing
- ruff check src/analyst_toolkit/mcp_server/schemas.py src/analyst_toolkit/mcp_server/tools/infer_configs.py src/analyst_toolkit/mcp_server/tools/auto_heal.py src/analyst_toolkit/mcp_server/tools/input_ingest.py src/analyst_toolkit/mcp_server/tools/cockpit_schemas.py tests/mcp_server/test_rpc_tools.py
- pytest tests/mcp_server/test_rpc_tools.py -q