### PR TITLE
fix: allow input_id + session_id in infer_configs and resolve session from descriptor

### DIFF
--- a/src/analyst_toolkit/mcp_server/tools/infer_configs.py
+++ b/src/analyst_toolkit/mcp_server/tools/infer_configs.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import yaml
 
+from analyst_toolkit.mcp_server.input.ingest import get_input_descriptor
 from analyst_toolkit.mcp_server.io import (
     load_input,
     resolve_run_context,
@@ -211,8 +212,14 @@ async def _toolkit_infer_configs(
     run_id = run_id or runtime_overrides.get("run_id")
     run_id, _lifecycle = resolve_run_context(run_id, session_id)
     options = options or {}
-    provided_inputs = [gcs_path is not None, session_id is not None, input_id is not None]
-    if sum(provided_inputs) > 1:
+
+    # When input_id is provided with session_id, use input_id as the data source
+    # and session_id as the config storage target (not a competing data source).
+    if input_id and session_id:
+        data_sources = [gcs_path is not None, True]  # input_id counts as data source
+    else:
+        data_sources = [gcs_path is not None, session_id is not None, input_id is not None]
+    if sum(data_sources) > 1:
         return {
             "status": "error",
             "module": "infer_configs",
@@ -220,8 +227,11 @@ async def _toolkit_infer_configs(
             "error_code": "AMBIGUOUS_INPUT_SOURCE",
             "config_yaml": "",
         }
+
+    # Load data from the single data source
+    load_session = session_id if not input_id else None
     try:
-        df = load_input(gcs_path, session_id=session_id, input_id=input_id)
+        df = load_input(gcs_path, session_id=load_session, input_id=input_id)
     except Exception as exc:
         return {
             "status": "error",
@@ -231,7 +241,13 @@ async def _toolkit_infer_configs(
             "config_yaml": "",
         }
 
-    # If it came from a path and we don't have a session, start one
+    # Resolve session_id from input descriptor if not provided
+    if not session_id and input_id:
+        descriptor = get_input_descriptor(input_id)
+        if descriptor and descriptor.session_id:
+            session_id = descriptor.session_id
+
+    # If we still don't have a session, start one
     if not session_id:
         session_id = save_to_session(df, run_id=run_id)
 

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -1450,6 +1450,79 @@ async def test_infer_configs_persists_configs_to_session(monkeypatch, mocker):
 
 
 @pytest.mark.asyncio
+async def test_infer_configs_accepts_input_id_with_session_id(monkeypatch, mocker):
+    """infer_configs should accept input_id + session_id together."""
+    df = pd.DataFrame({"id": [1, 2], "value": ["a", "b"]})
+    StateStore.clear()
+
+    mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
+
+    def fake_infer_configs(**kwargs):
+        return {"normalization": "normalization:\n  rules: {}\n"}
+
+    infer_mod = types.ModuleType("analyst_toolkit_deploy.infer_configs")
+    setattr(infer_mod, "infer_configs", fake_infer_configs)
+    pkg_mod = types.ModuleType("analyst_toolkit_deploy")
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy", pkg_mod)
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy.infer_configs", infer_mod)
+
+    result = await infer_configs_tool._toolkit_infer_configs(
+        input_id="input_test_combo",
+        session_id="sess_combo_test",
+        run_id="combo_run",
+        modules=["normalization"],
+    )
+
+    assert result["status"] == "pass"
+    assert result["session_id"] == "sess_combo_test"
+    StateStore.clear()
+
+
+@pytest.mark.asyncio
+async def test_infer_configs_resolves_session_from_input_id(monkeypatch, mocker):
+    """infer_configs should resolve session_id from input_id descriptor."""
+    from analyst_toolkit.mcp_server.input.models import InputDescriptor
+
+    df = pd.DataFrame({"id": [1, 2], "value": ["a", "b"]})
+    StateStore.clear()
+    session_id = StateStore.save(df, run_id="infer_resolve_run")
+
+    mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
+    descriptor = InputDescriptor(
+        input_id="input_resolve_test",
+        source_type="server_path",
+        original_reference="/tmp/test.csv",
+        resolved_reference="/tmp/test.csv",
+        display_name="test.csv",
+        media_type="text/csv",
+        session_id=session_id,
+        run_id="infer_resolve_run",
+    )
+    mocker.patch.object(infer_configs_tool, "get_input_descriptor", return_value=descriptor)
+
+    def fake_infer_configs(**kwargs):
+        return {"normalization": "normalization:\n  rules: {}\n"}
+
+    infer_mod = types.ModuleType("analyst_toolkit_deploy.infer_configs")
+    setattr(infer_mod, "infer_configs", fake_infer_configs)
+    pkg_mod = types.ModuleType("analyst_toolkit_deploy")
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy", pkg_mod)
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy.infer_configs", infer_mod)
+
+    result = await infer_configs_tool._toolkit_infer_configs(
+        input_id="input_resolve_test",
+        run_id="infer_resolve_run",
+        modules=["normalization"],
+    )
+
+    assert result["status"] == "pass"
+    assert result["session_id"] == session_id
+    stored = StateStore.get_config(session_id, "normalization")
+    assert stored is not None
+    StateStore.clear()
+
+
+@pytest.mark.asyncio
 async def test_final_audit_auto_discovers_inferred_cert_config(mocker, monkeypatch):
     """final_audit should use inferred certification config from session when none provided."""
     df = pd.DataFrame({"id": [1, 2], "value": ["a", "b"]})


### PR DESCRIPTION
## Summary

- `infer_configs` rejected requests with both `input_id` and `session_id` as `AMBIGUOUS_INPUT_SOURCE`. Agents naturally pass both after `register_input` — `input_id` as the data source and `session_id` as the config storage target.
- Also resolves `session_id` from the input descriptor when only `input_id` is provided, so configs get stored in the correct session for downstream tools like `final_audit` to discover.

## Test plan

- [x] New test: `test_infer_configs_accepts_input_id_with_session_id` — both provided, no error
- [x] New test: `test_infer_configs_resolves_session_from_input_id` — session resolved from descriptor, configs stored correctly
- [x] All 225 tests pass
- [x] ruff, mypy clean