### PR TITLE
fix: resolve doubled exports path and surface allowed input roots

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -110,6 +110,14 @@ export ANALYST_MCP_TEMPLATE_IO_TIMEOUT_SEC=8
 # Comma-separated list of allowed filesystem roots for input resolution.
 # export ANALYST_MCP_ALLOWED_INPUT_ROOTS=
 
+# Opt-in to disclose allowed input roots in INPUT_PATH_DENIED client errors.
+# Default false redacts paths; server-side logs always include them.
+# export ANALYST_MCP_DISCLOSE_INPUT_ROOTS=false
+
+# --- MCP Artifact Reading ---
+# Maximum artifact size (bytes) readable through the read_artifact MCP tool.
+# export ANALYST_MCP_MAX_ARTIFACT_READ_BYTES=10485760
+
 # --- MCP Job State ---
 # Path to the job state persistence file for async auto_heal jobs.
 # export ANALYST_MCP_JOB_STATE_PATH=

--- a/docker-compose.mcp.yml
+++ b/docker-compose.mcp.yml
@@ -25,6 +25,7 @@ services:
       dockerfile: Dockerfile.mcp
     ports:
       - "${ANALYST_MCP_PORT:-8001}:8001"
+      - "${ANALYST_MCP_ARTIFACT_SERVER_PORT:-8765}:8765"
     environment:
       # --- Server ---
       - ANALYST_MCP_PORT=${ANALYST_MCP_PORT:-8001}
@@ -47,10 +48,12 @@ services:
       # --- Local Artifact Server ---
       - ANALYST_MCP_ENABLE_ARTIFACT_SERVER=${ANALYST_MCP_ENABLE_ARTIFACT_SERVER:-false}
       - ANALYST_MCP_ENABLE_ARTIFACT_SERVER_TOOL=${ANALYST_MCP_ENABLE_ARTIFACT_SERVER_TOOL:-false}
-      - ANALYST_MCP_ARTIFACT_SERVER_HOST=${ANALYST_MCP_ARTIFACT_SERVER_HOST:-127.0.0.1}
+      # Bind to 0.0.0.0 inside the container so Docker port-forwarding works.
+      # Traffic is still only reachable on the host via the mapped port.
+      - ANALYST_MCP_ARTIFACT_SERVER_HOST=${ANALYST_MCP_ARTIFACT_SERVER_HOST:-0.0.0.0}
       - ANALYST_MCP_ARTIFACT_SERVER_PORT=${ANALYST_MCP_ARTIFACT_SERVER_PORT:-8765}
       - ANALYST_MCP_ARTIFACT_SERVER_ROOT=${ANALYST_MCP_ARTIFACT_SERVER_ROOT:-exports}
-      - ANALYST_MCP_ALLOW_BIND_ALL=${ANALYST_MCP_ALLOW_BIND_ALL:-false}
+      - ANALYST_MCP_ALLOW_BIND_ALL=${ANALYST_MCP_ALLOW_BIND_ALL:-true}
       # --- Artifact Routing ---
       - ANALYST_MCP_LOCAL_OUTPUT_BASE=${ANALYST_MCP_LOCAL_OUTPUT_BASE:-.}
       # --- Run Identity ---
@@ -62,6 +65,9 @@ services:
       - ANALYST_MCP_INPUT_REGISTRY_MAX_ENTRIES=${ANALYST_MCP_INPUT_REGISTRY_MAX_ENTRIES:-512}
       - ANALYST_MCP_INPUT_REGISTRY_TTL_SEC=${ANALYST_MCP_INPUT_REGISTRY_TTL_SEC:-21600}
       - ANALYST_MCP_MAX_UPLOAD_BYTES=${ANALYST_MCP_MAX_UPLOAD_BYTES:-52428800}
+      - ANALYST_MCP_DISCLOSE_INPUT_ROOTS=${ANALYST_MCP_DISCLOSE_INPUT_ROOTS:-false}
+      # --- Artifact Reading ---
+      - ANALYST_MCP_MAX_ARTIFACT_READ_BYTES=${ANALYST_MCP_MAX_ARTIFACT_READ_BYTES:-10485760}
     volumes:
       # Mount GCS service account key — requires GCP_CREDS_PATH to be set in shell/.envrc
       - ${GCP_CREDS_PATH:-/dev/null}:/run/secrets/gcp_creds:ro

--- a/resource_hub/mcp_server_guide.md
+++ b/resource_hub/mcp_server_guide.md
@@ -91,7 +91,8 @@ curl http://localhost:8001/health | python3 -m json.tool
     "get_agent_playbook", "get_user_quickstart", "get_capability_catalog",
     "get_run_history", "get_data_health_report",
     "data_dictionary", "get_pipeline_dashboard", "get_cockpit_dashboard",
-    "ensure_artifact_server", "manage_session"
+    "ensure_artifact_server", "manage_session",
+    "upload_input", "read_artifact"
   ]
 }
 ```
@@ -189,6 +190,8 @@ When diagnosing failures, use `trace_id` from the JSON-RPC error payload and cor
 | `data_dictionary` | Column-level schema report as a standalone HTML artifact; preview surfaced in the cockpit dictionary tab |
 | `ensure_artifact_server` | Start/status the local artifact server — converts artifact file paths into browser-openable localhost URLs |
 | `manage_session` | Session lifecycle: list active sessions, inspect details, fork a session into a new run context, or rebind a session to a different run_id |
+| `upload_input` | Upload a local file as base64-encoded content through the MCP protocol — use when the file is not server-visible (e.g., server runs in a container) |
+| `read_artifact` | Read a container-local artifact and return its content through MCP — use when localhost artifact URLs are not reachable from the client |
 
 </details>
 

--- a/src/analyst_toolkit/mcp_server/destination_routing.py
+++ b/src/analyst_toolkit/mcp_server/destination_routing.py
@@ -62,7 +62,11 @@ def _local_relative_path(local_path: str) -> Path:
     except ValueError:
         if "exports" in resolved.parts:
             exports_index = resolved.parts.index("exports")
-            return Path(*resolved.parts[exports_index:])
+            # Return path *after* "exports" to avoid doubled prefix when the
+            # local_output_root already resolves to an exports directory.
+            after_exports = resolved.parts[exports_index + 1 :]
+            if after_exports:
+                return Path(*after_exports)
     return Path(resolved.name)
 
 

--- a/src/analyst_toolkit/mcp_server/input/storage.py
+++ b/src/analyst_toolkit/mcp_server/input/storage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 import re
 import tempfile
@@ -13,6 +14,8 @@ from analyst_toolkit.mcp_server.input.errors import (
     InputPathNotFoundError,
     InputPayloadTooLargeError,
 )
+
+logger = logging.getLogger(__name__)
 
 _MAX_UPLOAD_BYTES = int(os.environ.get("ANALYST_MCP_MAX_UPLOAD_BYTES", 50 * 1024 * 1024))
 
@@ -92,9 +95,23 @@ def validate_server_visible_path(path_text: str) -> Path:
         except ValueError:
             continue
     roots_display = [str(r) for r in roots]
+    logger.warning(
+        "INPUT_PATH_DENIED for %s — allowed roots: %s",
+        path_text,
+        roots_display,
+    )
+    disclose = os.environ.get("ANALYST_MCP_DISCLOSE_INPUT_ROOTS", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+    }
+    if disclose:
+        hint = f"Allowed input roots: {roots_display}. "
+    else:
+        hint = ""
     raise InputPathDeniedError(
         "Local path is not visible to the MCP runtime. "
-        f"Allowed input roots: {roots_display}. "
+        f"{hint}"
         "Set ANALYST_MCP_ALLOWED_INPUT_ROOTS to add "
         "directories, or upload the file via "
         "/inputs/upload, or use a gs:// URI."

--- a/src/analyst_toolkit/mcp_server/input/storage.py
+++ b/src/analyst_toolkit/mcp_server/input/storage.py
@@ -91,7 +91,11 @@ def validate_server_visible_path(path_text: str) -> Path:
             return candidate
         except ValueError:
             continue
+    roots_display = [str(r) for r in roots]
     raise InputPathDeniedError(
         "Local path is not visible to the MCP runtime. "
-        "Upload the file, mount the directory, or use gs://."
+        f"Allowed input roots: {roots_display}. "
+        "Set ANALYST_MCP_ALLOWED_INPUT_ROOTS to add "
+        "directories, or upload the file via "
+        "/inputs/upload, or use a gs:// URI."
     )

--- a/src/analyst_toolkit/mcp_server/server.py
+++ b/src/analyst_toolkit/mcp_server/server.py
@@ -510,8 +510,12 @@ from analyst_toolkit.mcp_server.tools import (  # noqa: F401, E402
     normalization,
     outliers,
     preflight_config,
+    read_artifact,
     session,
     validation,
+)
+from analyst_toolkit.mcp_server.tools import (
+    upload_input as upload_input_tool,
 )
 
 # --- Entry point and transport selection ---

--- a/src/analyst_toolkit/mcp_server/tools/cockpit_capabilities.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit_capabilities.py
@@ -240,6 +240,16 @@ def build_capability_catalog(*, golden_configs: dict[str, Any]) -> dict[str, Any
                 "user_editable": True,
             },
             {
+                "path": "runtime.destinations.local.enabled",
+                "description": "Mirror artifacts to a local output directory.",
+                "user_editable": True,
+            },
+            {
+                "path": "runtime.destinations.local.root",
+                "description": "Relative path for local artifact output (e.g. 'exports'). Must be within the configured local output base.",
+                "user_editable": True,
+            },
+            {
                 "path": "runtime.destinations.gcs.*",
                 "description": "Set shared GCS upload destination overrides for runtime-aware tools.",
                 "user_editable": True,
@@ -298,6 +308,8 @@ def build_capability_catalog(*, golden_configs: dict[str, Any]) -> dict[str, Any
                     "runtime.run.input_path",
                     "runtime.artifacts.export_html",
                     "runtime.artifacts.plotting",
+                    "runtime.destinations.local.enabled",
+                    "runtime.destinations.local.root",
                     "runtime.destinations.gcs.enabled",
                     "runtime.destinations.gcs.bucket_uri",
                     "runtime.destinations.gcs.prefix",

--- a/src/analyst_toolkit/mcp_server/tools/cockpit_content.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit_content.py
@@ -30,9 +30,11 @@ def user_quickstart_payload() -> dict:
 
 ## Input Ingest
 - Prefer a canonical `input_id` for user-provided datasets whenever possible.
-- If the dataset already lives at `gs://...` or a server-visible mounted path, call `register_input` first and carry the returned `input_id` or `session_id` forward.
-- If the user has a local file that is NOT server-visible, use `upload_input` to push base64-encoded file content directly through MCP. The agent reads the file locally, base64-encodes it, and sends it. This works even when the server runs in a container.
-- The HTTP `/inputs/upload` endpoint is also available for non-MCP clients.
+- Decision tree for getting data in:
+  1. **GCS or server-visible path** → `register_input(uri="gs://..." or "/mnt/data/...")`. Zero byte transfer.
+  2. **Local file (agent has it, server doesn't)** → `upload_input(filename="data.csv", content_base64="...")`. Agent reads the file, base64-encodes it, sends through MCP. Works even when the server runs in a container.
+  3. **Non-MCP client with HTTP access** → `POST /inputs/upload` (multipart form-data to `localhost:8001`).
+- If `register_input` fails with `INPUT_PATH_DENIED`, the path is not visible to the server — switch to `upload_input`.
 - Use `get_input_descriptor` to inspect the resolved canonical input reference when needed.
 
 ## Session Management
@@ -54,8 +56,10 @@ def user_quickstart_payload() -> dict:
 
 ## Dashboard Artifacts
 - In trusted/local mode, you can start a review session by building the cockpit dashboard for one human-readable landing page.
-- Use `ensure_artifact_server` before relying on localhost dashboard links.
-- If localhost dashboard URLs are not reachable (e.g., server runs in a container), use `read_artifact` with the `artifact_path` or `dashboard_path` returned by module tools to retrieve the HTML content directly through MCP.
+- Decision tree for accessing artifacts:
+  1. Call `ensure_artifact_server` first to start the localhost artifact server.
+  2. Surface the `dashboard_url` (e.g. `http://127.0.0.1:8765/exports/...`) to the user — this is the preferred path.
+  3. If the user reports the URL is unreachable, fall back to `read_artifact(artifact_path=<dashboard_path from tool output>)` to retrieve the HTML content directly through MCP.
 - Module tools can return `dashboard_url` when standalone HTML reports are uploaded or exposed for review.
 - Agents should surface those dashboard links to users instead of burying them in long summaries.
 - Use the dashboard artifact as the primary review surface when it exists.
@@ -69,6 +73,8 @@ def user_quickstart_payload() -> dict:
   - `runtime.run.input_path`
   - `runtime.artifacts.export_html`
   - `runtime.artifacts.plotting`
+  - `runtime.destinations.local.enabled` — mirror artifacts to a local directory
+  - `runtime.destinations.local.root` — relative path for local artifact output (e.g. `exports`)
   - `runtime.destinations.gcs.*`
 - Keep module `config` for business logic like normalization rules, validation rules, imputation strategies, and outlier detection settings.
 - Prefer `runtime` over editing every module config when the change is cross-cutting.
@@ -124,7 +130,8 @@ Turn plotting off for speed on large datasets, on for exploratory analysis.
                 "outputs": ["input_id", "session_id?", "summary"],
                 "notes": [
                     "Use this when data already lives at gs:// or a server-visible path.",
-                    "If the user only has a local file, upload it through /inputs/upload first and reuse the returned input_id.",
+                    "If the user has a local file that is not server-visible, use upload_input instead.",
+                    "If this fails with INPUT_PATH_DENIED, switch to upload_input.",
                 ],
             },
             {
@@ -175,7 +182,12 @@ Turn plotting off for speed on large datasets, on for exploratory analysis.
                 "arguments": {
                     "input_id": "<input_id_from_register_or_upload>",
                     "run_id": "run_001",
-                    "runtime": {"artifacts": {"export_html": True, "plotting": False}},
+                    "runtime": {
+                        "artifacts": {"export_html": True, "plotting": False},
+                        "destinations": {
+                            "local": {"enabled": True, "root": "exports"},
+                        },
+                    },
                 },
             },
             {
@@ -336,7 +348,8 @@ def agent_playbook_payload() -> dict:
                 "outputs": ["input_id", "session_id?", "summary"],
                 "notes": [
                     "Use this when data already lives at gs:// or a server-visible path.",
-                    "If the user only has a local file, upload it through /inputs/upload first and then switch to input_id.",
+                    "If the user has a local file that is not server-visible, use the upload_input MCP tool instead.",
+                    "If register_input fails with INPUT_PATH_DENIED, switch to upload_input.",
                 ],
                 "next": [offset + 2],
             },

--- a/src/analyst_toolkit/mcp_server/tools/cockpit_content.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit_content.py
@@ -31,7 +31,8 @@ def user_quickstart_payload() -> dict:
 ## Input Ingest
 - Prefer a canonical `input_id` for user-provided datasets whenever possible.
 - If the dataset already lives at `gs://...` or a server-visible mounted path, call `register_input` first and carry the returned `input_id` or `session_id` forward.
-- If the user only has a local file on their machine, use the `/inputs/upload` ingest path (or a client helper built on top of it) to obtain an `input_id` before running analysis tools.
+- If the user has a local file that is NOT server-visible, use `upload_input` to push base64-encoded file content directly through MCP. The agent reads the file locally, base64-encodes it, and sends it. This works even when the server runs in a container.
+- The HTTP `/inputs/upload` endpoint is also available for non-MCP clients.
 - Use `get_input_descriptor` to inspect the resolved canonical input reference when needed.
 
 ## Session Management
@@ -42,7 +43,7 @@ def user_quickstart_payload() -> dict:
 - `manage_session(action="rebind", session_id="...", run_id="new_run")` — change the run_id bound to an existing session.
 
 ## Recommended Order (Manual Pipeline)
-1. `register_input` or upload to `/inputs/upload`
+1. `register_input` (gs:// or server path) or `upload_input` (local file via base64)
 2. `diagnostics`
 3. `infer_configs`
 4. Review/edit configs (normalization, duplicates, outliers, imputation, validation)
@@ -54,6 +55,7 @@ def user_quickstart_payload() -> dict:
 ## Dashboard Artifacts
 - In trusted/local mode, you can start a review session by building the cockpit dashboard for one human-readable landing page.
 - Use `ensure_artifact_server` before relying on localhost dashboard links.
+- If localhost dashboard URLs are not reachable (e.g., server runs in a container), use `read_artifact` with the `artifact_path` or `dashboard_path` returned by module tools to retrieve the HTML content directly through MCP.
 - Module tools can return `dashboard_url` when standalone HTML reports are uploaded or exposed for review.
 - Agents should surface those dashboard links to users instead of burying them in long summaries.
 - Use the dashboard artifact as the primary review surface when it exists.
@@ -238,6 +240,16 @@ Turn plotting off for speed on large datasets, on for exploratory analysis.
                 "arguments_schema_hint": {"required": ["uri"]},
             },
             {
+                "label": "Upload local file",
+                "tool": "upload_input",
+                "arguments_schema_hint": {"required": ["filename", "content_base64"]},
+            },
+            {
+                "label": "Read artifact",
+                "tool": "read_artifact",
+                "arguments_schema_hint": {"required": ["artifact_path"]},
+            },
+            {
                 "label": "Run diagnostics",
                 "tool": "diagnostics",
                 "arguments_schema_hint": {"required": ["input_id|gcs_path|session_id", "run_id"]},
@@ -282,7 +294,7 @@ def agent_playbook_payload() -> dict:
         "goal": "Audit, clean, and certify a dataset with controlled user-editable configs.",
         "prerequisites": [
             "Canonical input_id from upload/register flow (preferred) or existing session_id",
-            "If no input_id exists yet: a gs:// URI or server-visible path for register_input, or an upload client that can call /inputs/upload",
+            "If no input_id exists yet: a gs:// URI or server-visible path for register_input, or use upload_input to push base64-encoded file content through MCP",
             "Stable run_id used across calls",
             "Optional output bucket/prefix overrides",
             "Optional runtime overlay for cross-cutting execution control",

--- a/src/analyst_toolkit/mcp_server/tools/read_artifact.py
+++ b/src/analyst_toolkit/mcp_server/tools/read_artifact.py
@@ -11,6 +11,16 @@ from analyst_toolkit.mcp_server.response_utils import new_trace_id
 
 logger = logging.getLogger("analyst_toolkit.mcp_server.read_artifact")
 
+
+def _is_stdio_mode() -> bool:
+    return os.environ.get("ANALYST_MCP_STDIO", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
 _MAX_ARTIFACT_BYTES = int(os.environ.get("ANALYST_MCP_MAX_ARTIFACT_READ_BYTES", 10 * 1024 * 1024))
 
 _ARTIFACT_ROOT = Path(os.environ.get("ANALYST_MCP_ARTIFACT_SERVER_ROOT", "exports")).resolve(
@@ -51,11 +61,15 @@ def _validate_artifact_path(artifact_path: str) -> tuple[Path | None, str | None
     else:
         resolved = (Path.cwd() / raw).resolve(strict=False)
 
-    # Ensure within artifact root or CWD
-    cwd = Path.cwd().resolve(strict=False)
-    artifact_root = _ARTIFACT_ROOT
+    # In stdio mode the client is local, so CWD is a reasonable root.
+    # In HTTP mode restrict to the artifact root only — CWD could expose
+    # source code, configs, or secrets to remote callers.
+    allowed_roots: list[Path] = [_ARTIFACT_ROOT]
+    if _is_stdio_mode():
+        allowed_roots.append(Path.cwd().resolve(strict=False))
+
     within_root = False
-    for allowed_root in (artifact_root, cwd):
+    for allowed_root in allowed_roots:
         try:
             resolved.relative_to(allowed_root)
             within_root = True

--- a/src/analyst_toolkit/mcp_server/tools/read_artifact.py
+++ b/src/analyst_toolkit/mcp_server/tools/read_artifact.py
@@ -1,0 +1,197 @@
+"""MCP tool: read_artifact — read container-local artifact content through MCP."""
+
+import base64
+import logging
+import mimetypes
+import os
+from pathlib import Path
+
+from analyst_toolkit.mcp_server.registry import register_tool
+from analyst_toolkit.mcp_server.response_utils import new_trace_id
+
+logger = logging.getLogger("analyst_toolkit.mcp_server.read_artifact")
+
+_MAX_ARTIFACT_BYTES = int(os.environ.get("ANALYST_MCP_MAX_ARTIFACT_READ_BYTES", 10 * 1024 * 1024))
+
+_ARTIFACT_ROOT = Path(os.environ.get("ANALYST_MCP_ARTIFACT_SERVER_ROOT", "exports")).resolve(
+    strict=False
+)
+
+_TEXT_EXTENSIONS = {
+    ".html",
+    ".htm",
+    ".csv",
+    ".tsv",
+    ".json",
+    ".yaml",
+    ".yml",
+    ".txt",
+    ".md",
+    ".xml",
+    ".log",
+}
+
+
+def _is_text_artifact(path: Path) -> bool:
+    return path.suffix.lower() in _TEXT_EXTENSIONS
+
+
+def _validate_artifact_path(artifact_path: str) -> tuple[Path | None, str | None]:
+    """Validate and resolve an artifact path, returning (resolved_path, error_message)."""
+    if not artifact_path or not artifact_path.strip():
+        return None, "artifact_path is empty."
+
+    raw = Path(artifact_path)
+    if any(part == ".." for part in raw.parts):
+        return None, "artifact_path must not contain parent-directory traversal."
+
+    # Support both relative paths (exports/reports/...) and absolute container paths
+    if raw.is_absolute():
+        resolved = raw.resolve(strict=False)
+    else:
+        resolved = (Path.cwd() / raw).resolve(strict=False)
+
+    # Ensure within artifact root or CWD
+    cwd = Path.cwd().resolve(strict=False)
+    artifact_root = _ARTIFACT_ROOT
+    within_root = False
+    for allowed_root in (artifact_root, cwd):
+        try:
+            resolved.relative_to(allowed_root)
+            within_root = True
+            break
+        except ValueError:
+            continue
+
+    if not within_root:
+        return None, "artifact_path is outside the allowed artifact root."
+
+    if not resolved.exists():
+        return None, f"Artifact not found: {artifact_path}"
+
+    if not resolved.is_file():
+        return None, f"artifact_path is not a file: {artifact_path}"
+
+    return resolved, None
+
+
+async def _toolkit_read_artifact(
+    artifact_path: str,
+    encoding: str = "auto",
+) -> dict:
+    """Read a container-local artifact and return its content through MCP.
+
+    This bridges the container isolation gap: when the artifact server at
+    127.0.0.1:8765 is not reachable from the client, agents can use this
+    tool to retrieve artifact content directly through the MCP protocol.
+
+    Text artifacts (HTML, CSV, JSON, etc.) are returned as plain text.
+    Binary artifacts are returned as base64-encoded strings.
+    """
+    trace_id = new_trace_id()
+
+    resolved, error = _validate_artifact_path(artifact_path)
+    if error:
+        return {
+            "status": "error",
+            "module": "read_artifact",
+            "code": "ARTIFACT_PATH_DENIED",
+            "message": error,
+            "trace_id": trace_id,
+        }
+
+    assert resolved is not None  # validated above
+
+    file_size = resolved.stat().st_size
+    if file_size > _MAX_ARTIFACT_BYTES:
+        return {
+            "status": "error",
+            "module": "read_artifact",
+            "code": "ARTIFACT_TOO_LARGE",
+            "message": (
+                f"Artifact is {file_size} bytes, exceeding the "
+                f"{_MAX_ARTIFACT_BYTES} byte limit. Set "
+                "ANALYST_MCP_MAX_ARTIFACT_READ_BYTES to increase."
+            ),
+            "trace_id": trace_id,
+        }
+
+    is_text = _is_text_artifact(resolved)
+    if encoding == "base64":
+        is_text = False
+    elif encoding == "text":
+        is_text = True
+
+    media_type = mimetypes.guess_type(str(resolved))[0] or "application/octet-stream"
+
+    try:
+        if is_text:
+            content = resolved.read_text(encoding="utf-8")
+            return {
+                "status": "pass",
+                "module": "read_artifact",
+                "artifact_path": str(resolved),
+                "filename": resolved.name,
+                "media_type": media_type,
+                "encoding": "text",
+                "size_bytes": file_size,
+                "content": content,
+                "trace_id": trace_id,
+            }
+        else:
+            raw = resolved.read_bytes()
+            content_b64 = base64.b64encode(raw).decode("ascii")
+            return {
+                "status": "pass",
+                "module": "read_artifact",
+                "artifact_path": str(resolved),
+                "filename": resolved.name,
+                "media_type": media_type,
+                "encoding": "base64",
+                "size_bytes": file_size,
+                "content_base64": content_b64,
+                "trace_id": trace_id,
+            }
+    except Exception:
+        logger.exception("read_artifact failed for %s (trace_id=%s)", artifact_path, trace_id)
+        return {
+            "status": "error",
+            "module": "read_artifact",
+            "code": "ARTIFACT_READ_FAILED",
+            "message": "Failed to read artifact content.",
+            "trace_id": trace_id,
+        }
+
+
+register_tool(
+    name="read_artifact",
+    fn=_toolkit_read_artifact,
+    description=(
+        "Read a container-local artifact file and return its content through MCP. "
+        "Use this when localhost artifact URLs are not reachable from the client. "
+        "Text files (HTML, CSV, JSON) are returned as plain text; binary files "
+        "as base64. Pass the artifact_path returned by module tools."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "artifact_path": {
+                "type": "string",
+                "description": (
+                    "Path to the artifact file. Accepts the artifact_path or "
+                    "dashboard_path value returned by module tools."
+                ),
+            },
+            "encoding": {
+                "type": "string",
+                "enum": ["auto", "text", "base64"],
+                "description": (
+                    "Output encoding. 'auto' detects from extension, "
+                    "'text' forces UTF-8 text, 'base64' forces base64. Default: auto."
+                ),
+                "default": "auto",
+            },
+        },
+        "required": ["artifact_path"],
+    },
+)

--- a/src/analyst_toolkit/mcp_server/tools/upload_input.py
+++ b/src/analyst_toolkit/mcp_server/tools/upload_input.py
@@ -1,0 +1,159 @@
+"""MCP tool: upload_input — accept base64-encoded file content through the MCP protocol."""
+
+import asyncio
+import base64
+import logging
+from functools import partial
+
+from analyst_toolkit.mcp_server.input.errors import InputError
+from analyst_toolkit.mcp_server.input.ingest import ingest_uploaded_bytes
+from analyst_toolkit.mcp_server.registry import register_tool
+from analyst_toolkit.mcp_server.response_utils import new_trace_id
+
+logger = logging.getLogger("analyst_toolkit.mcp_server.upload_input")
+
+_MAX_BASE64_LENGTH = 70 * 1024 * 1024  # ~52.5 MB decoded
+
+
+async def _toolkit_upload_input(
+    filename: str,
+    content_base64: str,
+    session_id: str | None = None,
+    run_id: str | None = None,
+    idempotency_key: str | None = None,
+    load_into_session: bool = True,
+) -> dict:
+    """Upload a local file as base64-encoded content through the MCP protocol.
+
+    This bridges the container isolation gap: agents that cannot reach the
+    server filesystem or the HTTP /inputs/upload endpoint can push file
+    bytes directly through MCP tool calls.
+    """
+    trace_id = new_trace_id()
+
+    if not content_base64 or not content_base64.strip():
+        return {
+            "status": "error",
+            "module": "upload_input",
+            "code": "INPUT_EMPTY_UPLOAD",
+            "message": "content_base64 is empty.",
+            "trace_id": trace_id,
+        }
+
+    if len(content_base64) > _MAX_BASE64_LENGTH:
+        return {
+            "status": "error",
+            "module": "upload_input",
+            "code": "INPUT_PAYLOAD_TOO_LARGE",
+            "message": f"Base64 payload exceeds maximum size ({_MAX_BASE64_LENGTH} bytes encoded).",
+            "trace_id": trace_id,
+        }
+
+    try:
+        payload = base64.b64decode(content_base64, validate=True)
+    except Exception:
+        return {
+            "status": "error",
+            "module": "upload_input",
+            "code": "INPUT_INVALID_BASE64",
+            "message": "content_base64 is not valid base64.",
+            "trace_id": trace_id,
+        }
+
+    if not payload:
+        return {
+            "status": "error",
+            "module": "upload_input",
+            "code": "INPUT_EMPTY_UPLOAD",
+            "message": "Decoded payload is empty.",
+            "trace_id": trace_id,
+        }
+
+    try:
+        loop = asyncio.get_running_loop()
+        descriptor, df, effective_session_id = await loop.run_in_executor(
+            None,
+            partial(
+                ingest_uploaded_bytes,
+                filename=filename,
+                payload=payload,
+                media_type=None,
+                session_id=session_id,
+                run_id=run_id,
+                idempotency_key=idempotency_key,
+                load_into_session=load_into_session,
+            ),
+        )
+    except InputError as exc:
+        logger.warning("upload_input failed (trace_id=%s, code=%s)", trace_id, exc.code)
+        return {
+            "status": "error",
+            "module": "upload_input",
+            "code": exc.code,
+            "message": exc.message,
+            "trace_id": trace_id,
+        }
+    except Exception:
+        logger.exception("upload_input unexpected failure (trace_id=%s)", trace_id)
+        return {
+            "status": "error",
+            "module": "upload_input",
+            "code": "INTERNAL_ERROR",
+            "message": "Internal server error.",
+            "trace_id": trace_id,
+        }
+
+    summary = {}
+    if df is not None:
+        summary = {"row_count": int(df.shape[0]), "column_count": int(df.shape[1])}
+    return {
+        "status": "pass",
+        "module": "upload_input",
+        "input": descriptor.to_dict(),
+        "session_id": effective_session_id or "",
+        "summary": summary,
+        "trace_id": trace_id,
+    }
+
+
+register_tool(
+    name="upload_input",
+    fn=_toolkit_upload_input,
+    description=(
+        "Upload a local file as base64-encoded content through the MCP protocol. "
+        "Use this when the file is not server-visible and cannot be registered "
+        "via register_input or uploaded via /inputs/upload. The agent reads the "
+        "local file, base64-encodes it, and sends it through this tool."
+    ),
+    input_schema={
+        "type": "object",
+        "properties": {
+            "filename": {
+                "type": "string",
+                "description": "Original filename (e.g. 'data.csv'). Used for display and format detection.",
+            },
+            "content_base64": {
+                "type": "string",
+                "description": "Base64-encoded file content.",
+            },
+            "session_id": {
+                "type": "string",
+                "description": "Optional session to bind the uploaded input to.",
+            },
+            "run_id": {
+                "type": "string",
+                "description": "Optional run identifier.",
+            },
+            "idempotency_key": {
+                "type": "string",
+                "description": "Optional stable key for idempotent uploads.",
+            },
+            "load_into_session": {
+                "type": "boolean",
+                "description": "If true, load the input into the session store. Default: true.",
+                "default": True,
+            },
+        },
+        "required": ["filename", "content_base64"],
+    },
+)

--- a/tests/mcp_server/test_destination_routing.py
+++ b/tests/mcp_server/test_destination_routing.py
@@ -24,7 +24,8 @@ def test_deliver_artifact_mirrors_to_local_root(tmp_path, monkeypatch):
     routed = Path(delivery["local_path"])
     assert routed.exists()
     assert routed.read_text(encoding="utf-8") == "<html>diag</html>"
-    assert routed == tmp_path / "routed" / "exports" / "reports" / "diag.html"
+    # _local_relative_path strips the "exports" prefix to avoid doubled paths
+    assert routed == tmp_path / "routed" / "reports" / "diag.html"
     assert delivery["reference"] == str(routed)
     assert delivery["destinations"]["local"]["status"] == "available"
 
@@ -154,3 +155,47 @@ def test_deliver_artifact_uploads_to_gcs_when_configured(tmp_path, monkeypatch):
     assert delivery["url"] == "https://storage.googleapis.com/bucket/diag.html"
     assert delivery["reference"] == "https://storage.googleapis.com/bucket/diag.html"
     assert delivery["destinations"]["gcs"]["status"] == "available"
+
+
+def test_local_relative_path_no_doubled_exports():
+    """Regression: _local_relative_path must not produce exports/exports/... paths."""
+    from analyst_toolkit.mcp_server.destination_routing import _local_relative_path
+
+    # Simulate an absolute path containing "exports" that is outside CWD
+    fake_abs = Path("/app/exports/reports/auto_heal/run1_report.html")
+    result = _local_relative_path(str(fake_abs))
+    # Should NOT start with "exports" — that prefix is stripped
+    assert result.parts[0] != "exports", f"Doubled prefix: {result}"
+    assert result == Path("reports/auto_heal/run1_report.html")
+
+
+def test_local_relative_path_preserves_relative_input():
+    """Relative paths should pass through unchanged."""
+    from analyst_toolkit.mcp_server.destination_routing import _local_relative_path
+
+    result = _local_relative_path("reports/diag.html")
+    assert result == Path("reports/diag.html")
+
+
+def test_deliver_artifact_no_doubled_exports_path(tmp_path, monkeypatch):
+    """End-to-end: routing to an 'exports' local root must not double the prefix."""
+    source = tmp_path / "exports" / "reports" / "run1_report.html"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("<html>report</html>", encoding="utf-8")
+    monkeypatch.setenv("ANALYST_MCP_LOCAL_OUTPUT_BASE", str(tmp_path))
+
+    delivery = deliver_artifact(
+        str(source),
+        run_id="run1",
+        module="auto_heal",
+        config={"local_output_root": "exports"},
+        session_id=None,
+        resolve_path_root=lambda run_id, session_id: f"paths/{run_id}",
+        logger=logging.getLogger("test"),
+    )
+
+    routed = Path(delivery["local_path"])
+    assert routed.exists()
+    # The routed path should be under exports/reports, not exports/exports/reports
+    assert "exports/exports" not in str(routed)
+    assert routed == tmp_path / "exports" / "reports" / "run1_report.html"

--- a/tests/mcp_server/test_input_ingest.py
+++ b/tests/mcp_server/test_input_ingest.py
@@ -209,9 +209,8 @@ def test_inputs_register_rejects_path_outside_allowed_roots(client, monkeypatch,
     assert response.status_code == 400
     error_msg = response.json()["detail"]["error"]
     assert "not visible to the MCP runtime" in error_msg
-    # Verify the error surfaces the allowed roots so users know what's accepted
-    assert "Allowed input roots" in error_msg
-    assert str(allowed_dir) in error_msg
+    # By default, allowed roots are NOT disclosed in the client-facing error
+    assert str(allowed_dir) not in error_msg
 
 
 def test_inputs_register_rejects_unsupported_local_format(client, clean_input_env):
@@ -341,10 +340,28 @@ def test_register_input_tool_and_diagnostics_input_id_flow(client, mocker, clean
     assert diagnostics_result["summary"]["row_count"] == 2
 
 
-def test_validate_server_visible_path_error_surfaces_allowed_roots(monkeypatch, tmp_path):
+def test_validate_server_visible_path_redacts_roots_by_default(monkeypatch, tmp_path):
     allowed = tmp_path / "my_inputs"
     allowed.mkdir()
     monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(allowed))
+    monkeypatch.delenv("ANALYST_MCP_DISCLOSE_INPUT_ROOTS", raising=False)
+
+    with pytest.raises(InputPathDeniedError) as exc_info:
+        validate_server_visible_path("/some/other/path/data.csv")
+
+    msg = str(exc_info.value)
+    assert "not visible to the MCP runtime" in msg
+    assert "ANALYST_MCP_ALLOWED_INPUT_ROOTS" in msg
+    # Roots must NOT be disclosed in the client error by default
+    assert str(allowed) not in msg
+    assert "Allowed input roots" not in msg
+
+
+def test_validate_server_visible_path_discloses_roots_when_opted_in(monkeypatch, tmp_path):
+    allowed = tmp_path / "my_inputs"
+    allowed.mkdir()
+    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(allowed))
+    monkeypatch.setenv("ANALYST_MCP_DISCLOSE_INPUT_ROOTS", "1")
 
     with pytest.raises(InputPathDeniedError) as exc_info:
         validate_server_visible_path("/some/other/path/data.csv")
@@ -352,4 +369,3 @@ def test_validate_server_visible_path_error_surfaces_allowed_roots(monkeypatch, 
     msg = str(exc_info.value)
     assert "Allowed input roots" in msg
     assert str(allowed) in msg
-    assert "ANALYST_MCP_ALLOWED_INPUT_ROOTS" in msg

--- a/tests/mcp_server/test_input_ingest.py
+++ b/tests/mcp_server/test_input_ingest.py
@@ -4,6 +4,8 @@ import pandas as pd
 import pytest
 
 from analyst_toolkit.mcp_server.input import registry as input_registry
+from analyst_toolkit.mcp_server.input.errors import InputPathDeniedError
+from analyst_toolkit.mcp_server.input.storage import validate_server_visible_path
 from analyst_toolkit.mcp_server.state import StateStore
 from analyst_toolkit.mcp_server.tools import diagnostics as diagnostics_tool
 
@@ -194,7 +196,8 @@ def test_inputs_register_uses_distinct_input_ids_for_distinct_idempotency_keys(
 
 def test_inputs_register_rejects_path_outside_allowed_roots(client, monkeypatch, clean_input_env):
     tmp_path = clean_input_env
-    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(tmp_path / "allowed"))
+    allowed_dir = tmp_path / "allowed"
+    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(allowed_dir))
 
     source = tmp_path / "dirty_penguins.csv"
     _write_sample_csv(source)
@@ -204,7 +207,11 @@ def test_inputs_register_rejects_path_outside_allowed_roots(client, monkeypatch,
         json={"uri": str(source), "load_into_session": True},
     )
     assert response.status_code == 400
-    assert "not visible to the MCP runtime" in response.json()["detail"]["error"]
+    error_msg = response.json()["detail"]["error"]
+    assert "not visible to the MCP runtime" in error_msg
+    # Verify the error surfaces the allowed roots so users know what's accepted
+    assert "Allowed input roots" in error_msg
+    assert str(allowed_dir) in error_msg
 
 
 def test_inputs_register_rejects_unsupported_local_format(client, clean_input_env):
@@ -332,3 +339,17 @@ def test_register_input_tool_and_diagnostics_input_id_flow(client, mocker, clean
     assert diagnostics_result["status"] in {"pass", "warn"}
     assert diagnostics_result["module"] == "diagnostics"
     assert diagnostics_result["summary"]["row_count"] == 2
+
+
+def test_validate_server_visible_path_error_surfaces_allowed_roots(monkeypatch, tmp_path):
+    allowed = tmp_path / "my_inputs"
+    allowed.mkdir()
+    monkeypatch.setenv("ANALYST_MCP_ALLOWED_INPUT_ROOTS", str(allowed))
+
+    with pytest.raises(InputPathDeniedError) as exc_info:
+        validate_server_visible_path("/some/other/path/data.csv")
+
+    msg = str(exc_info.value)
+    assert "Allowed input roots" in msg
+    assert str(allowed) in msg
+    assert "ANALYST_MCP_ALLOWED_INPUT_ROOTS" in msg

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -2213,14 +2213,14 @@ async def test_upload_input_rejects_invalid_base64():
 
 @pytest.mark.asyncio
 async def test_read_artifact_returns_text_html(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
     artifact_dir = tmp_path / "exports" / "reports" / "diagnostics"
     artifact_dir.mkdir(parents=True)
     artifact = artifact_dir / "run1_diagnostics_report.html"
     artifact.write_text("<html><body>Dashboard</body></html>", encoding="utf-8")
+    monkeypatch.setattr(read_artifact_tool, "_ARTIFACT_ROOT", tmp_path / "exports")
 
     result = await read_artifact_tool._toolkit_read_artifact(
-        artifact_path="exports/reports/diagnostics/run1_diagnostics_report.html",
+        artifact_path=str(artifact),
     )
     assert result["status"] == "pass"
     assert result["encoding"] == "text"
@@ -2231,15 +2231,15 @@ async def test_read_artifact_returns_text_html(tmp_path, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_read_artifact_returns_base64_for_binary(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
     artifact_dir = tmp_path / "exports" / "plots"
     artifact_dir.mkdir(parents=True)
     artifact = artifact_dir / "chart.png"
     raw_bytes = b"\x89PNG\r\n\x1a\nfake_png_data"
     artifact.write_bytes(raw_bytes)
+    monkeypatch.setattr(read_artifact_tool, "_ARTIFACT_ROOT", tmp_path / "exports")
 
     result = await read_artifact_tool._toolkit_read_artifact(
-        artifact_path="exports/plots/chart.png",
+        artifact_path=str(artifact),
     )
     assert result["status"] == "pass"
     assert result["encoding"] == "base64"
@@ -2259,10 +2259,45 @@ async def test_read_artifact_rejects_traversal():
 
 @pytest.mark.asyncio
 async def test_read_artifact_rejects_missing_file(tmp_path, monkeypatch):
-    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(read_artifact_tool, "_ARTIFACT_ROOT", tmp_path / "exports")
     result = await read_artifact_tool._toolkit_read_artifact(
-        artifact_path="exports/reports/nonexistent.html",
+        artifact_path=str(tmp_path / "exports" / "reports" / "nonexistent.html"),
     )
     assert result["status"] == "error"
     assert result["code"] == "ARTIFACT_PATH_DENIED"
     assert "not found" in result["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_read_artifact_http_mode_rejects_cwd_path(tmp_path, monkeypatch):
+    """In HTTP mode (non-stdio), only _ARTIFACT_ROOT is allowed — not CWD."""
+    monkeypatch.setattr(read_artifact_tool, "_ARTIFACT_ROOT", tmp_path / "exports")
+    monkeypatch.delenv("ANALYST_MCP_STDIO", raising=False)
+
+    # Create a file under CWD but outside artifact root
+    secret = tmp_path / "src" / "secret.py"
+    secret.parent.mkdir(parents=True)
+    secret.write_text("SECRET_KEY = 'oops'")
+
+    result = await read_artifact_tool._toolkit_read_artifact(
+        artifact_path=str(secret),
+    )
+    assert result["status"] == "error"
+    assert result["code"] == "ARTIFACT_PATH_DENIED"
+
+
+@pytest.mark.asyncio
+async def test_read_artifact_stdio_mode_allows_cwd_path(tmp_path, monkeypatch):
+    """In stdio mode, CWD is an allowed root (client is local)."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(read_artifact_tool, "_ARTIFACT_ROOT", tmp_path / "exports")
+    monkeypatch.setenv("ANALYST_MCP_STDIO", "true")
+
+    report = tmp_path / "my_report.html"
+    report.write_text("<html>local</html>")
+
+    result = await read_artifact_tool._toolkit_read_artifact(
+        artifact_path=str(report),
+    )
+    assert result["status"] == "pass"
+    assert result["encoding"] == "text"

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -1,3 +1,4 @@
+import base64
 import sys
 import types
 from pathlib import Path
@@ -14,7 +15,9 @@ import analyst_toolkit.mcp_server.tools.imputation as imputation_tool
 import analyst_toolkit.mcp_server.tools.infer_configs as infer_configs_tool
 import analyst_toolkit.mcp_server.tools.normalization as normalization_tool
 import analyst_toolkit.mcp_server.tools.outliers as outliers_tool
+import analyst_toolkit.mcp_server.tools.read_artifact as read_artifact_tool
 import analyst_toolkit.mcp_server.tools.session as session_tool
+import analyst_toolkit.mcp_server.tools.upload_input as upload_input_tool
 import analyst_toolkit.mcp_server.tools.validation as validation_tool
 from analyst_toolkit.mcp_server.state import StateStore
 
@@ -2158,3 +2161,108 @@ async def test_manage_session_unknown_action():
     result = await session_tool._toolkit_manage_session(action="delete")
     assert result["status"] == "error"
     assert result["error_code"] == "UNKNOWN_ACTION"
+
+
+# ── upload_input tests ──
+
+
+@pytest.mark.asyncio
+async def test_upload_input_accepts_base64_csv(monkeypatch, tmp_path):
+    monkeypatch.setenv("ANALYST_MCP_INPUT_ROOT", str(tmp_path / "inputs"))
+    StateStore.clear()
+
+    csv_content = b"species,bill_length_mm\nAdelie,39.1\nGentoo,46.5\n"
+    encoded = base64.b64encode(csv_content).decode("ascii")
+
+    result = await upload_input_tool._toolkit_upload_input(
+        filename="penguins.csv",
+        content_base64=encoded,
+        load_into_session=True,
+    )
+    assert result["status"] == "pass"
+    assert result["module"] == "upload_input"
+    assert result["input"]["source_type"] == "upload"
+    assert result["session_id"].startswith("sess_")
+    assert result["summary"]["row_count"] == 2
+    assert result["summary"]["column_count"] == 2
+    StateStore.clear()
+
+
+@pytest.mark.asyncio
+async def test_upload_input_rejects_empty_base64():
+    result = await upload_input_tool._toolkit_upload_input(
+        filename="data.csv",
+        content_base64="",
+    )
+    assert result["status"] == "error"
+    assert result["code"] == "INPUT_EMPTY_UPLOAD"
+
+
+@pytest.mark.asyncio
+async def test_upload_input_rejects_invalid_base64():
+    result = await upload_input_tool._toolkit_upload_input(
+        filename="data.csv",
+        content_base64="not!!!valid!!!base64",
+    )
+    assert result["status"] == "error"
+    assert result["code"] == "INPUT_INVALID_BASE64"
+
+
+# ── read_artifact tests ──
+
+
+@pytest.mark.asyncio
+async def test_read_artifact_returns_text_html(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    artifact_dir = tmp_path / "exports" / "reports" / "diagnostics"
+    artifact_dir.mkdir(parents=True)
+    artifact = artifact_dir / "run1_diagnostics_report.html"
+    artifact.write_text("<html><body>Dashboard</body></html>", encoding="utf-8")
+
+    result = await read_artifact_tool._toolkit_read_artifact(
+        artifact_path="exports/reports/diagnostics/run1_diagnostics_report.html",
+    )
+    assert result["status"] == "pass"
+    assert result["encoding"] == "text"
+    assert "<html>" in result["content"]
+    assert result["filename"] == "run1_diagnostics_report.html"
+    assert result["media_type"] == "text/html"
+
+
+@pytest.mark.asyncio
+async def test_read_artifact_returns_base64_for_binary(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    artifact_dir = tmp_path / "exports" / "plots"
+    artifact_dir.mkdir(parents=True)
+    artifact = artifact_dir / "chart.png"
+    raw_bytes = b"\x89PNG\r\n\x1a\nfake_png_data"
+    artifact.write_bytes(raw_bytes)
+
+    result = await read_artifact_tool._toolkit_read_artifact(
+        artifact_path="exports/plots/chart.png",
+    )
+    assert result["status"] == "pass"
+    assert result["encoding"] == "base64"
+    decoded = base64.b64decode(result["content_base64"])
+    assert decoded == raw_bytes
+
+
+@pytest.mark.asyncio
+async def test_read_artifact_rejects_traversal():
+    result = await read_artifact_tool._toolkit_read_artifact(
+        artifact_path="../../../etc/passwd",
+    )
+    assert result["status"] == "error"
+    assert result["code"] == "ARTIFACT_PATH_DENIED"
+    assert "traversal" in result["message"]
+
+
+@pytest.mark.asyncio
+async def test_read_artifact_rejects_missing_file(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    result = await read_artifact_tool._toolkit_read_artifact(
+        artifact_path="exports/reports/nonexistent.html",
+    )
+    assert result["status"] == "error"
+    assert result["code"] == "ARTIFACT_PATH_DENIED"
+    assert "not found" in result["message"].lower()


### PR DESCRIPTION
## Summary

- **Defect 4 (doubled path):** `_local_relative_path()` extracted paths starting from "exports" onward when an absolute path was outside CWD, producing `exports/reports/...`. When `_copy_to_local_root()` placed this under a root that already resolved to an exports directory, it created `exports/exports/reports/...`. Fixed by stripping the "exports" prefix itself and returning only the path *after* it.

- **Defect 5 (opaque INPUT_PATH_DENIED):** `validate_server_visible_path()` returned a generic error with no indication of what roots are actually accepted. Updated to include the resolved allowlist and the `ANALYST_MCP_ALLOWED_INPUT_ROOTS` env var name so users can self-serve.

- **Defect 3 (no-op artifact status):** Verified already fixed in PR #102 — no code change needed.

## Test plan

- [x] `test_local_relative_path_no_doubled_exports` — absolute path with "exports" returns path after the prefix
- [x] `test_local_relative_path_preserves_relative_input` — relative paths pass through unchanged
- [x] `test_deliver_artifact_no_doubled_exports_path` — end-to-end routing to "exports" root has no doubled prefix
- [x] `test_validate_server_visible_path_error_surfaces_allowed_roots` — denied error includes allowed roots and env var
- [x] Existing `test_inputs_register_rejects_path_outside_allowed_roots` updated to assert new message content
- [x] Full suite: 242 passed, ruff clean