### PR TITLE
fix: restore full infer_configs module coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ mcp = [
   "gcsfs>=2024.2.0",
   "python-multipart>=0.0.9",
   "pydantic>=2.0",
-  "analyst_toolkit_deploy @ git+https://github.com/G-Schumacher44/analyst_toolkit_deployment_utility.git@b8127f990e1c7bd6b7fd6b66f4987e0bd86fbad6",
+  "analyst_toolkit_deploy @ git+https://github.com/G-Schumacher44/analyst_toolkit_deployment_utility.git@a27113c111e03a1084f02d6665d389a50102deca",
 ]
 dev = [
   "pytest>=7.0",

--- a/src/analyst_toolkit/mcp_server/tools/infer_configs.py
+++ b/src/analyst_toolkit/mcp_server/tools/infer_configs.py
@@ -265,6 +265,7 @@ async def _toolkit_infer_configs(
             os.unlink(temp_file.name)
 
     module_order = [
+        "diagnostics",
         "normalization",
         "duplicates",
         "outliers",
@@ -304,6 +305,14 @@ async def _toolkit_infer_configs(
     else:
         next_steps = apply_actions + [capability_action]
 
+    covered_modules = sorted(configs.keys())
+    requested_modules = sorted(set(modules)) if modules else sorted(_SUPPORTED_INFER_MODULES)
+    unsupported_modules = sorted(set(requested_modules) - set(covered_modules))
+    if unsupported_modules:
+        external_warnings.append(
+            f"Configs were not generated for: {', '.join(unsupported_modules)}."
+        )
+
     return with_next_actions(
         {
             "status": "pass",
@@ -311,6 +320,8 @@ async def _toolkit_infer_configs(
             "run_id": run_id,
             "session_id": session_id,
             "configs": configs,
+            "covered_modules": covered_modules,
+            "unsupported_modules": unsupported_modules,
             "config_dir": generated_config_dir or "",
             "runtime_applied": runtime_applied,
             "warnings": runtime_warnings + external_warnings,

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -790,6 +790,77 @@ async def test_infer_configs_gcs_path_uses_local_snapshot(monkeypatch, mocker):
 
 
 @pytest.mark.asyncio
+async def test_infer_configs_surfaces_covered_and_unsupported_modules(monkeypatch, mocker):
+    df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
+
+    mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
+
+    def fake_infer_configs(**kwargs):
+        return {
+            "validation": "validation:\n  schema_validation:\n    run: true\n",
+            "normalization": "normalization:\n  rules: {}\n",
+            "outliers": "outlier_detection:\n  run: true\n",
+            "imputation": "imputation:\n  rules: {}\n",
+            "diagnostics": "diagnostics:\n  run: true\n",
+            "duplicates": "duplicates:\n  subset: []\n",
+            "certification": "validation:\n  schema_validation:\n    run: true\n",
+            "handling": "outlier_detection:\n  run: true\n",
+            "final_audit": "final_audit:\n  certification_rules: {}\n",
+        }
+
+    infer_mod = types.ModuleType("analyst_toolkit_deploy.infer_configs")
+    setattr(infer_mod, "infer_configs", fake_infer_configs)
+    pkg_mod = types.ModuleType("analyst_toolkit_deploy")
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy", pkg_mod)
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy.infer_configs", infer_mod)
+
+    result = await infer_configs_tool._toolkit_infer_configs(session_id="sess_full")
+
+    assert result["status"] == "pass"
+    assert "covered_modules" in result
+    assert "unsupported_modules" in result
+    assert set(result["covered_modules"]) == {
+        "diagnostics",
+        "duplicates",
+        "final_audit",
+        "imputation",
+        "normalization",
+        "outliers",
+        "validation",
+    }
+    assert result["unsupported_modules"] == []
+
+
+@pytest.mark.asyncio
+async def test_infer_configs_reports_unsupported_when_partial(monkeypatch, mocker):
+    df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
+
+    mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
+
+    def fake_infer_configs(**kwargs):
+        return {
+            "validation": "validation:\n  schema_validation:\n    run: true\n",
+            "outliers": "outlier_detection:\n  run: true\n",
+        }
+
+    infer_mod = types.ModuleType("analyst_toolkit_deploy.infer_configs")
+    setattr(infer_mod, "infer_configs", fake_infer_configs)
+    pkg_mod = types.ModuleType("analyst_toolkit_deploy")
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy", pkg_mod)
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy.infer_configs", infer_mod)
+
+    result = await infer_configs_tool._toolkit_infer_configs(
+        session_id="sess_partial",
+        modules=["validation", "outliers", "normalization"],
+    )
+
+    assert result["status"] == "pass"
+    assert result["covered_modules"] == ["outliers", "validation"]
+    assert result["unsupported_modules"] == ["normalization"]
+    assert any("not generated for" in w for w in result["warnings"])
+
+
+@pytest.mark.asyncio
 async def test_final_audit_fails_closed_when_cert_rules_empty(mocker, monkeypatch):
     df = pd.DataFrame({"value": [1]})
 


### PR DESCRIPTION
## Summary
- Updates the pinned `analyst_toolkit_deploy` commit from `b8127f9` (which only generated validation/certification/outliers configs as directory output) to `a27113c` (which returns a dict with all 9 module configs and supports the `modules` filter parameter)
- Adds `covered_modules` and `unsupported_modules` fields to the `infer_configs` response so clients know exactly what was generated vs what was not
- Adds `diagnostics` to the `module_order` for next_actions generation

## Test plan
- [x] Two new regression tests: full module coverage and partial/unsupported surfacing
- [x] All 209 existing tests pass
- [x] mypy clean
- [x] ruff check + format clean

Closes #91