### PR TITLE
fix: map generated infer configs into module payloads

### DIFF
--- a/src/analyst_toolkit/mcp_server/tools/infer_configs.py
+++ b/src/analyst_toolkit/mcp_server/tools/infer_configs.py
@@ -3,6 +3,9 @@
 import inspect
 import os
 import tempfile
+from pathlib import Path
+
+import yaml
 
 from analyst_toolkit.mcp_server.io import load_input, resolve_run_context, save_to_session
 from analyst_toolkit.mcp_server.response_utils import next_action, with_next_actions
@@ -52,6 +55,97 @@ def _call_external_infer_configs(
             f"were ignored: {', '.join(dropped)}."
         )
     return infer_configs_fn(**filtered_kwargs), warnings
+
+
+def _module_name_from_generated_file(path: Path) -> str | None:
+    stem = path.stem.lower()
+    for suffix in ("_config_autofill", "_config_template", "_template", "_config", "_yaml"):
+        if stem.endswith(suffix):
+            stem = stem[: -len(suffix)]
+            break
+
+    aliases = {
+        "dups": "duplicates",
+        "duplicate": "duplicates",
+        "outlier": "outliers",
+        "handling": "outliers",
+        "certification": "final_audit",
+    }
+    normalized = aliases.get(stem, stem)
+    supported = {
+        "diagnostics",
+        "validation",
+        "normalization",
+        "duplicates",
+        "outliers",
+        "imputation",
+        "final_audit",
+    }
+    return normalized if normalized in supported else None
+
+
+def _module_name_from_generated_yaml(raw_yaml: str) -> str | None:
+    try:
+        loaded = yaml.safe_load(raw_yaml) or {}
+    except yaml.YAMLError:
+        return None
+    if not isinstance(loaded, dict) or not loaded:
+        return None
+    for key in loaded:
+        if not isinstance(key, str):
+            continue
+        module_name = _module_name_from_generated_file(Path(f"{key}.yaml"))
+        if module_name is not None:
+            return module_name
+    return None
+
+
+def _normalize_external_configs_result(
+    configs_result,
+) -> tuple[dict[str, str], list[str], str | None]:
+    """Normalize external infer_configs output into module->yaml mapping."""
+    if isinstance(configs_result, dict):
+        normalized = {
+            str(module): str(config_yaml)
+            for module, config_yaml in configs_result.items()
+            if config_yaml is not None
+        }
+        return normalized, [], None
+
+    if isinstance(configs_result, str):
+        config_dir = Path(configs_result)
+        if not config_dir.is_dir():
+            return (
+                {},
+                [f"External infer_configs returned non-directory path: {configs_result}."],
+                None,
+            )
+
+        configs: dict[str, str] = {}
+        for path in sorted(config_dir.rglob("*")):
+            if not path.is_file() or path.suffix.lower() not in {".yaml", ".yml"}:
+                continue
+            raw_yaml = path.read_text(encoding="utf-8")
+            module_name = _module_name_from_generated_yaml(raw_yaml) or _module_name_from_generated_file(
+                path
+            )
+            if module_name is None:
+                continue
+            configs[module_name] = raw_yaml
+
+        warnings = []
+        if not configs:
+            warnings.append(
+                "External infer_configs generated config files, but none could be mapped to "
+                "supported toolkit modules."
+            )
+        return configs, warnings, str(config_dir)
+
+    return (
+        {},
+        [f"External infer_configs returned unsupported type: {type(configs_result).__name__}."],
+        None,
+    )
 
 
 async def _toolkit_infer_configs(
@@ -117,14 +211,19 @@ async def _toolkit_infer_configs(
         }
 
     external_warnings: list[str] = []
+    generated_config_dir: str | None = None
     try:
-        configs, external_warnings = _call_external_infer_configs(
+        raw_configs, external_warnings = _call_external_infer_configs(
             infer_configs,
             input_path=input_path,
             options=options,
             modules=modules,
             sample_rows=sample_rows,
         )
+        configs, normalization_warnings, generated_config_dir = _normalize_external_configs_result(
+            raw_configs
+        )
+        external_warnings.extend(normalization_warnings)
     finally:
         if temp_file:
             os.unlink(temp_file.name)
@@ -176,6 +275,7 @@ async def _toolkit_infer_configs(
             "run_id": run_id,
             "session_id": session_id,
             "configs": configs,
+            "config_dir": generated_config_dir or "",
             "runtime_applied": runtime_applied,
             "warnings": runtime_warnings + external_warnings,
         },

--- a/src/analyst_toolkit/mcp_server/tools/infer_configs.py
+++ b/src/analyst_toolkit/mcp_server/tools/infer_configs.py
@@ -15,6 +15,24 @@ from analyst_toolkit.mcp_server.runtime_overlay import (
 )
 from analyst_toolkit.mcp_server.schemas import INPUT_ID_PROP
 
+_SUPPORTED_INFER_MODULES = {
+    "diagnostics",
+    "validation",
+    "normalization",
+    "duplicates",
+    "outliers",
+    "imputation",
+    "final_audit",
+}
+
+_INFER_MODULE_ALIASES = {
+    "dups": "duplicates",
+    "duplicate": "duplicates",
+    "outlier": "outliers",
+    "handling": "outliers",
+    "certification": "final_audit",
+}
+
 
 def _call_external_infer_configs(
     infer_configs_fn,
@@ -64,24 +82,8 @@ def _module_name_from_generated_file(path: Path) -> str | None:
             stem = stem[: -len(suffix)]
             break
 
-    aliases = {
-        "dups": "duplicates",
-        "duplicate": "duplicates",
-        "outlier": "outliers",
-        "handling": "outliers",
-        "certification": "final_audit",
-    }
-    normalized = aliases.get(stem, stem)
-    supported = {
-        "diagnostics",
-        "validation",
-        "normalization",
-        "duplicates",
-        "outliers",
-        "imputation",
-        "final_audit",
-    }
-    return normalized if normalized in supported else None
+    normalized = _INFER_MODULE_ALIASES.get(stem, stem)
+    return normalized if normalized in _SUPPORTED_INFER_MODULES else None
 
 
 def _module_name_from_generated_yaml(raw_yaml: str) -> str | None:
@@ -100,35 +102,67 @@ def _module_name_from_generated_yaml(raw_yaml: str) -> str | None:
     return None
 
 
+def _is_relative_to(path: Path, base: Path) -> bool:
+    try:
+        path.relative_to(base)
+        return True
+    except ValueError:
+        return False
+
+
+def _trusted_generated_config_root() -> Path:
+    return (Path.cwd() / "config").resolve()
+
+
 def _normalize_external_configs_result(
     configs_result,
+    *,
+    trusted_config_root: Path,
 ) -> tuple[dict[str, str], list[str], str | None]:
     """Normalize external infer_configs output into module->yaml mapping."""
     if isinstance(configs_result, dict):
-        normalized = {
-            str(module): str(config_yaml)
-            for module, config_yaml in configs_result.items()
-            if config_yaml is not None
-        }
-        return normalized, [], None
+        normalized: dict[str, str] = {}
+        warnings: list[str] = []
+        for module, config_yaml in configs_result.items():
+            if config_yaml is None:
+                continue
+            module_name = _module_name_from_generated_file(Path(f"{module}.yaml"))
+            if module_name is None and isinstance(config_yaml, str):
+                module_name = _module_name_from_generated_yaml(config_yaml)
+            if module_name is None:
+                warnings.append(f"Ignored unsupported inferred module key: {module}.")
+                continue
+            normalized[module_name] = str(config_yaml)
+        return normalized, warnings, None
 
     if isinstance(configs_result, str):
-        config_dir = Path(configs_result)
-        if not config_dir.is_dir():
+        config_dir = Path(configs_result).resolve()
+        if config_dir.is_symlink() or not config_dir.is_dir():
             return (
                 {},
                 [f"External infer_configs returned non-directory path: {configs_result}."],
                 None,
             )
+        if not _is_relative_to(config_dir, trusted_config_root):
+            return (
+                {},
+                [f"Rejected untrusted generated config directory: {configs_result}."],
+                None,
+            )
 
         configs: dict[str, str] = {}
         for path in sorted(config_dir.rglob("*")):
-            if not path.is_file() or path.suffix.lower() not in {".yaml", ".yml"}:
+            if path.is_symlink():
                 continue
-            raw_yaml = path.read_text(encoding="utf-8")
-            module_name = _module_name_from_generated_yaml(raw_yaml) or _module_name_from_generated_file(
-                path
-            )
+            resolved_path = path.resolve()
+            if not _is_relative_to(resolved_path, trusted_config_root):
+                continue
+            if not resolved_path.is_file() or resolved_path.suffix.lower() not in {".yaml", ".yml"}:
+                continue
+            raw_yaml = resolved_path.read_text(encoding="utf-8")
+            module_name = _module_name_from_generated_yaml(
+                raw_yaml
+            ) or _module_name_from_generated_file(resolved_path)
             if module_name is None:
                 continue
             configs[module_name] = raw_yaml
@@ -192,6 +226,7 @@ async def _toolkit_infer_configs(
     temp_file = tempfile.NamedTemporaryFile(suffix=".csv", delete=False)
     df.to_csv(temp_file.name, index=False)
     input_path = temp_file.name
+    trusted_config_root = _trusted_generated_config_root()
 
     try:
         try:
@@ -221,7 +256,8 @@ async def _toolkit_infer_configs(
             sample_rows=sample_rows,
         )
         configs, normalization_warnings, generated_config_dir = _normalize_external_configs_result(
-            raw_configs
+            raw_configs,
+            trusted_config_root=trusted_config_root,
         )
         external_warnings.extend(normalization_warnings)
     finally:

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -285,6 +285,125 @@ async def test_toolkit_infer_configs_ignores_unsupported_external_modules_kw(mon
 
 
 @pytest.mark.asyncio
+async def test_toolkit_infer_configs_reads_generated_directory_results(
+    monkeypatch, mocker, tmp_path
+):
+    df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
+
+    mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
+
+    generated_dir = tmp_path / "generated"
+    generated_dir.mkdir()
+    (generated_dir / "normalization_config.yaml").write_text(
+        "normalization:\n  rules: {}\n",
+        encoding="utf-8",
+    )
+    (generated_dir / "validation_config.yaml").write_text(
+        "validation:\n  schema_validation:\n    run: true\n",
+        encoding="utf-8",
+    )
+
+    def fake_infer_configs(**kwargs):
+        return str(generated_dir)
+
+    infer_mod = types.ModuleType("analyst_toolkit_deploy.infer_configs")
+    setattr(infer_mod, "infer_configs", fake_infer_configs)
+    pkg_mod = types.ModuleType("analyst_toolkit_deploy")
+
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy", pkg_mod)
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy.infer_configs", infer_mod)
+
+    result = await infer_configs_tool._toolkit_infer_configs(
+        session_id="sess_generated",
+        modules=["normalization", "validation"],
+    )
+
+    assert result["status"] == "pass"
+    assert result["config_dir"] == str(generated_dir)
+    assert "normalization" in result["configs"]
+    assert "validation" in result["configs"]
+    assert "normalization:" in result["configs"]["normalization"]
+    assert "validation:" in result["configs"]["validation"]
+
+
+@pytest.mark.asyncio
+async def test_toolkit_infer_configs_maps_generated_yaml_by_root_key(
+    monkeypatch, mocker, tmp_path
+):
+    df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
+
+    mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
+
+    generated_dir = tmp_path / "generated_by_content"
+    generated_dir.mkdir()
+    (generated_dir / "penguins_profile.yaml").write_text(
+        "normalization:\n  rules: {}\n",
+        encoding="utf-8",
+    )
+
+    def fake_infer_configs(**kwargs):
+        return str(generated_dir)
+
+    infer_mod = types.ModuleType("analyst_toolkit_deploy.infer_configs")
+    setattr(infer_mod, "infer_configs", fake_infer_configs)
+    pkg_mod = types.ModuleType("analyst_toolkit_deploy")
+
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy", pkg_mod)
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy.infer_configs", infer_mod)
+
+    result = await infer_configs_tool._toolkit_infer_configs(
+        session_id="sess_generated_by_content",
+        modules=["normalization"],
+    )
+
+    assert result["status"] == "pass"
+    assert result["config_dir"] == str(generated_dir)
+    assert "normalization" in result["configs"]
+    assert result["warnings"] == []
+
+
+@pytest.mark.asyncio
+async def test_toolkit_infer_configs_maps_autofill_files_with_metadata_prefix(
+    monkeypatch, mocker, tmp_path
+):
+    df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
+
+    mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
+
+    generated_dir = tmp_path / "generated_autofill"
+    generated_dir.mkdir()
+    (generated_dir / "outlier_config_autofill.yaml").write_text(
+        "notebook: true\nrun_id: ''\nlogging: auto\noutlier_detection:\n  run: true\n",
+        encoding="utf-8",
+    )
+    (generated_dir / "validation_config_autofill.yaml").write_text(
+        "notebook: true\nrun_id: ''\nlogging: auto\nvalidation:\n  schema_validation:\n    run: true\n",
+        encoding="utf-8",
+    )
+
+    def fake_infer_configs(**kwargs):
+        return str(generated_dir)
+
+    infer_mod = types.ModuleType("analyst_toolkit_deploy.infer_configs")
+    setattr(infer_mod, "infer_configs", fake_infer_configs)
+    pkg_mod = types.ModuleType("analyst_toolkit_deploy")
+
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy", pkg_mod)
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy.infer_configs", infer_mod)
+
+    result = await infer_configs_tool._toolkit_infer_configs(
+        session_id="sess_generated_autofill",
+        modules=["outliers", "validation"],
+    )
+
+    assert result["status"] == "pass"
+    assert result["config_dir"] == str(generated_dir)
+    assert "outliers" in result["configs"]
+    assert "validation" in result["configs"]
+    assert result["warnings"] == []
+
+
+@pytest.mark.asyncio
 async def test_toolkit_infer_configs_accepts_runtime_overrides(monkeypatch, mocker):
     df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
     captured = {}

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -292,8 +292,9 @@ async def test_toolkit_infer_configs_reads_generated_directory_results(
 
     mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
 
-    generated_dir = tmp_path / "generated"
-    generated_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    generated_dir = tmp_path / "config" / "generated"
+    generated_dir.mkdir(parents=True)
     (generated_dir / "normalization_config.yaml").write_text(
         "normalization:\n  rules: {}\n",
         encoding="utf-8",
@@ -327,15 +328,14 @@ async def test_toolkit_infer_configs_reads_generated_directory_results(
 
 
 @pytest.mark.asyncio
-async def test_toolkit_infer_configs_maps_generated_yaml_by_root_key(
-    monkeypatch, mocker, tmp_path
-):
+async def test_toolkit_infer_configs_maps_generated_yaml_by_root_key(monkeypatch, mocker, tmp_path):
     df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
 
     mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
 
-    generated_dir = tmp_path / "generated_by_content"
-    generated_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    generated_dir = tmp_path / "config" / "generated_by_content"
+    generated_dir.mkdir(parents=True)
     (generated_dir / "penguins_profile.yaml").write_text(
         "normalization:\n  rules: {}\n",
         encoding="utf-8",
@@ -370,8 +370,9 @@ async def test_toolkit_infer_configs_maps_autofill_files_with_metadata_prefix(
 
     mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
 
-    generated_dir = tmp_path / "generated_autofill"
-    generated_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+    generated_dir = tmp_path / "config" / "generated_autofill"
+    generated_dir.mkdir(parents=True)
     (generated_dir / "outlier_config_autofill.yaml").write_text(
         "notebook: true\nrun_id: ''\nlogging: auto\noutlier_detection:\n  run: true\n",
         encoding="utf-8",
@@ -400,6 +401,75 @@ async def test_toolkit_infer_configs_maps_autofill_files_with_metadata_prefix(
     assert result["config_dir"] == str(generated_dir)
     assert "outliers" in result["configs"]
     assert "validation" in result["configs"]
+    assert result["warnings"] == []
+
+
+@pytest.mark.asyncio
+async def test_toolkit_infer_configs_rejects_untrusted_generated_directory(
+    monkeypatch, mocker, tmp_path
+):
+    df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
+
+    mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
+
+    monkeypatch.chdir(tmp_path)
+    generated_dir = tmp_path / "outside_generated"
+    generated_dir.mkdir()
+    (generated_dir / "validation_config.yaml").write_text(
+        "validation:\n  schema_validation:\n    run: true\n",
+        encoding="utf-8",
+    )
+
+    def fake_infer_configs(**kwargs):
+        return str(generated_dir)
+
+    infer_mod = types.ModuleType("analyst_toolkit_deploy.infer_configs")
+    setattr(infer_mod, "infer_configs", fake_infer_configs)
+    pkg_mod = types.ModuleType("analyst_toolkit_deploy")
+
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy", pkg_mod)
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy.infer_configs", infer_mod)
+
+    result = await infer_configs_tool._toolkit_infer_configs(
+        session_id="sess_untrusted_generated",
+        modules=["validation"],
+    )
+
+    assert result["status"] == "pass"
+    assert result["configs"] == {}
+    assert result["config_dir"] == ""
+    assert any(
+        "Rejected untrusted generated config directory" in warning for warning in result["warnings"]
+    )
+
+
+@pytest.mark.asyncio
+async def test_toolkit_infer_configs_normalizes_dict_module_aliases(monkeypatch, mocker):
+    df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
+
+    mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
+
+    def fake_infer_configs(**kwargs):
+        return {
+            "certification": "final_audit:\n  summary:\n    run: true\n",
+            "outlier": "outlier_detection:\n  run: true\n",
+        }
+
+    infer_mod = types.ModuleType("analyst_toolkit_deploy.infer_configs")
+    setattr(infer_mod, "infer_configs", fake_infer_configs)
+    pkg_mod = types.ModuleType("analyst_toolkit_deploy")
+
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy", pkg_mod)
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy.infer_configs", infer_mod)
+
+    result = await infer_configs_tool._toolkit_infer_configs(
+        session_id="sess_alias_dict",
+        modules=["final_audit", "outliers"],
+    )
+
+    assert result["status"] == "pass"
+    assert "final_audit" in result["configs"]
+    assert "outliers" in result["configs"]
     assert result["warnings"] == []
 
 


### PR DESCRIPTION
## Summary
- normalize external `infer_configs` directory output into MCP client-usable module YAML payloads
- map generated files using both filename conventions and YAML top-level module keys
- handle live helper outputs like `*_config_autofill.yaml` with metadata-prefixed YAML bodies
- preserve the generated directory path as `config_dir`
- add regression tests for directory outputs, generic filenames, and autofill naming

## Why
Live MCP testing against `gs://data-reporting/test_data/synthetic_penguins_v0.4.0.csv` showed `toolkit_infer_configs` no longer crashing, but still returning unusable results:
- `configs: {}`
- `config_dir: /app/config/generated`
- warning that generated files could not be mapped to supported toolkit modules

Inspection of the running container showed actual generated files such as:
- `validation_config_autofill.yaml`
- `outlier_config_autofill.yaml`
- `certification_config_autofill.yaml`

Those files also begin with metadata keys like `notebook`, `run_id`, and `logging`, so the previous mapper missed them.

## Validation
- `ruff check src/analyst_toolkit/mcp_server/tools/infer_configs.py tests/test_mcp_tool_regressions.py`
- `pytest tests/test_mcp_tool_regressions.py -q`
- `mypy src/analyst_toolkit/mcp_server`

Addresses the live-tested infer_configs mapping/result-contract defect.