### PR TITLE
fix: resolve session from input_id for config discovery in final_audit

### DIFF
--- a/src/analyst_toolkit/mcp_server/tools/final_audit.py
+++ b/src/analyst_toolkit/mcp_server/tools/final_audit.py
@@ -12,6 +12,7 @@ from analyst_toolkit.m10_final_audit.final_audit_pipeline import (
     run_final_audit_pipeline,
 )
 from analyst_toolkit.mcp_server.config_normalizers import normalize_final_audit_config
+from analyst_toolkit.mcp_server.input.ingest import get_input_descriptor
 from analyst_toolkit.mcp_server.io import (
     ALLOW_EMPTY_CERT_RULES,
     append_to_run_history,
@@ -90,6 +91,12 @@ async def _toolkit_final_audit(
     run_id, lifecycle = resolve_run_context(run_id, session_id)
 
     config = coerce_config(config, "final_audit")
+
+    # Resolve session_id from input_id so config discovery can find inferred configs
+    if not session_id and input_id:
+        descriptor = get_input_descriptor(input_id)
+        if descriptor and descriptor.session_id:
+            session_id = descriptor.session_id
 
     # Auto-discover inferred configs from session when no explicit config is provided
     inferred_config: dict = {}

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -1684,3 +1684,79 @@ async def test_final_audit_strips_stale_inferred_paths(mocker, monkeypatch):
     # Certification rules should still be discovered
     assert "rule_contract_missing" not in result.get("violations_found", [])
     StateStore.clear()
+
+
+@pytest.mark.asyncio
+async def test_final_audit_resolves_session_from_input_id(mocker, monkeypatch):
+    """final_audit should discover inferred configs via input_id's session_id."""
+    from analyst_toolkit.mcp_server.input.models import InputDescriptor
+
+    df = pd.DataFrame({"id": [1, 2], "value": ["a", "b"]})
+    StateStore.clear()
+
+    # Pre-populate session with inferred certification config
+    session_id = StateStore.save(df, run_id="fa_input_id_run")
+    StateStore.save_config(
+        session_id,
+        "final_audit",
+        (
+            "final_audit:\n"
+            "  certification:\n"
+            "    schema_validation:\n"
+            "      rules:\n"
+            "        expected_columns:\n"
+            "          - id\n"
+            "          - value\n"
+        ),
+    )
+
+    # Mock input descriptor that points back to the session
+    descriptor = InputDescriptor(
+        input_id="input_test_resolve",
+        source_type="server_path",
+        original_reference="/tmp/test.csv",
+        resolved_reference="/tmp/test.csv",
+        display_name="test.csv",
+        media_type="text/csv",
+        session_id=session_id,
+        run_id="fa_input_id_run",
+    )
+    mocker.patch.object(final_audit_tool, "get_input_descriptor", return_value=descriptor)
+    mocker.patch.object(final_audit_tool, "load_input", return_value=df)
+    mocker.patch.object(final_audit_tool, "run_final_audit_pipeline", return_value=df)
+    mocker.patch.object(final_audit_tool, "save_to_session", return_value=session_id)
+    mocker.patch.object(final_audit_tool, "get_session_metadata", return_value={"row_count": 2})
+    mocker.patch.object(final_audit_tool, "save_output", return_value="gs://dummy/out.csv")
+    mocker.patch.object(
+        final_audit_tool,
+        "deliver_artifact",
+        side_effect=lambda local_path, *args, **kwargs: {
+            "reference": "",
+            "local_path": local_path,
+            "url": "https://example.com/a",
+            "warnings": [],
+            "destinations": {},
+        },
+    )
+    mocker.patch.object(final_audit_tool, "append_to_run_history", return_value=None)
+    mocker.patch.object(
+        final_audit_tool,
+        "run_validation_suite",
+        return_value={"schema_conformity": {"passed": True, "details": {}}},
+    )
+    monkeypatch.setattr(final_audit_tool, "ALLOW_EMPTY_CERT_RULES", False)
+
+    # Call with input_id only — no session_id provided
+    result = await final_audit_tool._toolkit_final_audit(
+        input_id="input_test_resolve",
+        run_id="fa_input_id_run",
+        config={},
+    )
+
+    # Should discover cert rules from the input_id's linked session
+    assert "rule_contract_missing" not in result.get("violations_found", [])
+    cert_cfg = result["effective_config"].get("certification", {})
+    schema_cfg = cert_cfg.get("schema_validation", {})
+    rules = schema_cfg.get("rules", {})
+    assert rules.get("expected_columns") == ["id", "value"]
+    StateStore.clear()


### PR DESCRIPTION
## Summary

- When `final_audit` is called with `input_id` (no `session_id`), the inferred config discovery block was skipped because `session_id` was `None`. Certification rules stored by `infer_configs` were never found, causing `rule_contract_missing` even though the rules existed in the session.
- The `InputDescriptor` already carries the `session_id` from `register_input`. This PR resolves it before config discovery runs.

## Root Cause

The typical agent workflow is:
1. `register_input` → returns `input_id` + `session_id`  
2. `infer_configs` with `session_id` → stores cert rules in session
3. `final_audit` with `input_id` → `session_id` is `None` → config discovery skipped → `rule_contract_missing`

The agent naturally passes `input_id` to downstream tools since that's the canonical reference. But `final_audit`'s config discovery only checked `session_id`, missing the link.

## Fix

Before the config discovery block, resolve `session_id` from the input descriptor when `input_id` is provided but `session_id` is not.

## Test plan

- [x] New test: `test_final_audit_resolves_session_from_input_id` — calls with `input_id` only, verifies cert rules discovered from linked session
- [x] All 223 tests pass
- [x] ruff, mypy clean