### PR TITLE
docs: enumerate all MCP environment variables in .envrc.example

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -21,6 +21,23 @@ export ANALYST_REPORT_BUCKET=gs://your-bucket-name
 # Reports land at: {bucket}/{prefix}/{session_ts}/{run_id}/{module}/
 export ANALYST_REPORT_PREFIX=analyst_toolkit/reports
 
+# --- MCP Server ---
+# Port and host for the HTTP MCP server.
+# export ANALYST_MCP_PORT=8001
+# export ANALYST_MCP_HOST=127.0.0.1
+
+# Run in stdio mode instead of HTTP (used by MCP clients like Claude Desktop).
+# export ANALYST_MCP_STDIO=true
+
+# Bearer token for HTTP mode authentication. Leave unset to disable auth.
+# export ANALYST_MCP_AUTH_TOKEN=
+
+# Emit structured JSON logs instead of plain text.
+# export ANALYST_MCP_STRUCTURED_LOGS=false
+
+# Fallback version string when package metadata is unavailable.
+# export ANALYST_MCP_VERSION_FALLBACK=0.0.0+local
+
 # --- MCP Resource/Template Timeout Guards ---
 # Timeout (seconds) for resources/list and resources/read filesystem operations.
 export ANALYST_MCP_RESOURCE_TIMEOUT_SEC=8
@@ -31,3 +48,68 @@ export ANALYST_MCP_ADVERTISE_RESOURCE_TEMPLATES=false
 
 # Timeout (seconds) for cockpit template loading calls.
 export ANALYST_MCP_TEMPLATE_IO_TIMEOUT_SEC=8
+
+# --- MCP Cockpit & History ---
+# Enable the cockpit dashboard and run history tools.
+# Defaults to the value of ANALYST_MCP_STDIO (true in stdio mode, false in HTTP).
+# export ANALYST_MCP_ENABLE_TRUSTED_HISTORY_TOOL=false
+
+# Default summary_only flag for run history queries.
+# export ANALYST_MCP_RUN_HISTORY_SUMMARY_ONLY_DEFAULT=true
+
+# Default limit for run history queries.
+# export ANALYST_MCP_RUN_HISTORY_DEFAULT_LIMIT=50
+
+# --- MCP Local Artifact Server ---
+# Serve report artifacts over a local HTTP endpoint for MCP clients.
+# export ANALYST_MCP_ENABLE_ARTIFACT_SERVER=false
+
+# Enable the artifact server control tool (start/stop/status).
+# Defaults to the value of ANALYST_MCP_STDIO.
+# export ANALYST_MCP_ENABLE_ARTIFACT_SERVER_TOOL=false
+
+# Host and port for the local artifact server.
+# export ANALYST_MCP_ARTIFACT_SERVER_HOST=127.0.0.1
+# export ANALYST_MCP_ARTIFACT_SERVER_PORT=8765
+
+# Root directory to serve artifacts from.
+# export ANALYST_MCP_ARTIFACT_SERVER_ROOT=exports
+
+# Allow binding to 0.0.0.0 (remote access). Default false restricts to localhost.
+# export ANALYST_MCP_ALLOW_BIND_ALL=false
+
+# --- MCP Artifact Routing ---
+# Base directory for local artifact output (used by deliver_artifact and local probe).
+# export ANALYST_MCP_LOCAL_OUTPUT_BASE=.
+
+# --- MCP Run Identity ---
+# Allow overriding a session-bound run_id with a different value.
+# export ANALYST_MCP_ALLOW_RUN_ID_OVERRIDE=false
+
+# Deduplicate repeated run_id coercion warnings within a session.
+# export ANALYST_MCP_DEDUP_RUN_ID_WARNINGS=true
+
+# --- MCP Final Audit ---
+# Allow final_audit to pass with empty certification rules.
+# Default false enforces fail-closed posture.
+# export ANALYST_MCP_ALLOW_EMPTY_CERT_RULES=false
+
+# --- MCP Input Registry ---
+# Maximum number of registered inputs to keep in memory.
+# export ANALYST_MCP_INPUT_REGISTRY_MAX_ENTRIES=512
+
+# TTL (seconds) for registered inputs before eviction.
+# export ANALYST_MCP_INPUT_REGISTRY_TTL_SEC=21600
+
+# Maximum upload size (bytes) for inline input ingestion.
+# export ANALYST_MCP_MAX_UPLOAD_BYTES=52428800
+
+# Root directory for persisted input files.
+# export ANALYST_MCP_INPUT_ROOT=
+
+# Comma-separated list of allowed filesystem roots for input resolution.
+# export ANALYST_MCP_ALLOWED_INPUT_ROOTS=
+
+# --- MCP Job State ---
+# Path to the job state persistence file for async auto_heal jobs.
+# export ANALYST_MCP_JOB_STATE_PATH=

--- a/docker-compose.mcp.yml
+++ b/docker-compose.mcp.yml
@@ -4,17 +4,15 @@
 #   docker compose -f docker-compose.mcp.yml up --build
 #
 # Environment:
-#   ANALYST_MCP_PORT               — override default port 8001 (optional)
-#   ANALYST_REPORT_BUCKET          — GCS bucket for HTML report upload, e.g. gs://data-reporting
-#                                    If unset, reports are written to ./exports only (local dev)
-#   ANALYST_REPORT_PREFIX          — blob path prefix, default "analyst_toolkit/reports"
-#                                    Reports land at: {bucket}/{prefix}/{run_id}/{module}/{filename}
-#   ANALYST_MCP_ADVERTISE_RESOURCE_TEMPLATES
-#                                  — if true, resources/templates/list returns URI templates
-#                                    (default false to avoid duplicate resource/template listings in some clients)
-#   GCP_CREDS_PATH                 — path to GCS service account key on host (optional)
-#                                    e.g. export GCP_CREDS_PATH=~/.secrets/analyst-toolkit-mcp.json
-#                                    If unset, GCS upload is disabled (local-only mode)
+#   All ANALYST_* variables are read from your shell or .envrc.
+#   See .envrc.example for the full list with descriptions.
+#
+#   Key variables:
+#     GCP_CREDS_PATH                 — path to GCS service account key on host
+#     ANALYST_REPORT_BUCKET          — GCS bucket for report upload (e.g. gs://data-reporting)
+#     ANALYST_MCP_PORT               — override default port 8001
+#     ANALYST_MCP_ENABLE_TRUSTED_HISTORY_TOOL — enable cockpit/history tools
+#     ANALYST_MCP_ENABLE_ARTIFACT_SERVER      — serve reports over local HTTP
 #
 # fridai-core integration:
 #   Set FRIDAI_ANALYST_MCP_ENABLED=true and FRIDAI_ANALYST_MCP_URL=http://127.0.0.1:8001
@@ -28,14 +26,42 @@ services:
     ports:
       - "${ANALYST_MCP_PORT:-8001}:8001"
     environment:
+      # --- Server ---
       - ANALYST_MCP_PORT=${ANALYST_MCP_PORT:-8001}
       - ANALYST_MCP_HOST=0.0.0.0
-      # GCS auth — only set if GCP_CREDS_PATH is provided
+      - ANALYST_MCP_AUTH_TOKEN=${ANALYST_MCP_AUTH_TOKEN:-}
+      - ANALYST_MCP_STRUCTURED_LOGS=${ANALYST_MCP_STRUCTURED_LOGS:-false}
+      # --- GCS auth ---
       - GOOGLE_APPLICATION_CREDENTIALS=${GCP_CREDS_PATH:+/run/secrets/gcp_creds}
-      # Report upload — set ANALYST_REPORT_BUCKET to enable GCS upload of HTML reports
+      # --- Report output ---
       - ANALYST_REPORT_BUCKET=${ANALYST_REPORT_BUCKET:-}
       - ANALYST_REPORT_PREFIX=${ANALYST_REPORT_PREFIX:-analyst_toolkit/reports}
+      # --- Resources/Templates ---
+      - ANALYST_MCP_RESOURCE_TIMEOUT_SEC=${ANALYST_MCP_RESOURCE_TIMEOUT_SEC:-8}
       - ANALYST_MCP_ADVERTISE_RESOURCE_TEMPLATES=${ANALYST_MCP_ADVERTISE_RESOURCE_TEMPLATES:-false}
+      - ANALYST_MCP_TEMPLATE_IO_TIMEOUT_SEC=${ANALYST_MCP_TEMPLATE_IO_TIMEOUT_SEC:-8}
+      # --- Cockpit & History ---
+      - ANALYST_MCP_ENABLE_TRUSTED_HISTORY_TOOL=${ANALYST_MCP_ENABLE_TRUSTED_HISTORY_TOOL:-false}
+      - ANALYST_MCP_RUN_HISTORY_SUMMARY_ONLY_DEFAULT=${ANALYST_MCP_RUN_HISTORY_SUMMARY_ONLY_DEFAULT:-true}
+      - ANALYST_MCP_RUN_HISTORY_DEFAULT_LIMIT=${ANALYST_MCP_RUN_HISTORY_DEFAULT_LIMIT:-50}
+      # --- Local Artifact Server ---
+      - ANALYST_MCP_ENABLE_ARTIFACT_SERVER=${ANALYST_MCP_ENABLE_ARTIFACT_SERVER:-false}
+      - ANALYST_MCP_ENABLE_ARTIFACT_SERVER_TOOL=${ANALYST_MCP_ENABLE_ARTIFACT_SERVER_TOOL:-false}
+      - ANALYST_MCP_ARTIFACT_SERVER_HOST=${ANALYST_MCP_ARTIFACT_SERVER_HOST:-127.0.0.1}
+      - ANALYST_MCP_ARTIFACT_SERVER_PORT=${ANALYST_MCP_ARTIFACT_SERVER_PORT:-8765}
+      - ANALYST_MCP_ARTIFACT_SERVER_ROOT=${ANALYST_MCP_ARTIFACT_SERVER_ROOT:-exports}
+      - ANALYST_MCP_ALLOW_BIND_ALL=${ANALYST_MCP_ALLOW_BIND_ALL:-false}
+      # --- Artifact Routing ---
+      - ANALYST_MCP_LOCAL_OUTPUT_BASE=${ANALYST_MCP_LOCAL_OUTPUT_BASE:-.}
+      # --- Run Identity ---
+      - ANALYST_MCP_ALLOW_RUN_ID_OVERRIDE=${ANALYST_MCP_ALLOW_RUN_ID_OVERRIDE:-false}
+      - ANALYST_MCP_DEDUP_RUN_ID_WARNINGS=${ANALYST_MCP_DEDUP_RUN_ID_WARNINGS:-true}
+      # --- Final Audit ---
+      - ANALYST_MCP_ALLOW_EMPTY_CERT_RULES=${ANALYST_MCP_ALLOW_EMPTY_CERT_RULES:-false}
+      # --- Input Registry ---
+      - ANALYST_MCP_INPUT_REGISTRY_MAX_ENTRIES=${ANALYST_MCP_INPUT_REGISTRY_MAX_ENTRIES:-512}
+      - ANALYST_MCP_INPUT_REGISTRY_TTL_SEC=${ANALYST_MCP_INPUT_REGISTRY_TTL_SEC:-21600}
+      - ANALYST_MCP_MAX_UPLOAD_BYTES=${ANALYST_MCP_MAX_UPLOAD_BYTES:-52428800}
     volumes:
       # Mount GCS service account key — requires GCP_CREDS_PATH to be set in shell/.envrc
       - ${GCP_CREDS_PATH:-/dev/null}:/run/secrets/gcp_creds:ro


### PR DESCRIPTION
## Summary
Adds every `ANALYST_MCP_*` and `ANALYST_REPORT_*` env variable to `.envrc.example`, grouped by concern with descriptions and defaults.

## Variables added
- **Server**: PORT, HOST, STDIO, AUTH_TOKEN, STRUCTURED_LOGS, VERSION_FALLBACK
- **Cockpit/History**: ENABLE_TRUSTED_HISTORY_TOOL, RUN_HISTORY_SUMMARY_ONLY_DEFAULT, RUN_HISTORY_DEFAULT_LIMIT
- **Artifact Server**: ENABLE_ARTIFACT_SERVER, ENABLE_ARTIFACT_SERVER_TOOL, ARTIFACT_SERVER_HOST/PORT/ROOT, ALLOW_BIND_ALL
- **Artifact Routing**: LOCAL_OUTPUT_BASE
- **Run Identity**: ALLOW_RUN_ID_OVERRIDE, DEDUP_RUN_ID_WARNINGS
- **Final Audit**: ALLOW_EMPTY_CERT_RULES
- **Input Registry**: INPUT_REGISTRY_MAX_ENTRIES, INPUT_REGISTRY_TTL_SEC, MAX_UPLOAD_BYTES, INPUT_ROOT, ALLOWED_INPUT_ROOTS
- **Job State**: JOB_STATE_PATH