### PR TITLE
fix: strip stale /tmp paths from provided config and auto-create output dirs

### DIFF
--- a/src/analyst_toolkit/mcp_server/tools/final_audit.py
+++ b/src/analyst_toolkit/mcp_server/tools/final_audit.py
@@ -3,6 +3,7 @@
 import logging
 import os
 import tempfile
+from pathlib import Path
 from typing import Any
 
 import yaml
@@ -44,6 +45,25 @@ from analyst_toolkit.mcp_server.runtime_overlay import (
     runtime_to_tool_overrides,
 )
 from analyst_toolkit.mcp_server.schemas import base_input_schema
+
+_TRANSIENT_PATH_KEYS = ("raw_data_path", "input_path", "input_df_path")
+
+
+def _is_transient_path(value: str | None) -> bool:
+    """Return True if the path looks like a temp file that won't survive across tool calls."""
+    if not value or not isinstance(value, str):
+        return False
+    return value.startswith("/tmp/") or value.startswith(tempfile.gettempdir())
+
+
+def _strip_transient_paths(cfg: dict) -> list[str]:
+    """Remove transient filesystem paths from a config dict. Returns list of stripped keys."""
+    stripped = []
+    for key in _TRANSIENT_PATH_KEYS:
+        if key in cfg and _is_transient_path(cfg[key]):
+            del cfg[key]
+            stripped.append(key)
+    return stripped
 
 
 def _has_effective_certification_rules(rules: dict) -> bool:
@@ -126,10 +146,12 @@ async def _toolkit_final_audit(
                 else:
                     inferred_config.setdefault(key, value)
 
-    # Strip transient filesystem paths injected by infer_configs — these reference
-    # temp files that no longer exist by the time final_audit runs.
-    for stale_key in ("raw_data_path", "input_path", "input_df_path"):
-        inferred_config.pop(stale_key, None)
+    # Strip transient filesystem paths from both inferred and provided configs.
+    # infer_configs embeds /tmp paths that expire after the inference call returns;
+    # agents often pass those same stale paths back as explicit config.
+    _strip_transient_paths(inferred_config)
+    if isinstance(config, dict):
+        _strip_transient_paths(config)
 
     config, runtime_meta = resolve_layered_config(
         inferred=inferred_config,
@@ -143,6 +165,8 @@ async def _toolkit_final_audit(
     # Write the current df to a temp CSV as the "raw" snapshot if not provided.
     tmp_raw = None
     raw_data_path = base_cfg.get("raw_data_path")
+    if _is_transient_path(raw_data_path):
+        raw_data_path = None
     if not raw_data_path:
         tmp_raw = tempfile.NamedTemporaryFile(suffix=".csv", delete=False)
         df.to_csv(tmp_raw.name, index=False)
@@ -170,6 +194,14 @@ async def _toolkit_final_audit(
             },
         }
     }
+
+    # Ensure output directories exist — the M10 pipeline does not create them.
+    for path_value in module_cfg["final_audit"].get("settings", {}).get("paths", {}).values():
+        if isinstance(path_value, str) and path_value:
+            resolved = path_value.replace("{run_id}", run_id)
+            parent = Path(resolved).parent
+            if not parent.is_absolute() or str(parent).startswith(os.getcwd()):
+                parent.mkdir(parents=True, exist_ok=True)
 
     try:
         # run_final_audit_pipeline returns the certified dataframe

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -1833,3 +1833,111 @@ async def test_final_audit_resolves_session_from_input_id(mocker, monkeypatch):
     rules = schema_cfg.get("rules", {})
     assert rules.get("expected_columns") == ["id", "value"]
     StateStore.clear()
+
+
+@pytest.mark.asyncio
+async def test_final_audit_strips_stale_paths_from_provided_config(mocker, monkeypatch):
+    """When the agent passes raw inferred YAML as explicit config, stale /tmp paths
+    should still be stripped so final_audit doesn't crash with FileNotFoundError."""
+    df = pd.DataFrame({"id": [1, 2], "value": ["a", "b"]})
+    StateStore.clear()
+
+    mocker.patch.object(final_audit_tool, "load_input", return_value=df)
+    mocker.patch.object(final_audit_tool, "run_final_audit_pipeline", return_value=df)
+    mocker.patch.object(final_audit_tool, "save_to_session", return_value="sess_provided")
+    mocker.patch.object(final_audit_tool, "get_session_metadata", return_value={"row_count": 2})
+    mocker.patch.object(final_audit_tool, "save_output", return_value="gs://dummy/out.csv")
+    mocker.patch.object(
+        final_audit_tool,
+        "deliver_artifact",
+        side_effect=lambda local_path, *args, **kwargs: {
+            "reference": "",
+            "local_path": local_path,
+            "url": "https://example.com/a",
+            "warnings": [],
+            "destinations": {},
+        },
+    )
+    mocker.patch.object(final_audit_tool, "append_to_run_history", return_value=None)
+    mocker.patch.object(
+        final_audit_tool,
+        "run_validation_suite",
+        return_value={"schema_conformity": {"passed": True, "details": {}}},
+    )
+    monkeypatch.setattr(final_audit_tool, "ALLOW_EMPTY_CERT_RULES", True)
+
+    # Agent passes inferred YAML verbatim as explicit config with stale temp paths
+    result = await final_audit_tool._toolkit_final_audit(
+        session_id="sess_provided",
+        run_id="fa_provided_stale",
+        config={
+            "raw_data_path": "/tmp/tmpABCDEF.csv",
+            "input_path": "/tmp/tmpGHIJKL.csv",
+            "input_df_path": "/tmp/tmpMNOPQR.csv",
+            "certification": {
+                "schema_validation": {
+                    "rules": {"expected_columns": ["id", "value"]},
+                },
+            },
+        },
+    )
+
+    # Should not crash; stale paths stripped before pipeline runs
+    assert result["status"] != "error"
+    assert result["effective_config"].get("raw_data_path") is None or not result[
+        "effective_config"
+    ].get("raw_data_path", "").startswith("/tmp/")
+    StateStore.clear()
+
+
+@pytest.mark.asyncio
+async def test_final_audit_creates_output_directories(mocker, monkeypatch, tmp_path):
+    """final_audit should auto-create directories referenced in settings.paths."""
+    df = pd.DataFrame({"id": [1], "value": ["a"]})
+    StateStore.clear()
+
+    # Track the module_cfg that run_final_audit_pipeline receives
+    captured_cfg = {}
+
+    def fake_pipeline(config, df, run_id, notebook):
+        captured_cfg.update(config)
+        return df
+
+    mocker.patch.object(final_audit_tool, "load_input", return_value=df)
+    mocker.patch.object(final_audit_tool, "run_final_audit_pipeline", side_effect=fake_pipeline)
+    mocker.patch.object(final_audit_tool, "save_to_session", return_value="sess_dirs")
+    mocker.patch.object(final_audit_tool, "get_session_metadata", return_value={"row_count": 1})
+    mocker.patch.object(final_audit_tool, "save_output", return_value="gs://dummy/out.csv")
+    mocker.patch.object(
+        final_audit_tool,
+        "deliver_artifact",
+        side_effect=lambda local_path, *args, **kwargs: {
+            "reference": "",
+            "local_path": local_path,
+            "url": "https://example.com/a",
+            "warnings": [],
+            "destinations": {},
+        },
+    )
+    mocker.patch.object(final_audit_tool, "append_to_run_history", return_value=None)
+    mocker.patch.object(
+        final_audit_tool,
+        "run_validation_suite",
+        return_value={"schema_conformity": {"passed": True, "details": {}}},
+    )
+    monkeypatch.setattr(final_audit_tool, "ALLOW_EMPTY_CERT_RULES", True)
+
+    result = await final_audit_tool._toolkit_final_audit(
+        session_id="sess_dirs",
+        run_id="fa_dirs_test",
+        config={},
+    )
+
+    assert result["status"] != "error"
+    # The default paths should have their parent directories created
+    paths = captured_cfg.get("final_audit", {}).get("settings", {}).get("paths", {})
+    for path_template in paths.values():
+        resolved = path_template.replace("{run_id}", "fa_dirs_test")
+        parent = Path(resolved).parent
+        assert parent.exists(), f"Expected directory {parent} to be auto-created"
+    StateStore.clear()


### PR DESCRIPTION
## Summary
- Strip transient `/tmp` paths from the **provided** config layer (not just session-discovered inferred config), closing the attack vector where agents pass raw inferred YAML back as explicit `config`
- Add `_is_transient_path` guard on `base_cfg.raw_data_path` after config normalization as a final safety net
- Auto-create parent directories for all `settings.paths` entries before calling `run_final_audit_pipeline`, which does not create them itself

Fixes the two remaining `final_audit` failure modes from live testing:
1. `FileNotFoundError: /tmp/tmpv8ww57wv.csv` — stale temp path in provided config
2. `OSError: Cannot save file into a non-existent directory: 'data/processed'` — M10 pipeline expects pre-existing dirs

## Test plan
- [x] `test_final_audit_strips_stale_paths_from_provided_config` — verifies stale `/tmp` paths in explicit config don't crash final_audit
- [x] `test_final_audit_creates_output_directories` — verifies output dirs are auto-created before pipeline runs
- [x] `test_final_audit_strips_stale_inferred_paths` — existing test still passes (session-discovered path stripping)
- [x] Full regression suite: 50/50 pass
- [x] ruff clean