### PR TITLE
feat: add manage_session tool for session lifecycle management

### DIFF
--- a/resource_hub/mcp_server_guide.md
+++ b/resource_hub/mcp_server_guide.md
@@ -91,7 +91,7 @@ curl http://localhost:8001/health | python3 -m json.tool
     "get_agent_playbook", "get_user_quickstart", "get_capability_catalog",
     "get_run_history", "get_data_health_report",
     "data_dictionary", "get_pipeline_dashboard", "get_cockpit_dashboard",
-    "ensure_artifact_server"
+    "ensure_artifact_server", "manage_session"
   ]
 }
 ```
@@ -188,6 +188,7 @@ When diagnosing failures, use `trace_id` from the JSON-RPC error payload and cor
 | `get_pipeline_dashboard` | Combined multi-module HTML dashboard for a specific `run_id`; linked from the cockpit hub |
 | `data_dictionary` | Column-level schema report as a standalone HTML artifact; preview surfaced in the cockpit dictionary tab |
 | `ensure_artifact_server` | Start/status the local artifact server — converts artifact file paths into browser-openable localhost URLs |
+| `manage_session` | Session lifecycle: list active sessions, inspect details, fork a session into a new run context, or rebind a session to a different run_id |
 
 </details>
 
@@ -225,6 +226,8 @@ A `run_id` ties all steps together in the Healing Ledger. Pass the same `run_id`
 If a tool call provides both `session_id` and `run_id`, the server enforces lifecycle consistency by default:
 - If the session already has a bound run id and it differs from the requested run id, the tool coerces to the session run id and emits a warning.
 - To allow explicit overrides, set `ANALYST_MCP_ALLOW_RUN_ID_OVERRIDE=1`.
+- To start a new run context without re-downloading data, use `manage_session(action="fork", session_id="...", run_id="new_run")`. This clones the session's DataFrame and inferred configs into a fresh session with its own run_id.
+- To change the run_id on an existing session in-place, use `manage_session(action="rebind", session_id="...", run_id="new_run")`.
 
 > **Config structure note:** `infer_configs` returns YAML strings. Parse each one with `yaml.safe_load` and pass the resulting dict directly to the relevant tool. Never flatten nested keys — for normalization, `standardize_text_columns`, `coerce_dtypes`, etc. must stay nested inside `rules:` or the pipeline will skip all transformations.
 >

--- a/src/analyst_toolkit/mcp_server/server.py
+++ b/src/analyst_toolkit/mcp_server/server.py
@@ -510,6 +510,7 @@ from analyst_toolkit.mcp_server.tools import (  # noqa: F401, E402
     normalization,
     outliers,
     preflight_config,
+    session,
     validation,
 )
 

--- a/src/analyst_toolkit/mcp_server/state.py
+++ b/src/analyst_toolkit/mcp_server/state.py
@@ -116,6 +116,7 @@ class StateStore:
         Returns the new session_id, or None if the source session does not exist.
         """
         with cls._lock:
+            cls._cleanup_unsafe()
             df = cls._sessions.get(source_session_id)
             if df is None:
                 return None
@@ -150,6 +151,7 @@ class StateStore:
     def rebind_run_id(cls, session_id: str, run_id: str) -> bool:
         """Rebind a session to a new run_id. Returns False if session does not exist."""
         with cls._lock:
+            cls._cleanup_unsafe()
             if session_id not in cls._sessions:
                 return False
             cls._session_run_ids[session_id] = run_id
@@ -160,6 +162,7 @@ class StateStore:
     def list_sessions(cls) -> Dict[str, dict]:
         """List available sessions and their metadata."""
         with cls._lock:
+            cls._cleanup_unsafe()
             return {k: cls._metadata.get(k, {}) for k in cls._sessions.keys()}
 
     @classmethod

--- a/src/analyst_toolkit/mcp_server/state.py
+++ b/src/analyst_toolkit/mcp_server/state.py
@@ -135,9 +135,7 @@ class StateStore:
                 cls._session_run_ids[new_session_id] = run_id
 
             if copy_configs and source_session_id in cls._session_configs:
-                cls._session_configs[new_session_id] = dict(
-                    cls._session_configs[source_session_id]
-                )
+                cls._session_configs[new_session_id] = dict(cls._session_configs[source_session_id])
 
         logger.info(
             "Forked session %s → %s (run_id: %s, copy_configs: %s)",

--- a/src/analyst_toolkit/mcp_server/state.py
+++ b/src/analyst_toolkit/mcp_server/state.py
@@ -104,6 +104,61 @@ class StateStore:
             return dict(cls._session_configs.get(session_id, {}))
 
     @classmethod
+    def fork(
+        cls,
+        source_session_id: str,
+        *,
+        run_id: Optional[str] = None,
+        copy_configs: bool = True,
+    ) -> Optional[str]:
+        """Clone a session's DataFrame (and optionally configs) into a new session.
+
+        Returns the new session_id, or None if the source session does not exist.
+        """
+        with cls._lock:
+            df = cls._sessions.get(source_session_id)
+            if df is None:
+                return None
+
+            new_session_id = f"sess_{uuid.uuid4().hex[:8]}"
+            now_ts = pd.Timestamp.now()
+            cls._sessions[new_session_id] = df.copy()
+            cls._metadata[new_session_id] = {
+                "row_count": len(df),
+                "col_count": len(df.columns),
+                "updated_at": now_ts.isoformat(),
+            }
+            cls._last_accessed[new_session_id] = time.time()
+            cls._session_start_times[new_session_id] = now_ts.strftime("%Y%m%d_%H%M%S")
+
+            if run_id:
+                cls._session_run_ids[new_session_id] = run_id
+
+            if copy_configs and source_session_id in cls._session_configs:
+                cls._session_configs[new_session_id] = dict(
+                    cls._session_configs[source_session_id]
+                )
+
+        logger.info(
+            "Forked session %s → %s (run_id: %s, copy_configs: %s)",
+            source_session_id,
+            new_session_id,
+            run_id,
+            copy_configs,
+        )
+        return new_session_id
+
+    @classmethod
+    def rebind_run_id(cls, session_id: str, run_id: str) -> bool:
+        """Rebind a session to a new run_id. Returns False if session does not exist."""
+        with cls._lock:
+            if session_id not in cls._sessions:
+                return False
+            cls._session_run_ids[session_id] = run_id
+        logger.info("Rebound session %s to run_id %s", session_id, run_id)
+        return True
+
+    @classmethod
     def list_sessions(cls) -> Dict[str, dict]:
         """List available sessions and their metadata."""
         with cls._lock:

--- a/src/analyst_toolkit/mcp_server/tools/cockpit.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit.py
@@ -604,6 +604,11 @@ def _build_cockpit_dashboard_report(limit: int) -> dict[str, Any]:
             "Tool": "get_run_history",
             "Why": "Read the prescription and healing ledger behind dashboard surfaces.",
         },
+        {
+            "Action": "Fork Session",
+            "Tool": "manage_session",
+            "Why": "Clone the current session into a new run context without re-downloading data or re-running infer_configs.",
+        },
     ]
     launch_sequences = [
         {
@@ -628,6 +633,14 @@ def _build_cockpit_dashboard_report(limit: int) -> dict[str, Any]:
                 "Start from infer_configs so the data dictionary inherits inferred types, rules, and high-signal column hints.",
                 "Use the data_dictionary request template to keep the prelaunch contract consistent.",
                 "Treat the prelaunch report as a cockpit-linked surface, not a disconnected export.",
+            ],
+        },
+        {
+            "title": "Second Pass With New Run Context",
+            "steps": [
+                "Use manage_session(action='fork') to clone the current session and its inferred configs into a fresh run_id.",
+                "Adjust configs on the forked session as needed — the original session stays untouched.",
+                "Run modules on the forked session and compare results via the pipeline dashboard.",
             ],
         },
     ]
@@ -910,6 +923,11 @@ async def _toolkit_get_cockpit_dashboard(limit: int = 8) -> dict:
                     "ensure_artifact_server",
                     "Start the local artifact server so cockpit and module dashboard links resolve as local URLs.",
                     {},
+                ),
+                next_action(
+                    "manage_session",
+                    "List or fork sessions to start a new run context from existing data.",
+                    {"action": "list"},
                 ),
             ],
         )

--- a/src/analyst_toolkit/mcp_server/tools/cockpit_capabilities.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit_capabilities.py
@@ -123,8 +123,19 @@ _WORKFLOW_TOOL_METADATA: dict[str, dict[str, Any]] = {
         "outputs": ["session_id", "dashboard_url?", "dashboard_path?", "export_url?"],
     },
     "data_dictionary": {
-        "description": "Artifact-first prelaunch dictionary flow seeded by infer_configs and surfaced through cockpit/dashboard artifacts.",
+        "description": (
+            "Artifact-first prelaunch dictionary flow seeded by infer_configs "
+            "and surfaced through cockpit/dashboard artifacts."
+        ),
         "outputs": ["dashboard_url?", "dashboard_path?", "xlsx_url?", "summary"],
+    },
+    "manage_session": {
+        "description": (
+            "Session lifecycle management: list, inspect, fork, or rebind. "
+            "Use fork to start a new run context from an existing session "
+            "without re-downloading data or re-running infer_configs."
+        ),
+        "outputs": ["session_id", "new_session_id?", "run_id", "sessions?"],
     },
 }
 

--- a/src/analyst_toolkit/mcp_server/tools/cockpit_content.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit_content.py
@@ -34,6 +34,13 @@ def user_quickstart_payload() -> dict:
 - If the user only has a local file on their machine, use the `/inputs/upload` ingest path (or a client helper built on top of it) to obtain an `input_id` before running analysis tools.
 - Use `get_input_descriptor` to inspect the resolved canonical input reference when needed.
 
+## Session Management
+- Use `manage_session` to control session lifecycle without re-downloading data or re-running `infer_configs`.
+- `manage_session(action="list")` — see all active sessions.
+- `manage_session(action="inspect", session_id="...")` — view session details and stored configs.
+- `manage_session(action="fork", session_id="...", run_id="new_run")` — clone a session into a new run context. The forked session gets its own run_id and optionally inherits inferred configs.
+- `manage_session(action="rebind", session_id="...", run_id="new_run")` — change the run_id bound to an existing session.
+
 ## Recommended Order (Manual Pipeline)
 1. `register_input` or upload to `/inputs/upload`
 2. `diagnostics`
@@ -42,6 +49,7 @@ def user_quickstart_payload() -> dict:
 5. `normalization` -> `duplicates` -> `outliers` -> `imputation` -> `validation`
 6. `final_audit`
 7. `get_run_history` + `get_data_health_report`
+8. (Optional) `manage_session(action="fork")` to start a second pass with a new run_id
 
 ## Dashboard Artifacts
 - In trusted/local mode, you can start a review session by building the cockpit dashboard for one human-readable landing page.
@@ -191,6 +199,14 @@ Turn plotting off for speed on large datasets, on for exploratory analysis.
                     "runtime": {"artifacts": {"export_html": True}},
                 },
             },
+            {
+                "tool": "manage_session",
+                "arguments": {
+                    "action": "fork",
+                    "session_id": "<session_id_from_previous_run>",
+                    "run_id": "second_pass_001",
+                },
+            },
         ],
     }
     return {
@@ -248,6 +264,11 @@ Turn plotting off for speed on large datasets, on for exploratory analysis.
                 "tool": "data_dictionary",
                 "arguments_schema_hint": {"required": []},
             },
+            {
+                "label": "Manage sessions",
+                "tool": "manage_session",
+                "arguments_schema_hint": {"required": ["action"]},
+            },
         ],
     }
 
@@ -265,6 +286,7 @@ def agent_playbook_payload() -> dict:
             "Stable run_id used across calls",
             "Optional output bucket/prefix overrides",
             "Optional runtime overlay for cross-cutting execution control",
+            "Use manage_session(action='fork') to start a new run context from an existing session without re-downloading data or re-running infer_configs",
         ],
         "ordered_steps": (
             [

--- a/src/analyst_toolkit/mcp_server/tools/session.py
+++ b/src/analyst_toolkit/mcp_server/tools/session.py
@@ -1,0 +1,223 @@
+"""MCP tool: toolkit_manage_session — session lifecycle management."""
+
+from datetime import datetime, timezone
+
+from analyst_toolkit.mcp_server.response_utils import next_action, with_next_actions
+from analyst_toolkit.mcp_server.state import StateStore
+
+
+def _session_summary(session_id: str) -> dict:
+    """Build a compact summary dict for a session."""
+    metadata = StateStore.get_metadata(session_id) or {}
+    return {
+        "session_id": session_id,
+        "run_id": StateStore.get_run_id(session_id),
+        "started_at": StateStore.get_session_start(session_id),
+        "row_count": metadata.get("row_count"),
+        "col_count": metadata.get("col_count"),
+        "updated_at": metadata.get("updated_at"),
+        "stored_configs": sorted(StateStore.get_configs(session_id).keys()),
+    }
+
+
+async def _toolkit_manage_session(
+    action: str,
+    session_id: str | None = None,
+    run_id: str | None = None,
+    copy_configs: bool = True,
+) -> dict:
+    """
+    Manage session lifecycle: list, inspect, fork, or rebind.
+
+    Actions:
+      list    — show all active sessions
+      inspect — show details for a single session
+      fork    — clone a session into a new session with a new run_id
+      rebind  — change the run_id bound to a session
+    """
+    action = (action or "").strip().lower()
+
+    if action == "list":
+        sessions = StateStore.list_sessions()
+        summaries = [_session_summary(sid) for sid in sessions]
+        return {
+            "status": "pass",
+            "module": "manage_session",
+            "action": "list",
+            "sessions": summaries,
+            "session_count": len(summaries),
+        }
+
+    if action == "inspect":
+        if not session_id:
+            return {
+                "status": "error",
+                "module": "manage_session",
+                "action": "inspect",
+                "error": "session_id is required for inspect.",
+                "error_code": "MISSING_SESSION_ID",
+            }
+        if StateStore.get(session_id) is None:
+            return {
+                "status": "error",
+                "module": "manage_session",
+                "action": "inspect",
+                "error": f"Session '{session_id}' not found or expired.",
+                "error_code": "SESSION_NOT_FOUND",
+            }
+        summary = _session_summary(session_id)
+        return with_next_actions(
+            {
+                "status": "pass",
+                "module": "manage_session",
+                "action": "inspect",
+                "session": summary,
+            },
+            [
+                next_action(
+                    "manage_session",
+                    "Fork this session to start a new run.",
+                    {"action": "fork", "session_id": session_id},
+                ),
+            ],
+        )
+
+    if action == "fork":
+        if not session_id:
+            return {
+                "status": "error",
+                "module": "manage_session",
+                "action": "fork",
+                "error": "session_id is required for fork.",
+                "error_code": "MISSING_SESSION_ID",
+            }
+        # Generate a fresh run_id if none provided
+        if not run_id:
+            run_id = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        new_session_id = StateStore.fork(
+            session_id,
+            run_id=run_id,
+            copy_configs=copy_configs,
+        )
+        if new_session_id is None:
+            return {
+                "status": "error",
+                "module": "manage_session",
+                "action": "fork",
+                "error": f"Source session '{session_id}' not found or expired.",
+                "error_code": "SESSION_NOT_FOUND",
+            }
+        return with_next_actions(
+            {
+                "status": "pass",
+                "module": "manage_session",
+                "action": "fork",
+                "source_session_id": session_id,
+                "new_session_id": new_session_id,
+                "run_id": run_id,
+                "configs_copied": copy_configs,
+                "session": _session_summary(new_session_id),
+            },
+            [
+                next_action(
+                    "infer_configs",
+                    "Run config inference on the forked session.",
+                    {"session_id": new_session_id, "run_id": run_id},
+                ),
+                next_action(
+                    "final_audit",
+                    "Run final audit on the forked session.",
+                    {"session_id": new_session_id, "run_id": run_id},
+                ),
+            ],
+        )
+
+    if action == "rebind":
+        if not session_id:
+            return {
+                "status": "error",
+                "module": "manage_session",
+                "action": "rebind",
+                "error": "session_id is required for rebind.",
+                "error_code": "MISSING_SESSION_ID",
+            }
+        if not run_id:
+            return {
+                "status": "error",
+                "module": "manage_session",
+                "action": "rebind",
+                "error": "run_id is required for rebind.",
+                "error_code": "MISSING_RUN_ID",
+            }
+        old_run_id = StateStore.get_run_id(session_id)
+        ok = StateStore.rebind_run_id(session_id, run_id)
+        if not ok:
+            return {
+                "status": "error",
+                "module": "manage_session",
+                "action": "rebind",
+                "error": f"Session '{session_id}' not found or expired.",
+                "error_code": "SESSION_NOT_FOUND",
+            }
+        return {
+            "status": "pass",
+            "module": "manage_session",
+            "action": "rebind",
+            "session_id": session_id,
+            "previous_run_id": old_run_id,
+            "new_run_id": run_id,
+        }
+
+    return {
+        "status": "error",
+        "module": "manage_session",
+        "error": f"Unknown action '{action}'. Use list, inspect, fork, or rebind.",
+        "error_code": "UNKNOWN_ACTION",
+    }
+
+
+_INPUT_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "action": {
+            "type": "string",
+            "enum": ["list", "inspect", "fork", "rebind"],
+            "description": (
+                "Action to perform: "
+                "list (show all sessions), "
+                "inspect (show details for one session), "
+                "fork (clone a session with a new run_id), "
+                "rebind (change the run_id bound to a session)."
+            ),
+        },
+        "session_id": {
+            "type": "string",
+            "description": "Target session. Required for inspect, fork, and rebind.",
+        },
+        "run_id": {
+            "type": "string",
+            "description": (
+                "New run_id for fork or rebind. "
+                "If omitted during fork, a timestamp-based run_id is generated."
+            ),
+        },
+        "copy_configs": {
+            "type": "boolean",
+            "description": "Whether to copy inferred configs when forking. Defaults to true.",
+            "default": True,
+        },
+    },
+    "required": ["action"],
+}
+
+from analyst_toolkit.mcp_server.registry import register_tool  # noqa: E402
+
+register_tool(
+    name="manage_session",
+    fn=_toolkit_manage_session,
+    description=(
+        "Manage session lifecycle: list active sessions, inspect a session, "
+        "fork a session into a new run context, or rebind a session to a different run_id."
+    ),
+    input_schema=_INPUT_SCHEMA,
+)

--- a/src/analyst_toolkit/mcp_server/tools/session.py
+++ b/src/analyst_toolkit/mcp_server/tools/session.py
@@ -1,5 +1,6 @@
 """MCP tool: toolkit_manage_session — session lifecycle management."""
 
+import uuid
 from datetime import datetime, timezone
 
 from analyst_toolkit.mcp_server.response_utils import next_action, with_next_actions
@@ -91,9 +92,10 @@ async def _toolkit_manage_session(
                 "error": "session_id is required for fork.",
                 "error_code": "MISSING_SESSION_ID",
             }
-        # Generate a fresh run_id if none provided
+        # Generate a fresh run_id if none provided (include uuid suffix to avoid collisions)
         if not run_id:
-            run_id = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+            ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+            run_id = f"{ts}_{uuid.uuid4().hex[:6]}"
         new_session_id = StateStore.fork(
             session_id,
             run_id=run_id,

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -2105,9 +2105,13 @@ async def test_manage_session_fork_generates_run_id():
     df = pd.DataFrame({"v": [1]})
     sid = StateStore.save(df)
 
-    result = await session_tool._toolkit_manage_session(action="fork", session_id=sid)
-    assert result["status"] == "pass"
-    assert result["run_id"]  # auto-generated, non-empty
+    result1 = await session_tool._toolkit_manage_session(action="fork", session_id=sid)
+    result2 = await session_tool._toolkit_manage_session(action="fork", session_id=sid)
+    assert result1["status"] == "pass"
+    assert result2["status"] == "pass"
+    assert result1["run_id"]  # auto-generated, non-empty
+    assert result2["run_id"]
+    assert result1["run_id"] != result2["run_id"]  # unique even within same second
     StateStore.clear()
 
 

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -2143,9 +2143,7 @@ async def test_manage_session_rebind_missing_run_id():
     df = pd.DataFrame({"v": [1]})
     sid = StateStore.save(df, run_id="r1")
 
-    result = await session_tool._toolkit_manage_session(
-        action="rebind", session_id=sid
-    )
+    result = await session_tool._toolkit_manage_session(action="rebind", session_id=sid)
     assert result["status"] == "error"
     assert result["error_code"] == "MISSING_RUN_ID"
     StateStore.clear()

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -14,6 +14,7 @@ import analyst_toolkit.mcp_server.tools.imputation as imputation_tool
 import analyst_toolkit.mcp_server.tools.infer_configs as infer_configs_tool
 import analyst_toolkit.mcp_server.tools.normalization as normalization_tool
 import analyst_toolkit.mcp_server.tools.outliers as outliers_tool
+import analyst_toolkit.mcp_server.tools.session as session_tool
 import analyst_toolkit.mcp_server.tools.validation as validation_tool
 from analyst_toolkit.mcp_server.state import StateStore
 
@@ -2004,3 +2005,154 @@ async def test_final_audit_rejects_path_traversal(mocker, monkeypatch, tmp_path)
         "Traversal path was not removed from pipeline config"
     )
     StateStore.clear()
+
+
+# ── manage_session tool tests ──
+
+
+@pytest.mark.asyncio
+async def test_manage_session_list():
+    StateStore.clear()
+    df = pd.DataFrame({"a": [1, 2]})
+    sid1 = StateStore.save(df, run_id="run_1")
+    sid2 = StateStore.save(df, run_id="run_2")
+
+    result = await session_tool._toolkit_manage_session(action="list")
+    assert result["status"] == "pass"
+    assert result["session_count"] == 2
+    session_ids = {s["session_id"] for s in result["sessions"]}
+    assert sid1 in session_ids
+    assert sid2 in session_ids
+    StateStore.clear()
+
+
+@pytest.mark.asyncio
+async def test_manage_session_inspect():
+    StateStore.clear()
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    sid = StateStore.save(df, run_id="inspect_run")
+    StateStore.save_config(sid, "validation", "validation:\n  run: true\n")
+
+    result = await session_tool._toolkit_manage_session(action="inspect", session_id=sid)
+    assert result["status"] == "pass"
+    assert result["session"]["session_id"] == sid
+    assert result["session"]["run_id"] == "inspect_run"
+    assert result["session"]["row_count"] == 3
+    assert "validation" in result["session"]["stored_configs"]
+    assert "next_actions" in result
+    StateStore.clear()
+
+
+@pytest.mark.asyncio
+async def test_manage_session_inspect_missing():
+    StateStore.clear()
+    result = await session_tool._toolkit_manage_session(
+        action="inspect", session_id="sess_nonexistent"
+    )
+    assert result["status"] == "error"
+    assert result["error_code"] == "SESSION_NOT_FOUND"
+    StateStore.clear()
+
+
+@pytest.mark.asyncio
+async def test_manage_session_fork():
+    StateStore.clear()
+    df = pd.DataFrame({"col": [10, 20, 30]})
+    sid = StateStore.save(df, run_id="original_run")
+    StateStore.save_config(sid, "diagnostics", "diagnostics:\n  run: true\n")
+
+    result = await session_tool._toolkit_manage_session(
+        action="fork", session_id=sid, run_id="forked_run"
+    )
+    assert result["status"] == "pass"
+    assert result["source_session_id"] == sid
+    new_sid = result["new_session_id"]
+    assert new_sid != sid
+    assert result["run_id"] == "forked_run"
+    assert result["configs_copied"] is True
+
+    # Verify the forked session has the data and configs
+    forked_df = StateStore.get(new_sid)
+    assert forked_df is not None
+    assert len(forked_df) == 3
+    assert StateStore.get_run_id(new_sid) == "forked_run"
+    assert StateStore.get_config(new_sid, "diagnostics") is not None
+
+    # Verify source session is unchanged
+    assert StateStore.get_run_id(sid) == "original_run"
+    StateStore.clear()
+
+
+@pytest.mark.asyncio
+async def test_manage_session_fork_without_configs():
+    StateStore.clear()
+    df = pd.DataFrame({"v": [1]})
+    sid = StateStore.save(df, run_id="r1")
+    StateStore.save_config(sid, "validation", "yaml")
+
+    result = await session_tool._toolkit_manage_session(
+        action="fork", session_id=sid, run_id="r2", copy_configs=False
+    )
+    assert result["status"] == "pass"
+    new_sid = result["new_session_id"]
+    assert StateStore.get_configs(new_sid) == {}
+    StateStore.clear()
+
+
+@pytest.mark.asyncio
+async def test_manage_session_fork_generates_run_id():
+    StateStore.clear()
+    df = pd.DataFrame({"v": [1]})
+    sid = StateStore.save(df)
+
+    result = await session_tool._toolkit_manage_session(action="fork", session_id=sid)
+    assert result["status"] == "pass"
+    assert result["run_id"]  # auto-generated, non-empty
+    StateStore.clear()
+
+
+@pytest.mark.asyncio
+async def test_manage_session_fork_missing_source():
+    StateStore.clear()
+    result = await session_tool._toolkit_manage_session(
+        action="fork", session_id="sess_gone", run_id="new"
+    )
+    assert result["status"] == "error"
+    assert result["error_code"] == "SESSION_NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_manage_session_rebind():
+    StateStore.clear()
+    df = pd.DataFrame({"v": [1]})
+    sid = StateStore.save(df, run_id="old_run")
+
+    result = await session_tool._toolkit_manage_session(
+        action="rebind", session_id=sid, run_id="new_run"
+    )
+    assert result["status"] == "pass"
+    assert result["previous_run_id"] == "old_run"
+    assert result["new_run_id"] == "new_run"
+    assert StateStore.get_run_id(sid) == "new_run"
+    StateStore.clear()
+
+
+@pytest.mark.asyncio
+async def test_manage_session_rebind_missing_run_id():
+    StateStore.clear()
+    df = pd.DataFrame({"v": [1]})
+    sid = StateStore.save(df, run_id="r1")
+
+    result = await session_tool._toolkit_manage_session(
+        action="rebind", session_id=sid
+    )
+    assert result["status"] == "error"
+    assert result["error_code"] == "MISSING_RUN_ID"
+    StateStore.clear()
+
+
+@pytest.mark.asyncio
+async def test_manage_session_unknown_action():
+    result = await session_tool._toolkit_manage_session(action="delete")
+    assert result["status"] == "error"
+    assert result["error_code"] == "UNKNOWN_ACTION"


### PR DESCRIPTION
## Summary
- New `manage_session` MCP tool with 4 actions: `list`, `inspect`, `fork`, `rebind`
- `fork` clones a session's DataFrame + inferred configs into a new session with a fresh run_id — enables starting a new pipeline run without re-downloading data or re-running `infer_configs`
- `rebind` changes the run_id bound to an existing session, addressing the run_id coercion issue where all tools on a session are forced to the original run_id
- New `StateStore.fork()` and `StateStore.rebind_run_id()` methods

Addresses the gap where users had no way to change session/run context without re-registering input data. The run_id coercion in `resolve_run_context` is still the correct default for pipeline consistency, but users now have an escape hatch via `fork` or `rebind`.

## Test plan
- [x] `test_manage_session_list` — lists multiple sessions
- [x] `test_manage_session_inspect` — returns metadata, run_id, stored configs
- [x] `test_manage_session_inspect_missing` — returns SESSION_NOT_FOUND
- [x] `test_manage_session_fork` — clones data + configs, new session_id, independent run_id
- [x] `test_manage_session_fork_without_configs` — copy_configs=false omits configs
- [x] `test_manage_session_fork_generates_run_id` — auto-generates timestamp run_id
- [x] `test_manage_session_fork_missing_source` — returns SESSION_NOT_FOUND
- [x] `test_manage_session_rebind` — changes run_id, returns old/new
- [x] `test_manage_session_rebind_missing_run_id` — returns MISSING_RUN_ID
- [x] `test_manage_session_unknown_action` — returns UNKNOWN_ACTION
- [x] Full regression suite: 61/61 pass
- [x] ruff clean