### PR TITLE
fix: prevent path traversal in final_audit output dir creation

### DIFF
--- a/src/analyst_toolkit/mcp_server/tools/final_audit.py
+++ b/src/analyst_toolkit/mcp_server/tools/final_audit.py
@@ -196,18 +196,25 @@ async def _toolkit_final_audit(
     }
 
     # Ensure output directories exist — the M10 pipeline does not create them.
+    # Also strip any paths that resolve outside the project root to prevent
+    # the downstream pipeline from writing to untrusted locations.
     project_root = Path(os.getcwd()).resolve()
-    for path_value in module_cfg["final_audit"].get("settings", {}).get("paths", {}).values():
-        if isinstance(path_value, str) and path_value:
-            resolved = path_value.replace("{run_id}", run_id)
-            parent = (project_root / resolved).resolve().parent
-            try:
-                parent.relative_to(project_root)
-                parent.mkdir(parents=True, exist_ok=True)
-            except ValueError:
-                logging.getLogger(__name__).warning(
-                    "Refusing to create directory outside project root: %s", parent
-                )
+    paths_cfg = module_cfg["final_audit"].get("settings", {}).get("paths", {})
+    for path_key, path_value in list(paths_cfg.items()):
+        if not isinstance(path_value, str) or not path_value:
+            continue
+        resolved = path_value.replace("{run_id}", run_id)
+        target = (project_root / resolved).resolve()
+        try:
+            target.relative_to(project_root)
+            target.parent.mkdir(parents=True, exist_ok=True)
+        except ValueError:
+            logging.getLogger(__name__).warning(
+                "Refusing to use output path outside project root (%s): %s",
+                path_key,
+                target,
+            )
+            del paths_cfg[path_key]
 
     try:
         # run_final_audit_pipeline returns the certified dataframe

--- a/src/analyst_toolkit/mcp_server/tools/final_audit.py
+++ b/src/analyst_toolkit/mcp_server/tools/final_audit.py
@@ -196,12 +196,18 @@ async def _toolkit_final_audit(
     }
 
     # Ensure output directories exist — the M10 pipeline does not create them.
+    project_root = Path(os.getcwd()).resolve()
     for path_value in module_cfg["final_audit"].get("settings", {}).get("paths", {}).values():
         if isinstance(path_value, str) and path_value:
             resolved = path_value.replace("{run_id}", run_id)
-            parent = Path(resolved).parent
-            if not parent.is_absolute() or str(parent).startswith(os.getcwd()):
+            parent = (project_root / resolved).resolve().parent
+            try:
+                parent.relative_to(project_root)
                 parent.mkdir(parents=True, exist_ok=True)
+            except ValueError:
+                logging.getLogger(__name__).warning(
+                    "Refusing to create directory outside project root: %s", parent
+                )
 
     try:
         # run_final_audit_pipeline returns the certified dataframe

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -1941,3 +1941,61 @@ async def test_final_audit_creates_output_directories(mocker, monkeypatch, tmp_p
         parent = Path(resolved).parent
         assert parent.exists(), f"Expected directory {parent} to be auto-created"
     StateStore.clear()
+
+
+@pytest.mark.asyncio
+async def test_final_audit_rejects_path_traversal(mocker, monkeypatch, tmp_path):
+    """Paths that traverse outside the project root must not create directories."""
+    df = pd.DataFrame({"id": [1], "value": ["a"]})
+    StateStore.clear()
+
+    traversal_target = tmp_path / "escaped"
+    captured_cfg = {}
+
+    def fake_pipeline(config, df, run_id, notebook):
+        captured_cfg.update(config)
+        return df
+
+    mocker.patch.object(final_audit_tool, "load_input", return_value=df)
+    mocker.patch.object(final_audit_tool, "run_final_audit_pipeline", side_effect=fake_pipeline)
+    mocker.patch.object(final_audit_tool, "save_to_session", return_value="sess_trav")
+    mocker.patch.object(final_audit_tool, "get_session_metadata", return_value={"row_count": 1})
+    mocker.patch.object(final_audit_tool, "save_output", return_value="gs://dummy/out.csv")
+    mocker.patch.object(
+        final_audit_tool,
+        "deliver_artifact",
+        side_effect=lambda local_path, *args, **kwargs: {
+            "reference": "",
+            "local_path": local_path,
+            "url": "https://example.com/a",
+            "warnings": [],
+            "destinations": {},
+        },
+    )
+    mocker.patch.object(final_audit_tool, "append_to_run_history", return_value=None)
+    mocker.patch.object(
+        final_audit_tool,
+        "run_validation_suite",
+        return_value={"schema_conformity": {"passed": True, "details": {}}},
+    )
+    monkeypatch.setattr(final_audit_tool, "ALLOW_EMPTY_CERT_RULES", True)
+
+    # Inject a traversal path into the config
+    result = await final_audit_tool._toolkit_final_audit(
+        session_id="sess_trav",
+        run_id="fa_traversal",
+        config={
+            "settings": {
+                "paths": {
+                    "checkpoint_csv": f"../../../{traversal_target}/evil.csv",
+                },
+            },
+        },
+    )
+
+    assert result["status"] != "error"
+    # The traversal target must NOT have been created
+    assert not traversal_target.exists(), (
+        f"Path traversal created directory outside project root: {traversal_target}"
+    )
+    StateStore.clear()

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -1998,4 +1998,9 @@ async def test_final_audit_rejects_path_traversal(mocker, monkeypatch, tmp_path)
     assert not traversal_target.exists(), (
         f"Path traversal created directory outside project root: {traversal_target}"
     )
+    # The traversal path must be stripped from the config passed to the pipeline
+    pipeline_paths = captured_cfg.get("final_audit", {}).get("settings", {}).get("paths", {})
+    assert "checkpoint_csv" not in pipeline_paths, (
+        "Traversal path was not removed from pipeline config"
+    )
     StateStore.clear()


### PR DESCRIPTION
## Summary
- Resolve output paths against `project_root` and verify via `relative_to()` before `mkdir` — rejects traversal paths like `../../../etc/evil` with a warning log
- Addresses CodeRabbit finding: relative paths in `settings.paths` could escape the project root

## Test plan
- [x] `test_final_audit_rejects_path_traversal` — injects `../../../<tmp>/evil.csv`, asserts target dir is NOT created
- [x] `test_final_audit_creates_output_directories` — existing test still passes for legitimate paths
- [x] Full regression suite: 51/51 pass
- [x] ruff clean