### PR TITLE
fix: auto-discover inferred certification config in final_audit

### DIFF
--- a/src/analyst_toolkit/mcp_server/io.py
+++ b/src/analyst_toolkit/mcp_server/io.py
@@ -217,6 +217,16 @@ def save_to_session(
     return StateStore.save(df, session_id, run_id=run_id)
 
 
+def save_session_config(session_id: str, module: str, config_yaml: str) -> None:
+    """Persist an inferred config YAML string for a module in session scope."""
+    StateStore.save_config(session_id, module, config_yaml)
+
+
+def get_session_config(session_id: str, module: str) -> Optional[str]:
+    """Retrieve a previously stored inferred config for a module."""
+    return StateStore.get_config(session_id, module)
+
+
 def get_session_run_id(session_id: str) -> Optional[str]:
     return StateStore.get_run_id(session_id)
 

--- a/src/analyst_toolkit/mcp_server/state.py
+++ b/src/analyst_toolkit/mcp_server/state.py
@@ -28,6 +28,7 @@ class StateStore:
     _last_accessed: Dict[str, float] = {}
     _session_run_ids: Dict[str, str] = {}
     _session_start_times: Dict[str, str] = {}
+    _session_configs: Dict[str, Dict[str, str]] = {}
 
     @classmethod
     def save(
@@ -83,6 +84,26 @@ class StateStore:
             return cls._metadata.get(session_id)
 
     @classmethod
+    def save_config(cls, session_id: str, module: str, config_yaml: str) -> None:
+        """Store an inferred config YAML string for a module in session scope."""
+        with cls._lock:
+            if session_id not in cls._session_configs:
+                cls._session_configs[session_id] = {}
+            cls._session_configs[session_id][module] = config_yaml
+
+    @classmethod
+    def get_config(cls, session_id: str, module: str) -> Optional[str]:
+        """Retrieve a previously stored inferred config for a module."""
+        with cls._lock:
+            return cls._session_configs.get(session_id, {}).get(module)
+
+    @classmethod
+    def get_configs(cls, session_id: str) -> Dict[str, str]:
+        """Retrieve all stored inferred configs for a session."""
+        with cls._lock:
+            return dict(cls._session_configs.get(session_id, {}))
+
+    @classmethod
     def list_sessions(cls) -> Dict[str, dict]:
         """List available sessions and their metadata."""
         with cls._lock:
@@ -103,6 +124,7 @@ class StateStore:
             cls._last_accessed.pop(sid, None)
             cls._session_run_ids.pop(sid, None)
             cls._session_start_times.pop(sid, None)
+            cls._session_configs.pop(sid, None)
             logger.info(f"Evicted expired session {sid} (TTL reached)")
 
     @classmethod
@@ -121,9 +143,11 @@ class StateStore:
                 cls._last_accessed.pop(session_id, None)
                 cls._session_run_ids.pop(session_id, None)
                 cls._session_start_times.pop(session_id, None)
+                cls._session_configs.pop(session_id, None)
             else:
                 cls._sessions.clear()
                 cls._metadata.clear()
                 cls._last_accessed.clear()
                 cls._session_run_ids.clear()
                 cls._session_start_times.clear()
+                cls._session_configs.clear()

--- a/src/analyst_toolkit/mcp_server/tools/final_audit.py
+++ b/src/analyst_toolkit/mcp_server/tools/final_audit.py
@@ -1,8 +1,11 @@
 """MCP tool: toolkit_final_audit — final certification and big HTML report via M10."""
 
+import logging
 import os
 import tempfile
 from typing import Any
+
+import yaml
 
 from analyst_toolkit.m02_validation.validate_data import run_validation_suite
 from analyst_toolkit.m10_final_audit.final_audit_pipeline import (
@@ -19,6 +22,7 @@ from analyst_toolkit.mcp_server.io import (
     empty_delivery_state,
     fold_status_with_artifacts,
     generate_default_export_path,
+    get_session_config,
     get_session_metadata,
     load_input,
     make_json_safe,
@@ -86,7 +90,37 @@ async def _toolkit_final_audit(
     run_id, lifecycle = resolve_run_context(run_id, session_id)
 
     config = coerce_config(config, "final_audit")
+
+    # Auto-discover inferred configs from session when no explicit config is provided
+    inferred_config: dict = {}
+    if session_id:
+        for config_key in ("final_audit", "certification"):
+            raw_yaml = get_session_config(session_id, config_key)
+            if not raw_yaml:
+                continue
+            try:
+                parsed = yaml.safe_load(raw_yaml)
+            except yaml.YAMLError:
+                logging.getLogger(__name__).warning(
+                    "Failed to parse inferred %s config from session %s",
+                    config_key,
+                    session_id,
+                )
+                continue
+            if not isinstance(parsed, dict):
+                continue
+            # Unwrap module-level key so the structure matches provided config
+            if "final_audit" in parsed and isinstance(parsed["final_audit"], dict):
+                parsed = parsed["final_audit"]
+            # Merge each discovered config layer (final_audit first, certification second)
+            for key, value in parsed.items():
+                if isinstance(value, dict) and isinstance(inferred_config.get(key), dict):
+                    inferred_config[key] = {**inferred_config[key], **value}
+                else:
+                    inferred_config.setdefault(key, value)
+
     config, runtime_meta = resolve_layered_config(
+        inferred=inferred_config,
         provided=config,
         explicit=runtime_to_config_overlay(runtime_cfg),
     )

--- a/src/analyst_toolkit/mcp_server/tools/infer_configs.py
+++ b/src/analyst_toolkit/mcp_server/tools/infer_configs.py
@@ -7,7 +7,12 @@ from pathlib import Path
 
 import yaml
 
-from analyst_toolkit.mcp_server.io import load_input, resolve_run_context, save_to_session
+from analyst_toolkit.mcp_server.io import (
+    load_input,
+    resolve_run_context,
+    save_session_config,
+    save_to_session,
+)
 from analyst_toolkit.mcp_server.response_utils import next_action, with_next_actions
 from analyst_toolkit.mcp_server.runtime_overlay import (
     normalize_runtime_overlay,
@@ -272,6 +277,10 @@ async def _toolkit_infer_configs(
     finally:
         if temp_file:
             os.unlink(temp_file.name)
+
+    # Persist inferred configs to session so downstream tools can auto-discover them
+    for module_name, config_yaml in configs.items():
+        save_session_config(session_id, module_name, config_yaml)
 
     module_order = [
         "diagnostics",

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -1404,3 +1404,152 @@ async def test_auto_heal_returns_error_when_infer_configs_load_fails(monkeypatch
 
     assert result["status"] == "error"
     assert result["error_code"] == "INPUT_LOAD_FAILED"
+
+
+@pytest.mark.asyncio
+async def test_infer_configs_persists_configs_to_session(monkeypatch, mocker):
+    """infer_configs should store inferred configs in StateStore for downstream tools."""
+    df = pd.DataFrame({"id": [1, 2], "value": ["a", "b"]})
+    StateStore.clear()
+
+    mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
+
+    def fake_infer_configs(**kwargs):
+        return {
+            "final_audit": "final_audit:\n  certification:\n    schema_validation:\n      rules:\n        expected_columns: [id, value]\n",
+            "certification": "validation:\n  schema_validation:\n    rules:\n      expected_columns: [id, value]\n",
+        }
+
+    infer_mod = types.ModuleType("analyst_toolkit_deploy.infer_configs")
+    setattr(infer_mod, "infer_configs", fake_infer_configs)
+    pkg_mod = types.ModuleType("analyst_toolkit_deploy")
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy", pkg_mod)
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy.infer_configs", infer_mod)
+
+    result = await infer_configs_tool._toolkit_infer_configs(
+        session_id="sess_persist_test",
+        run_id="persist_run",
+    )
+
+    assert result["status"] == "pass"
+
+    # Configs should now be persisted in StateStore
+    stored_fa = StateStore.get_config("sess_persist_test", "final_audit")
+    stored_cert = StateStore.get_config("sess_persist_test", "certification")
+    assert stored_fa is not None
+    assert "expected_columns" in stored_fa
+    assert stored_cert is not None
+    StateStore.clear()
+
+
+@pytest.mark.asyncio
+async def test_final_audit_auto_discovers_inferred_cert_config(mocker, monkeypatch):
+    """final_audit should use inferred certification config from session when none provided."""
+    df = pd.DataFrame({"id": [1, 2], "value": ["a", "b"]})
+    StateStore.clear()
+
+    # Pre-populate session with inferred certification config
+    session_id = StateStore.save(df, run_id="fa_inferred_run")
+    StateStore.save_config(
+        session_id,
+        "final_audit",
+        "final_audit:\n  certification:\n    schema_validation:\n      rules:\n        expected_columns:\n          - id\n          - value\n",
+    )
+
+    mocker.patch.object(final_audit_tool, "load_input", return_value=df)
+    mocker.patch.object(final_audit_tool, "run_final_audit_pipeline", return_value=df)
+    mocker.patch.object(final_audit_tool, "save_to_session", return_value=session_id)
+    mocker.patch.object(final_audit_tool, "get_session_metadata", return_value={"row_count": 2})
+    mocker.patch.object(final_audit_tool, "save_output", return_value="gs://dummy/out.csv")
+    mocker.patch.object(
+        final_audit_tool,
+        "deliver_artifact",
+        side_effect=lambda local_path, *args, **kwargs: {
+            "reference": "",
+            "local_path": local_path,
+            "url": "https://example.com/a",
+            "warnings": [],
+            "destinations": {},
+        },
+    )
+    mocker.patch.object(final_audit_tool, "append_to_run_history", return_value=None)
+    mocker.patch.object(
+        final_audit_tool,
+        "run_validation_suite",
+        return_value={"schema_conformity": {"passed": True, "details": {}}},
+    )
+    monkeypatch.setattr(final_audit_tool, "ALLOW_EMPTY_CERT_RULES", False)
+
+    result = await final_audit_tool._toolkit_final_audit(
+        session_id=session_id,
+        run_id="fa_inferred_run",
+        config={},  # No explicit config — should auto-discover from session
+    )
+
+    # With inferred rules discovered, should NOT fail with rule_contract_missing
+    assert "rule_contract_missing" not in result.get("violations_found", [])
+    # The effective config should contain the inferred certification rules
+    cert_cfg = result["effective_config"].get("certification", {})
+    schema_cfg = cert_cfg.get("schema_validation", {})
+    rules = schema_cfg.get("rules", {})
+    assert rules.get("expected_columns") == ["id", "value"]
+    StateStore.clear()
+
+
+@pytest.mark.asyncio
+async def test_final_audit_explicit_config_overrides_inferred(mocker, monkeypatch):
+    """Explicit config should take precedence over inferred session config."""
+    df = pd.DataFrame({"id": [1, 2], "value": ["a", "b"]})
+    StateStore.clear()
+
+    session_id = StateStore.save(df, run_id="fa_override_run")
+    # Store inferred config with expected_columns: [x, y]
+    StateStore.save_config(
+        session_id,
+        "final_audit",
+        "final_audit:\n  certification:\n    schema_validation:\n      rules:\n        expected_columns: [x, y]\n",
+    )
+
+    mocker.patch.object(final_audit_tool, "load_input", return_value=df)
+    mocker.patch.object(final_audit_tool, "run_final_audit_pipeline", return_value=df)
+    mocker.patch.object(final_audit_tool, "save_to_session", return_value=session_id)
+    mocker.patch.object(final_audit_tool, "get_session_metadata", return_value={"row_count": 2})
+    mocker.patch.object(final_audit_tool, "save_output", return_value="gs://dummy/out.csv")
+    mocker.patch.object(
+        final_audit_tool,
+        "deliver_artifact",
+        side_effect=lambda local_path, *args, **kwargs: {
+            "reference": "",
+            "local_path": local_path,
+            "url": "https://example.com/a",
+            "warnings": [],
+            "destinations": {},
+        },
+    )
+    mocker.patch.object(final_audit_tool, "append_to_run_history", return_value=None)
+    mocker.patch.object(
+        final_audit_tool,
+        "run_validation_suite",
+        return_value={"schema_conformity": {"passed": True, "details": {}}},
+    )
+    monkeypatch.setattr(final_audit_tool, "ALLOW_EMPTY_CERT_RULES", False)
+
+    # Explicit config with expected_columns: [id, value]
+    result = await final_audit_tool._toolkit_final_audit(
+        session_id=session_id,
+        run_id="fa_override_run",
+        config={
+            "certification": {
+                "schema_validation": {
+                    "rules": {"expected_columns": ["id", "value"]},
+                }
+            }
+        },
+    )
+
+    # Explicit config should win over inferred
+    cert_cfg = result["effective_config"].get("certification", {})
+    schema_cfg = cert_cfg.get("schema_validation", {})
+    rules = schema_cfg.get("rules", {})
+    assert rules.get("expected_columns") == ["id", "value"]
+    StateStore.clear()


### PR DESCRIPTION
## Summary
- Adds session-scoped config storage to `StateStore` (`save_config`/`get_config`/`get_configs`)
- `infer_configs` now persists all inferred module configs to the session after inference
- `final_audit` auto-discovers inferred `final_audit` and `certification` configs from the session when no explicit config is provided
- Uses the existing `inferred` layer in `resolve_layered_config`, so explicit configs always take precedence
- Session eviction and clear properly clean up stored configs

This means `final_audit` called with just a `session_id` (after `infer_configs` ran on that session) will automatically have certification rules populated instead of failing with `rule_contract_missing`.

## Test plan
- [x] `test_infer_configs_persists_configs_to_session` — verifies configs are stored in StateStore
- [x] `test_final_audit_auto_discovers_inferred_cert_config` — verifies auto-discovery prevents rule_contract_missing
- [x] `test_final_audit_explicit_config_overrides_inferred` — verifies explicit config takes precedence
- [x] Full regression suite passes (40/40)

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)