### PR TITLE
fix: flatten quickstart tool response contract

### DIFF
--- a/src/analyst_toolkit/mcp_server/resources.py
+++ b/src/analyst_toolkit/mcp_server/resources.py
@@ -78,14 +78,7 @@ def _read_quickstart_resource() -> tuple[str, str]:
             code="QUICKSTART_PAYLOAD_INVALID",
             message="Invalid quickstart payload.",
         )
-    content = payload.get("content")
-    if not isinstance(content, dict):
-        logger.warning("Quickstart payload missing content mapping: %r", payload)
-        raise ResourcePayloadError(
-            code="QUICKSTART_PAYLOAD_INVALID",
-            message="Invalid quickstart payload.",
-        )
-    markdown = content.get("markdown")
+    markdown = payload.get("markdown")
     if not isinstance(markdown, str) or not markdown.strip():
         logger.warning("Quickstart payload missing markdown body: %r", payload)
         raise ResourcePayloadError(

--- a/src/analyst_toolkit/mcp_server/tools/cockpit_content.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit_content.py
@@ -195,11 +195,9 @@ Turn plotting off for speed on large datasets, on for exploratory analysis.
     }
     return {
         "status": "pass",
-        "content": {
-            "format": "markdown",
-            "title": "Analyst Toolkit Quickstart",
-            "markdown": guide.strip(),
-        },
+        "format": "markdown",
+        "title": "Analyst Toolkit Quickstart",
+        "markdown": guide.strip(),
         "machine_guide": machine_guide,
         "quick_actions": (
             [

--- a/tests/mcp_server/test_rpc_tools.py
+++ b/tests/mcp_server/test_rpc_tools.py
@@ -173,15 +173,15 @@ def test_rpc_user_quickstart_tool(client, monkeypatch):
     assert response.status_code == 200
     result = response.json()["result"]
     assert result["status"] == "pass"
-    assert result["content"]["format"] == "markdown"
-    assert result["content"]["title"] == "Analyst Toolkit Quickstart"
-    assert "fuzzy matching" in result["content"]["markdown"].lower()
-    assert "plotting" in result["content"]["markdown"].lower()
-    assert "auto_heal" in result["content"]["markdown"]
-    assert "cockpit dashboard" in result["content"]["markdown"].lower()
-    assert "ensure_artifact_server" in result["content"]["markdown"]
-    assert "register_input" in result["content"]["markdown"]
-    assert "/inputs/upload" in result["content"]["markdown"]
+    assert result["format"] == "markdown"
+    assert result["title"] == "Analyst Toolkit Quickstart"
+    assert "fuzzy matching" in result["markdown"].lower()
+    assert "plotting" in result["markdown"].lower()
+    assert "auto_heal" in result["markdown"]
+    assert "cockpit dashboard" in result["markdown"].lower()
+    assert "ensure_artifact_server" in result["markdown"]
+    assert "register_input" in result["markdown"]
+    assert "/inputs/upload" in result["markdown"]
     assert "machine_guide" in result
     assert result["machine_guide"]["ordered_steps"][0]["tool"] == "register_input"
     assert result["machine_guide"]["ordered_steps"][1]["tool"] == "diagnostics"


### PR DESCRIPTION
## Summary
- flatten `get_user_quickstart` to return standard top-level fields
- keep the quickstart resource URI behavior intact
- update RPC tests to assert the flattened contract

## Why
Live MCP testing showed `toolkit_get_user_quickstart` failing in the client with:

`Unexpected response type`

This tool was the only cockpit surface returning a top-level `content` wrapper. Flattening it to ordinary fields aligns it with the rest of the MCP tool surface and preserves the resource-based quickstart document.

## Validation
- `ruff check src/analyst_toolkit/mcp_server/tools/cockpit_content.py src/analyst_toolkit/mcp_server/resources.py tests/mcp_server/test_rpc_tools.py`
- `pytest tests/mcp_server/test_rpc_tools.py tests/mcp_server/test_rpc_resources.py -q`
- `mypy src/analyst_toolkit/mcp_server`

Closes the live-tested quickstart response-contract bug.