### PR TITLE
fix: preserve certification as distinct module in infer_configs

### DIFF
--- a/src/analyst_toolkit/mcp_server/tools/infer_configs.py
+++ b/src/analyst_toolkit/mcp_server/tools/infer_configs.py
@@ -18,6 +18,7 @@ from analyst_toolkit.mcp_server.schemas import INPUT_ID_PROP
 _SUPPORTED_INFER_MODULES = {
     "diagnostics",
     "validation",
+    "certification",
     "normalization",
     "duplicates",
     "outliers",
@@ -30,7 +31,6 @@ _INFER_MODULE_ALIASES = {
     "duplicate": "duplicates",
     "outlier": "outliers",
     "handling": "outliers",
-    "certification": "final_audit",
 }
 
 
@@ -271,6 +271,7 @@ async def _toolkit_infer_configs(
         "outliers",
         "imputation",
         "validation",
+        "certification",
         "final_audit",
     ]
     apply_actions = [
@@ -306,8 +307,11 @@ async def _toolkit_infer_configs(
         next_steps = apply_actions + [capability_action]
 
     covered_modules = sorted(configs.keys())
-    requested_modules = sorted(set(modules)) if modules else sorted(_SUPPORTED_INFER_MODULES)
-    unsupported_modules = sorted(set(requested_modules) - set(covered_modules))
+    if modules:
+        normalized_requested = {_INFER_MODULE_ALIASES.get(m, m) for m in modules}
+    else:
+        normalized_requested = set(_SUPPORTED_INFER_MODULES)
+    unsupported_modules = sorted(normalized_requested - set(covered_modules))
     if unsupported_modules:
         external_warnings.append(
             f"Configs were not generated for: {', '.join(unsupported_modules)}."

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -451,8 +451,9 @@ async def test_toolkit_infer_configs_normalizes_dict_module_aliases(monkeypatch,
 
     def fake_infer_configs(**kwargs):
         return {
-            "certification": "final_audit:\n  summary:\n    run: true\n",
+            "certification": "validation:\n  schema_validation:\n    run: true\n",
             "outlier": "outlier_detection:\n  run: true\n",
+            "dups": "duplicates:\n  subset: []\n",
         }
 
     infer_mod = types.ModuleType("analyst_toolkit_deploy.infer_configs")
@@ -464,13 +465,17 @@ async def test_toolkit_infer_configs_normalizes_dict_module_aliases(monkeypatch,
 
     result = await infer_configs_tool._toolkit_infer_configs(
         session_id="sess_alias_dict",
-        modules=["final_audit", "outliers"],
+        modules=["certification", "outliers", "duplicates"],
     )
 
     assert result["status"] == "pass"
-    assert "final_audit" in result["configs"]
+    # certification is its own supported module, not aliased
+    assert "certification" in result["configs"]
+    # outlier → outliers alias still works
     assert "outliers" in result["configs"]
-    assert result["warnings"] == []
+    # dups → duplicates alias still works
+    assert "duplicates" in result["configs"]
+    assert result["unsupported_modules"] == []
 
 
 @pytest.mark.asyncio
@@ -820,6 +825,7 @@ async def test_infer_configs_surfaces_covered_and_unsupported_modules(monkeypatc
     assert "covered_modules" in result
     assert "unsupported_modules" in result
     assert set(result["covered_modules"]) == {
+        "certification",
         "diagnostics",
         "duplicates",
         "final_audit",
@@ -858,6 +864,36 @@ async def test_infer_configs_reports_unsupported_when_partial(monkeypatch, mocke
     assert result["covered_modules"] == ["outliers", "validation"]
     assert result["unsupported_modules"] == ["normalization"]
     assert any("not generated for" in w for w in result["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_infer_configs_aliased_requests_resolve_before_unsupported_check(monkeypatch, mocker):
+    """Requesting 'handling' (alias for outliers) should not appear unsupported."""
+    df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
+    mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
+
+    def fake_infer_configs(**kwargs):
+        return {
+            "outliers": "outlier_detection:\n  run: true\n",
+            "certification": "validation:\n  schema_validation:\n    run: true\n",
+        }
+
+    infer_mod = types.ModuleType("analyst_toolkit_deploy.infer_configs")
+    setattr(infer_mod, "infer_configs", fake_infer_configs)
+    pkg_mod = types.ModuleType("analyst_toolkit_deploy")
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy", pkg_mod)
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy.infer_configs", infer_mod)
+
+    result = await infer_configs_tool._toolkit_infer_configs(
+        session_id="sess_alias_req",
+        modules=["handling", "certification"],
+    )
+
+    assert result["status"] == "pass"
+    assert "certification" in result["configs"]
+    assert "outliers" in result["configs"]
+    # handling resolves to outliers, certification is its own module — neither unsupported
+    assert result["unsupported_modules"] == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- The external `infer_configs` helper returns both `certification` (strict validation rules with `fail_on_error: true`) and `final_audit` (audit orchestration config) as separate keys with different content
- The alias `certification → final_audit` was collapsing both into the same key, causing whichever was iterated last to overwrite the other — losing the certification rules that `final_audit` needs for its `rule_contract_missing` check
- Also fixes `unsupported_modules` reporting: requested module names are now normalized through the alias map before comparison, so aliases like `handling` no longer appear as "unsupported"

## Root cause
Dict iteration order meant `final_audit` (the audit config) overwrote `certification` (the rules config) when both mapped to `final_audit`. This caused downstream `final_audit` calls to fail with `rule_contract_missing` because the actual certification rules were silently lost.

## Changes
- Add `certification` to `_SUPPORTED_INFER_MODULES` as its own module
- Remove the `certification → final_audit` alias
- Normalize requested module names through `_INFER_MODULE_ALIASES` before comparing to `covered_modules`
- Add `certification` to `module_order` for next_actions

## Test plan
- [x] 213 tests pass (1 updated, 1 new)
- [x] mypy, ruff check, ruff format clean

Related to #97