### PR TITLE
fix: separate artifact delivery warnings from status escalation

### DIFF
--- a/src/analyst_toolkit/mcp_server/tools/imputation.py
+++ b/src/analyst_toolkit/mcp_server/tools/imputation.py
@@ -141,11 +141,13 @@ async def _toolkit_imputation(
     xlsx_delivery: dict[str, Any] = empty_delivery_state()
     plot_delivery: dict[str, dict] = {}
 
-    warnings: list = []
-    warnings.extend(lifecycle["warnings"])
-    warnings.extend(runtime_warnings)
-    warnings.extend(runtime_meta["runtime_warnings"])
-    warnings.extend(export_delivery["warnings"])
+    status_warnings: list = []
+    status_warnings.extend(lifecycle["warnings"])
+    status_warnings.extend(runtime_warnings)
+    status_warnings.extend(runtime_meta["runtime_warnings"])
+    status_warnings.extend(export_delivery["warnings"])
+
+    artifact_warnings: list = []
 
     if should_export_html(config):
         artifact_path = f"exports/reports/imputation/{run_id}_imputation_report.html"
@@ -158,7 +160,7 @@ async def _toolkit_imputation(
         )
         artifact_path = artifact_delivery["local_path"]
         artifact_url = artifact_delivery["url"]
-        warnings.extend(artifact_delivery["warnings"])
+        artifact_warnings.extend(artifact_delivery["warnings"])
 
         xlsx_path = f"exports/reports/imputation/{run_id}_imputation_report.xlsx"
         xlsx_delivery = deliver_artifact(
@@ -169,7 +171,7 @@ async def _toolkit_imputation(
             session_id=session_id,
         )
         xlsx_url = xlsx_delivery["url"]
-        warnings.extend(xlsx_delivery["warnings"])
+        artifact_warnings.extend(xlsx_delivery["warnings"])
 
         # Upload plots - search both root and run_id subdir
         plot_dirs = [
@@ -187,7 +189,7 @@ async def _toolkit_imputation(
                         session_id=session_id,
                     )
                     plot_delivery[plot_file.name] = delivered
-                    warnings.extend(delivered["warnings"])
+                    artifact_warnings.extend(delivered["warnings"])
                     if delivered["url"]:
                         plot_urls[plot_file.name] = delivered["url"]
 
@@ -208,8 +210,9 @@ async def _toolkit_imputation(
         required_html=False,
         probe_local_paths=True,
     )
-    warnings.extend(artifact_contract["artifact_warnings"])
-    base_status = "warn" if warnings else "pass"
+    artifact_warnings.extend(artifact_contract["artifact_warnings"])
+    warnings = status_warnings + artifact_warnings
+    base_status = "warn" if status_warnings else "pass"
     status = fold_status_with_artifacts(
         base_status, artifact_contract["missing_required_artifacts"]
     )

--- a/src/analyst_toolkit/mcp_server/tools/normalization.py
+++ b/src/analyst_toolkit/mcp_server/tools/normalization.py
@@ -131,11 +131,16 @@ async def _toolkit_normalization(
     artifact_delivery: dict[str, Any] = empty_delivery_state()
     xlsx_delivery: dict[str, Any] = empty_delivery_state()
 
-    warnings: list = []
-    warnings.extend(lifecycle["warnings"])
-    warnings.extend(runtime_warnings)
-    warnings.extend(runtime_meta["runtime_warnings"])
-    warnings.extend(export_delivery["warnings"])
+    status_warnings: list = []
+    status_warnings.extend(lifecycle["warnings"])
+    status_warnings.extend(runtime_warnings)
+    status_warnings.extend(runtime_meta["runtime_warnings"])
+    status_warnings.extend(export_delivery["warnings"])
+
+    # Artifact delivery warnings are informational — collected separately so they
+    # appear in the response but do not escalate base_status when the artifacts
+    # are non-required.
+    artifact_warnings: list = []
 
     if should_export_html(config):
         artifact_path = f"exports/reports/normalization/{run_id}_normalization_report.html"
@@ -148,7 +153,7 @@ async def _toolkit_normalization(
         )
         artifact_path = artifact_delivery["local_path"]
         artifact_url = artifact_delivery["url"]
-        warnings.extend(artifact_delivery["warnings"])
+        artifact_warnings.extend(artifact_delivery["warnings"])
 
         xlsx_path = f"exports/reports/normalization/{run_id}_normalization_report.xlsx"
         xlsx_delivery = deliver_artifact(
@@ -159,7 +164,7 @@ async def _toolkit_normalization(
             session_id=session_id,
         )
         xlsx_url = xlsx_delivery["url"]
-        warnings.extend(xlsx_delivery["warnings"])
+        artifact_warnings.extend(xlsx_delivery["warnings"])
 
     artifact_contract = build_artifact_contract(
         export_url,
@@ -173,8 +178,9 @@ async def _toolkit_normalization(
         required_html=False,
         probe_local_paths=True,
     )
-    warnings.extend(artifact_contract["artifact_warnings"])
-    base_status = "warn" if warnings else "pass"
+    artifact_warnings.extend(artifact_contract["artifact_warnings"])
+    warnings = status_warnings + artifact_warnings
+    base_status = "warn" if status_warnings else "pass"
     status = fold_status_with_artifacts(
         base_status, artifact_contract["missing_required_artifacts"]
     )

--- a/src/analyst_toolkit/mcp_server/tools/outliers.py
+++ b/src/analyst_toolkit/mcp_server/tools/outliers.py
@@ -132,11 +132,13 @@ async def _toolkit_outliers(
     artifact_delivery: dict[str, Any] = empty_delivery_state()
     xlsx_delivery: dict[str, Any] = empty_delivery_state()
     plot_delivery: dict[str, dict] = {}
-    warnings: list = []
-    warnings.extend(lifecycle["warnings"])
-    warnings.extend(runtime_warnings)
-    warnings.extend(runtime_meta["runtime_warnings"])
-    warnings.extend(export_delivery["warnings"])
+    status_warnings: list = []
+    status_warnings.extend(lifecycle["warnings"])
+    status_warnings.extend(runtime_warnings)
+    status_warnings.extend(runtime_meta["runtime_warnings"])
+    status_warnings.extend(export_delivery["warnings"])
+
+    artifact_warnings: list = []
     if should_export_html(config):
         # Path where the pipeline runner saves its report
         artifact_path = f"exports/reports/outliers/detection/{run_id}_outlier_report.html"
@@ -149,7 +151,7 @@ async def _toolkit_outliers(
         )
         artifact_path = artifact_delivery["local_path"]
         artifact_url = artifact_delivery["url"]
-        warnings.extend(artifact_delivery["warnings"])
+        artifact_warnings.extend(artifact_delivery["warnings"])
 
         xlsx_path = f"exports/reports/outliers/detection/{run_id}_outlier_report.xlsx"
         xlsx_delivery = deliver_artifact(
@@ -160,7 +162,7 @@ async def _toolkit_outliers(
             session_id=session_id,
         )
         xlsx_url = xlsx_delivery["url"]
-        warnings.extend(xlsx_delivery["warnings"])
+        artifact_warnings.extend(xlsx_delivery["warnings"])
 
         # Upload plots - search both root and run_id subdir
         plot_dirs = [
@@ -178,7 +180,7 @@ async def _toolkit_outliers(
                         session_id=session_id,
                     )
                     plot_delivery[plot_file.name] = delivered
-                    warnings.extend(delivered["warnings"])
+                    artifact_warnings.extend(delivered["warnings"])
                     if delivered["url"]:
                         plot_urls[plot_file.name] = delivered["url"]
 
@@ -199,9 +201,10 @@ async def _toolkit_outliers(
         required_html=False,
         probe_local_paths=True,
     )
-    warnings.extend(artifact_contract["artifact_warnings"])
+    artifact_warnings.extend(artifact_contract["artifact_warnings"])
+    warnings = status_warnings + artifact_warnings
     base_status = "pass" if outlier_count == 0 else "warn"
-    if warnings and base_status == "pass":
+    if status_warnings and base_status == "pass":
         base_status = "warn"
     status = fold_status_with_artifacts(
         base_status, artifact_contract["missing_required_artifacts"]

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -933,12 +933,16 @@ async def test_normalization_reports_artifact_contract(mocker):
         config={},
     )
 
+    # Artifact delivery warnings are informational and do not escalate status
+    assert result["status"] == "pass"
     assert "artifact_matrix" in result
     assert "html_report" in result["artifact_matrix"]
     # HTML/XLSX are expected but not required — missing ones do not force warn
     assert "html_report" not in result["missing_required_artifacts"]
     assert "xlsx_report" in result["artifact_matrix"]
     assert result["artifact_matrix"]["xlsx_report"]["status"] == "missing"
+    # Delivery warnings still appear in the response for client visibility
+    assert any("Upload failed" in w for w in result["warnings"])
     assert (
         result["dashboard_path"]
         == "exports/reports/normalization/norm_artifact_contract_normalization_report.html"


### PR DESCRIPTION
## Summary
- Artifact delivery warnings from non-required HTML/XLSX/plot files were being folded into the main `warnings` list, triggering `base_status = "warn"` even when data processing completed successfully
- Splits warnings into `status_warnings` (lifecycle, runtime, export delivery) and `artifact_warnings` (report routing for optional artifacts)
- Only `status_warnings` affect `base_status`; both appear in the response for client visibility
- Affects normalization, imputation, and outliers tools

## Root cause
PR #94 made HTML/XLSX `required_html=False`, preventing `missing_required_artifacts` from escalating status. But `deliver_artifact()` returns warnings like `"Artifact not found for routing: ..."` when report files don't exist, and those were still triggering `base_status = "warn" if warnings else "pass"`.

## Test plan
- [x] 212 tests pass
- [x] Existing normalization artifact contract test updated to assert `status == "pass"` and confirm delivery warnings still present in response
- [x] mypy, ruff check, ruff format clean

Follow-up to #92 / PR #94