### PR TITLE
fix: tolerate older infer_configs helper signatures

### DIFF
--- a/src/analyst_toolkit/mcp_server/tools/cockpit_content.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit_content.py
@@ -28,13 +28,20 @@ def user_quickstart_payload() -> dict:
 - You can enable/disable plotting and HTML export per module.
 - When HTML export is enabled, module tools return standalone dashboard artifacts that should be opened or linked for review.
 
+## Input Ingest
+- Prefer a canonical `input_id` for user-provided datasets whenever possible.
+- If the dataset already lives at `gs://...` or a server-visible mounted path, call `register_input` first and carry the returned `input_id` or `session_id` forward.
+- If the user only has a local file on their machine, use the `/inputs/upload` ingest path (or a client helper built on top of it) to obtain an `input_id` before running analysis tools.
+- Use `get_input_descriptor` to inspect the resolved canonical input reference when needed.
+
 ## Recommended Order (Manual Pipeline)
-1. `diagnostics`
-2. `infer_configs`
-3. Review/edit configs (normalization, duplicates, outliers, imputation, validation)
-4. `normalization` -> `duplicates` -> `outliers` -> `imputation` -> `validation`
-5. `final_audit`
-6. `get_run_history` + `get_data_health_report`
+1. `register_input` or upload to `/inputs/upload`
+2. `diagnostics`
+3. `infer_configs`
+4. Review/edit configs (normalization, duplicates, outliers, imputation, validation)
+5. `normalization` -> `duplicates` -> `outliers` -> `imputation` -> `validation`
+6. `final_audit`
+7. `get_run_history` + `get_data_health_report`
 
 ## Dashboard Artifacts
 - In trusted/local mode, you can start a review session by building the cockpit dashboard for one human-readable landing page.
@@ -102,20 +109,30 @@ Turn plotting off for speed on large datasets, on for exploratory analysis.
         [
             {
                 "step": 1 if trusted_history else 0,
+                "tool": "register_input",
+                "required_inputs": ["uri"],
+                "outputs": ["input_id", "session_id?", "summary"],
+                "notes": [
+                    "Use this when data already lives at gs:// or a server-visible path.",
+                    "If the user only has a local file, upload it through /inputs/upload first and reuse the returned input_id.",
+                ],
+            },
+            {
+                "step": 2 if trusted_history else 1,
                 "tool": "diagnostics",
                 "required_inputs": [
-                    "gcs_path|session_id|runtime.run.input_path",
+                    "input_id|gcs_path|session_id|runtime.run.input_path",
                     "run_id|runtime.run.run_id",
                 ],
                 "outputs": ["session_id", "summary", "dashboard_url?"],
             },
             {
-                "step": 2 if trusted_history else 1,
+                "step": 3 if trusted_history else 2,
                 "tool": "infer_configs",
-                "required_inputs": ["gcs_path|session_id"],
+                "required_inputs": ["input_id|gcs_path|session_id"],
             },
             {
-                "step": 3 if trusted_history else 2,
+                "step": 4 if trusted_history else 3,
                 "tool_chain": [
                     "normalization",
                     "duplicates",
@@ -126,7 +143,7 @@ Turn plotting off for speed on large datasets, on for exploratory analysis.
                 "required_inputs": ["session_id", "run_id", "config", "runtime?"],
             },
             {
-                "step": 4 if trusted_history else 3,
+                "step": 5 if trusted_history else 4,
                 "tool": "final_audit",
                 "required_inputs": ["session_id", "run_id"],
             },
@@ -136,44 +153,42 @@ Turn plotting off for speed on large datasets, on for exploratory analysis.
         "ordered_steps": ordered_steps,
         "example_calls": [
             {
+                "tool": "register_input",
+                "arguments": {
+                    "uri": "gs://bucket/data.csv",
+                    "load_into_session": True,
+                    "idempotency_key": "run_001_source",
+                },
+            },
+            {
                 "tool": "diagnostics",
                 "arguments": {
-                    "runtime": {
-                        "run": {
-                            "input_path": "gs://bucket/data.csv",
-                            "run_id": "run_001",
-                        },
-                        "artifacts": {"export_html": True, "plotting": False},
-                    }
+                    "input_id": "<input_id_from_register_or_upload>",
+                    "run_id": "run_001",
+                    "runtime": {"artifacts": {"export_html": True, "plotting": False}},
                 },
             },
             {
                 "tool": "infer_configs",
-                "arguments": {"session_id": "<session_id_from_diagnostics>"},
+                "arguments": {"input_id": "<input_id_from_register_or_upload>"},
             },
             {
                 "tool": "auto_heal",
                 "arguments": {
+                    "input_id": "<input_id_from_register_or_upload>",
                     "runtime": {
-                        "run": {
-                            "input_path": "gs://bucket/data.csv",
-                            "run_id": "auto_heal_run_001",
-                        },
+                        "run": {"run_id": "auto_heal_run_001"},
                         "artifacts": {"export_html": True, "plotting": False},
                     },
-                    "mode": "sync",
                 },
             },
             {
                 "tool": "data_dictionary",
                 "arguments": {
-                    "gcs_path": "gs://bucket/data.csv",
+                    "input_id": "<input_id_from_register_or_upload>",
                     "run_id": "dictionary_prelaunch_001",
                     "prelaunch_report": True,
-                    "runtime": {
-                        "run": {"input_path": "gs://bucket/data.csv"},
-                        "artifacts": {"export_html": True},
-                    },
+                    "runtime": {"artifacts": {"export_html": True}},
                 },
             },
         ],
@@ -204,14 +219,19 @@ Turn plotting off for speed on large datasets, on for exploratory analysis.
         )
         + [
             {
+                "label": "Register input",
+                "tool": "register_input",
+                "arguments_schema_hint": {"required": ["uri"]},
+            },
+            {
                 "label": "Run diagnostics",
                 "tool": "diagnostics",
-                "arguments_schema_hint": {"required": ["gcs_path|session_id", "run_id"]},
+                "arguments_schema_hint": {"required": ["input_id|gcs_path|session_id", "run_id"]},
             },
             {
                 "label": "Infer configs",
                 "tool": "infer_configs",
-                "arguments_schema_hint": {"required": ["gcs_path|session_id"]},
+                "arguments_schema_hint": {"required": ["input_id|gcs_path|session_id"]},
             },
             {
                 "label": "Open capabilities",
@@ -222,7 +242,7 @@ Turn plotting off for speed on large datasets, on for exploratory analysis.
                 "label": "Run auto-heal",
                 "tool": "auto_heal",
                 "arguments_schema_hint": {
-                    "required": ["gcs_path|session_id|runtime.run.input_path"]
+                    "required": ["input_id|gcs_path|session_id|runtime.run.input_path"]
                 },
             },
             {
@@ -242,7 +262,8 @@ def agent_playbook_payload() -> dict:
         "version": "1.0",
         "goal": "Audit, clean, and certify a dataset with controlled user-editable configs.",
         "prerequisites": [
-            "Input data path (local csv/parquet or gs:// URI) or existing session_id",
+            "Canonical input_id from upload/register flow (preferred) or existing session_id",
+            "If no input_id exists yet: a gs:// URI or server-visible path for register_input, or an upload client that can call /inputs/upload",
             "Stable run_id used across calls",
             "Optional output bucket/prefix overrides",
             "Optional runtime overlay for cross-cutting execution control",
@@ -278,9 +299,20 @@ def agent_playbook_payload() -> dict:
             },
             {
                 "step": offset + 1,
+                "tool": "register_input",
+                "required_inputs": ["uri"],
+                "outputs": ["input_id", "session_id?", "summary"],
+                "notes": [
+                    "Use this when data already lives at gs:// or a server-visible path.",
+                    "If the user only has a local file, upload it through /inputs/upload first and then switch to input_id.",
+                ],
+                "next": [offset + 2],
+            },
+            {
+                "step": offset + 2,
                 "tool": "diagnostics",
                 "required_inputs": [
-                    "gcs_path|session_id|runtime.run.input_path",
+                    "input_id|gcs_path|session_id|runtime.run.input_path",
                     "run_id|runtime.run.run_id",
                 ],
                 "outputs": [
@@ -290,31 +322,31 @@ def agent_playbook_payload() -> dict:
                     "artifact_url?",
                     "plot_urls?",
                 ],
-                "next": [offset + 2],
-            },
-            {
-                "step": offset + 2,
-                "tool": "get_data_health_report",
-                "required_inputs": ["run_id", "session_id?"],
-                "outputs": ["health_score", "breakdown"],
                 "next": [offset + 3],
             },
             {
                 "step": offset + 3,
-                "tool": "infer_configs",
-                "required_inputs": ["gcs_path|session_id"],
-                "outputs": ["configs (YAML strings by module)"],
+                "tool": "get_data_health_report",
+                "required_inputs": ["run_id", "session_id?"],
+                "outputs": ["health_score", "breakdown"],
                 "next": [offset + 4],
             },
             {
                 "step": offset + 4,
-                "tool": "get_capability_catalog",
-                "required_inputs": [],
-                "outputs": ["editable knobs + defaults + example paths"],
+                "tool": "infer_configs",
+                "required_inputs": ["input_id|gcs_path|session_id"],
+                "outputs": ["configs (YAML strings by module)"],
                 "next": [offset + 5],
             },
             {
                 "step": offset + 5,
+                "tool": "get_capability_catalog",
+                "required_inputs": [],
+                "outputs": ["editable knobs + defaults + example paths"],
+                "next": [offset + 6],
+            },
+            {
+                "step": offset + 6,
                 "tool": "manual config + runtime review",
                 "required_inputs": [
                     "inferred configs",
@@ -329,13 +361,13 @@ def agent_playbook_payload() -> dict:
                     "Use runtime for paths, run_id, export_html, plotting, and destination overrides.",
                     "Use module config for business logic and per-module rules.",
                 ],
-                "next": [offset + 6],
+                "next": [offset + 7],
             },
             {
-                "step": offset + 6,
+                "step": offset + 7,
                 "tool": "auto_heal",
                 "required_inputs": [
-                    "gcs_path|session_id|runtime.run.input_path",
+                    "input_id|gcs_path|session_id|runtime.run.input_path",
                     "run_id|runtime.run.run_id",
                 ],
                 "outputs": ["session_id", "dashboard_url?", "dashboard_path?", "export_url?"],
@@ -343,10 +375,10 @@ def agent_playbook_payload() -> dict:
                     "Use only when the user explicitly wants one-shot automation.",
                     "Open or link the auto-heal dashboard artifact for review.",
                 ],
-                "next": [offset + 7],
+                "next": [offset + 8],
             },
             {
-                "step": offset + 7,
+                "step": offset + 8,
                 "tool_chain": [
                     "normalization",
                     "duplicates",
@@ -361,10 +393,10 @@ def agent_playbook_payload() -> dict:
                     "Prefer the standalone dashboard artifact as the main review surface.",
                     "Use runtime instead of editing every module config when the override is cross-cutting.",
                 ],
-                "next": [offset + 8],
+                "next": [offset + 9],
             },
             {
-                "step": offset + 8,
+                "step": offset + 9,
                 "tool_chain": ["final_audit", "get_run_history"],
                 "required_inputs": ["session_id", "run_id"],
                 "outputs": ["final certificate artifacts", "healing ledger"],

--- a/src/analyst_toolkit/mcp_server/tools/infer_configs.py
+++ b/src/analyst_toolkit/mcp_server/tools/infer_configs.py
@@ -1,5 +1,6 @@
 """MCP tool: toolkit_infer_configs — config generation via analyst_toolkit_deploy."""
 
+import inspect
 import os
 import tempfile
 
@@ -10,6 +11,47 @@ from analyst_toolkit.mcp_server.runtime_overlay import (
     runtime_to_tool_overrides,
 )
 from analyst_toolkit.mcp_server.schemas import INPUT_ID_PROP
+
+
+def _call_external_infer_configs(
+    infer_configs_fn,
+    *,
+    input_path: str,
+    options: dict,
+    modules: list[str] | None,
+    sample_rows: int | None,
+) -> tuple[dict, list[str]]:
+    """Call the external infer_configs helper with signature compatibility."""
+    kwargs = {
+        "root": options.get("root", "."),
+        "input_path": input_path,
+        "modules": modules or options.get("modules"),
+        "outdir": options.get("outdir"),
+        "sample_rows": sample_rows or options.get("sample_rows"),
+        "max_unique": options.get("max_unique", 30),
+        "exclude_patterns": options.get("exclude_patterns", "id|uuid|tag"),
+        "detect_datetimes": options.get("detect_datetimes", True),
+        "datetime_hints": options.get("datetime_hints"),
+    }
+
+    signature = inspect.signature(infer_configs_fn)
+    accepts_var_kwargs = any(
+        parameter.kind == inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    )
+    if accepts_var_kwargs:
+        return infer_configs_fn(**kwargs), []
+
+    supported = set(signature.parameters)
+    filtered_kwargs = {key: value for key, value in kwargs.items() if key in supported}
+    dropped = sorted(key for key in kwargs if key not in supported and kwargs[key] is not None)
+    warnings = []
+    if dropped:
+        warnings.append(
+            "External infer_configs helper does not support the following arguments and they "
+            f"were ignored: {', '.join(dropped)}."
+        )
+    return infer_configs_fn(**filtered_kwargs), warnings
 
 
 async def _toolkit_infer_configs(
@@ -74,17 +116,14 @@ async def _toolkit_infer_configs(
             "config_yaml": "",
         }
 
+    external_warnings: list[str] = []
     try:
-        configs = infer_configs(
-            root=options.get("root", "."),
+        configs, external_warnings = _call_external_infer_configs(
+            infer_configs,
             input_path=input_path,
-            modules=modules or options.get("modules"),
-            outdir=options.get("outdir"),
-            sample_rows=sample_rows or options.get("sample_rows"),
-            max_unique=options.get("max_unique", 30),
-            exclude_patterns=options.get("exclude_patterns", "id|uuid|tag"),
-            detect_datetimes=options.get("detect_datetimes", True),
-            datetime_hints=options.get("datetime_hints"),
+            options=options,
+            modules=modules,
+            sample_rows=sample_rows,
         )
     finally:
         if temp_file:
@@ -138,7 +177,7 @@ async def _toolkit_infer_configs(
             "session_id": session_id,
             "configs": configs,
             "runtime_applied": runtime_applied,
-            "warnings": runtime_warnings,
+            "warnings": runtime_warnings + external_warnings,
         },
         next_steps,
     )

--- a/tests/mcp_server/test_rpc_tools.py
+++ b/tests/mcp_server/test_rpc_tools.py
@@ -180,17 +180,27 @@ def test_rpc_user_quickstart_tool(client, monkeypatch):
     assert "auto_heal" in result["content"]["markdown"]
     assert "cockpit dashboard" in result["content"]["markdown"].lower()
     assert "ensure_artifact_server" in result["content"]["markdown"]
+    assert "register_input" in result["content"]["markdown"]
+    assert "/inputs/upload" in result["content"]["markdown"]
     assert "machine_guide" in result
-    assert result["machine_guide"]["ordered_steps"][0]["tool"] == "diagnostics"
-    assert result["machine_guide"]["ordered_steps"][1]["tool"] == "infer_configs"
-    assert result["machine_guide"]["ordered_steps"][1]["required_inputs"] == ["gcs_path|session_id"]
+    assert result["machine_guide"]["ordered_steps"][0]["tool"] == "register_input"
+    assert result["machine_guide"]["ordered_steps"][1]["tool"] == "diagnostics"
+    assert result["machine_guide"]["ordered_steps"][1]["required_inputs"] == [
+        "input_id|gcs_path|session_id|runtime.run.input_path",
+        "run_id|runtime.run.run_id",
+    ]
+    assert result["machine_guide"]["ordered_steps"][2]["tool"] == "infer_configs"
+    assert result["machine_guide"]["ordered_steps"][2]["required_inputs"] == [
+        "input_id|gcs_path|session_id"
+    ]
     assert len(result["quick_actions"]) >= 2
     assert not any(a["tool"] == "get_cockpit_dashboard" for a in result["quick_actions"])
+    assert any(a["tool"] == "register_input" for a in result["quick_actions"])
     assert any(a["tool"] == "diagnostics" for a in result["quick_actions"])
     assert any(a["tool"] == "infer_configs" for a in result["quick_actions"])
     assert any(a["tool"] == "auto_heal" for a in result["quick_actions"])
     infer_quick = next(a for a in result["quick_actions"] if a["tool"] == "infer_configs")
-    assert infer_quick["arguments_schema_hint"]["required"] == ["gcs_path|session_id"]
+    assert infer_quick["arguments_schema_hint"]["required"] == ["input_id|gcs_path|session_id"]
     assert isinstance(result.get("trace_id"), str)
     assert result["trace_id"]
 
@@ -209,16 +219,17 @@ def test_rpc_agent_playbook_infer_configs_inputs_allow_path_or_session(client, m
     result = response.json()["result"]
     assert result["status"] == "pass"
     assert result["ordered_steps"][0]["tool"] == "ensure_artifact_server"
-    assert result["ordered_steps"][1]["tool"] == "diagnostics"
+    assert result["ordered_steps"][1]["tool"] == "register_input"
+    assert result["ordered_steps"][2]["tool"] == "diagnostics"
     infer_step = next(
         step for step in result["ordered_steps"] if step.get("tool") == "infer_configs"
     )
-    assert infer_step["required_inputs"] == ["gcs_path|session_id"]
+    assert infer_step["required_inputs"] == ["input_id|gcs_path|session_id"]
     auto_heal_step = next(
         step for step in result["ordered_steps"] if step.get("tool") == "auto_heal"
     )
     assert auto_heal_step["required_inputs"] == [
-        "gcs_path|session_id|runtime.run.input_path",
+        "input_id|gcs_path|session_id|runtime.run.input_path",
         "run_id|runtime.run.run_id",
     ]
 

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -253,6 +253,38 @@ async def test_toolkit_infer_configs_includes_apply_next_actions(monkeypatch, mo
 
 
 @pytest.mark.asyncio
+async def test_toolkit_infer_configs_ignores_unsupported_external_modules_kw(monkeypatch, mocker):
+    df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
+
+    mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
+
+    def fake_infer_configs(*, root, input_path, sample_rows=None):
+        assert root == "."
+        assert input_path
+        assert sample_rows == 5
+        return {"normalization": "normalization:\\n  rules: {}\\n"}
+
+    infer_mod = types.ModuleType("analyst_toolkit_deploy.infer_configs")
+    setattr(infer_mod, "infer_configs", fake_infer_configs)
+    pkg_mod = types.ModuleType("analyst_toolkit_deploy")
+
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy", pkg_mod)
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy.infer_configs", infer_mod)
+
+    result = await infer_configs_tool._toolkit_infer_configs(
+        session_id="sess_compat",
+        modules=["normalization"],
+        sample_rows=5,
+    )
+
+    assert result["status"] == "pass"
+    assert "normalization" in result["configs"]
+    assert any(
+        "does not support the following arguments" in warning for warning in result["warnings"]
+    )
+
+
+@pytest.mark.asyncio
 async def test_toolkit_infer_configs_accepts_runtime_overrides(monkeypatch, mocker):
     df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
     captured = {}


### PR DESCRIPTION
## Summary
- make `toolkit_infer_configs` tolerate older `analyst_toolkit_deploy.infer_configs` helper signatures
- drop unsupported kwargs like `modules` when the installed helper does not accept them
- surface a warning to clients instead of crashing
- add a regression test for older helper compatibility

## Why
Live MCP testing against `gs://data-reporting/test_data/synthetic_penguins_v0.4.0.csv` showed `toolkit_infer_configs` failing server-side with:

`TypeError: infer_configs() got an unexpected keyword argument 'modules'`

This change preserves the current contract while making the wrapper compatible with older deployed helper versions.

## Validation
- `ruff check src/analyst_toolkit/mcp_server/tools/infer_configs.py tests/test_mcp_tool_regressions.py`
- `pytest tests/test_mcp_tool_regressions.py -q`
- `mypy src/analyst_toolkit/mcp_server`

Closes the live-tested `infer_configs` signature compatibility bug.