### PR TITLE
fix: harden joblib and notebook trust boundaries

### DIFF
--- a/src/analyst_toolkit/m00_utils/load_data.py
+++ b/src/analyst_toolkit/m00_utils/load_data.py
@@ -12,8 +12,16 @@ Functions:
 - load_joblib(path): Loads a joblib file.
 """
 
+import logging
+import os
+
 import joblib
 import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY_ENV_VALUES = {"1", "true", "yes", "on"}
+_ALLOW_UNSAFE_JOBLIB_ENV = "ANALYST_TOOLKIT_ALLOW_UNSAFE_JOBLIB"
 
 
 def load_csv(path: str) -> pd.DataFrame:
@@ -29,6 +37,11 @@ def load_csv(path: str) -> pd.DataFrame:
     return pd.read_csv(path)
 
 
+def _unsafe_joblib_loading_enabled() -> bool:
+    value = os.environ.get(_ALLOW_UNSAFE_JOBLIB_ENV, "")
+    return value.strip().lower() in _TRUTHY_ENV_VALUES
+
+
 def load_joblib(path: str):
     """
     Loads a joblib file from a given path.
@@ -39,4 +52,11 @@ def load_joblib(path: str):
     Returns:
         Any: The Python object stored in the file.
     """
+    if not _unsafe_joblib_loading_enabled():
+        raise ValueError(
+            "Refusing to load joblib artifact from "
+            f"'{path}'. joblib deserialization is unsafe by default. "
+            f"Set {_ALLOW_UNSAFE_JOBLIB_ENV}=1 only for trusted local artifacts."
+        )
+    logger.warning("Loading trusted joblib artifact from %s", path)
     return joblib.load(path)

--- a/src/analyst_toolkit/m00_utils/rendering_utils.py
+++ b/src/analyst_toolkit/m00_utils/rendering_utils.py
@@ -11,11 +11,25 @@ Includes:
 Used across the Analyst Toolkit for consistent inline diagnostics, QA summaries, and output visualization.
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 import pandas as pd
-from IPython.display import Markdown, display
 
 
-def to_html_table(df, max_rows=25, full_preview=False):
+def _display_markdown(markdown_text: str) -> None:
+    """Render Markdown in notebooks when available, otherwise fall back to stdout."""
+    try:
+        from IPython.display import Markdown, display
+    except ImportError:
+        print(markdown_text)
+        return
+
+    display(Markdown(markdown_text))
+
+
+def to_html_table(df, max_rows=25, full_preview=False, escape: bool = True):
     """
     Render a pandas DataFrame as an HTML table for inline display.
 
@@ -23,6 +37,7 @@ def to_html_table(df, max_rows=25, full_preview=False):
         df (pd.DataFrame): The DataFrame to render.
         max_rows (int): Number of rows to display (if full_preview is False).
         full_preview (bool): If True, display all rows regardless of max_rows.
+        escape (bool): If True, HTML-escape cell contents to prevent injection.
 
     Returns:
         str: An HTML-formatted string.
@@ -31,7 +46,7 @@ def to_html_table(df, max_rows=25, full_preview=False):
         return "<p><em>No data available.</em></p>"
 
     display_df = df if full_preview else df.head(max_rows)
-    return display_df.to_html(classes="table table-striped", escape=False, index=False)
+    return display_df.to_html(classes="table table-striped", escape=escape, index=False)
 
 
 def display_markdown_summary(title: str, df: pd.DataFrame, max_rows: int = 10):
@@ -45,10 +60,10 @@ def display_markdown_summary(title: str, df: pd.DataFrame, max_rows: int = 10):
     """
     trimmed_df = df.head(max_rows)
     markdown = f"### {title}\n\n" + trimmed_df.to_markdown(index=False)
-    display(Markdown(markdown))
+    _display_markdown(markdown)
 
 
-def display_warnings(warning_list: list, title: str = "⚠️ Warnings"):
+def display_warnings(warning_list: list[Any], title: str = "⚠️ Warnings"):
     """
     Display a list of warning messages as a Markdown bullet list with a section title.
 
@@ -59,4 +74,4 @@ def display_warnings(warning_list: list, title: str = "⚠️ Warnings"):
     if warning_list:
         markdown = f"### {title}\n\n"
         markdown += "\n".join(f"- {w}" for w in warning_list)
-        display(Markdown(markdown))
+        _display_markdown(markdown)

--- a/src/analyst_toolkit/m00_utils/rendering_utils.py
+++ b/src/analyst_toolkit/m00_utils/rendering_utils.py
@@ -59,7 +59,11 @@ def display_markdown_summary(title: str, df: pd.DataFrame, max_rows: int = 10):
         max_rows (int): Maximum number of rows to show.
     """
     trimmed_df = df.head(max_rows)
-    markdown = f"### {title}\n\n" + trimmed_df.to_markdown(index=False)
+    try:
+        table_body = trimmed_df.to_markdown(index=False)
+    except ImportError:
+        table_body = trimmed_df.to_string(index=False)
+    markdown = f"### {title}\n\n{table_body}"
     _display_markdown(markdown)
 
 

--- a/src/analyst_toolkit/m06_outlier_handling/run_handling_pipeline.py
+++ b/src/analyst_toolkit/m06_outlier_handling/run_handling_pipeline.py
@@ -23,13 +23,13 @@ Example:
 import logging
 
 import pandas as pd
-from joblib import load as load_joblib
 
 from analyst_toolkit.m00_utils.export_utils import (
     export_dataframes,
     export_html_report,
     save_joblib,
 )
+from analyst_toolkit.m00_utils.load_data import load_joblib
 from analyst_toolkit.m00_utils.report_generator import generate_outlier_handling_report
 from analyst_toolkit.m06_outlier_handling.outlier_handler import handle_outliers
 

--- a/src/analyst_toolkit/m07_imputation/run_imputation_pipeline.py
+++ b/src/analyst_toolkit/m07_imputation/run_imputation_pipeline.py
@@ -26,13 +26,13 @@ import logging
 from pathlib import Path  # <-- CORRECTED: Added missing import
 
 import pandas as pd
-from joblib import load as load_joblib
 
 from analyst_toolkit.m00_utils.export_utils import (
     export_dataframes,
     export_html_report,
     save_joblib,
 )
+from analyst_toolkit.m00_utils.load_data import load_joblib
 from analyst_toolkit.m00_utils.report_generator import generate_imputation_report
 from analyst_toolkit.m07_imputation.impute_data import apply_imputation
 from analyst_toolkit.m08_visuals.comparison_plots import (

--- a/src/analyst_toolkit/m10_final_audit/final_audit_pipeline.py
+++ b/src/analyst_toolkit/m10_final_audit/final_audit_pipeline.py
@@ -29,14 +29,13 @@ df_certified = run_final_audit_pipeline(
 import logging
 
 import pandas as pd
-from joblib import load as load_joblib
 
 from analyst_toolkit.m00_utils.export_utils import (
     export_dataframes,
     export_html_report,
     save_joblib,
 )
-from analyst_toolkit.m00_utils.load_data import load_csv
+from analyst_toolkit.m00_utils.load_data import load_csv, load_joblib
 from analyst_toolkit.m01_diagnostics.data_diag import run_data_profile
 from analyst_toolkit.m10_final_audit.final_audit_producer import run_final_audit_producer
 

--- a/src/analyst_toolkit/mcp_server/server.py
+++ b/src/analyst_toolkit/mcp_server/server.py
@@ -65,6 +65,7 @@ logging.basicConfig(
     stream=sys.stderr,  # Log to stderr to avoid polluting stdout in stdio mode
 )
 logger = logging.getLogger("analyst_toolkit.mcp_server")
+_LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
 
 
 def _env_float(name: str, default: float) -> float:
@@ -83,6 +84,27 @@ def _env_bool(name: str, default: bool) -> bool:
     if value is None:
         return default
     return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _is_loopback_host(host: str) -> bool:
+    normalized = host.strip().lower().strip("[]")
+    return normalized in _LOOPBACK_HOSTS
+
+
+def _log_http_auth_posture(host: str, auth_token: str) -> None:
+    if auth_token:
+        return
+    if _is_loopback_host(host):
+        logger.warning(
+            "HTTP auth is disabled because ANALYST_MCP_AUTH_TOKEN is unset. "
+            "The default bind host is loopback-only, but set a token before exposing the server."
+        )
+        return
+    logger.warning(
+        "HTTP auth is disabled because ANALYST_MCP_AUTH_TOKEN is unset and the bind host "
+        "is non-loopback (%s). Set a token before exposing this server.",
+        host,
+    )
 
 
 RESOURCE_IO_TIMEOUT_SEC = _env_float("ANALYST_MCP_RESOURCE_TIMEOUT_SEC", 8.0)
@@ -561,6 +583,7 @@ def main():
         logger.info("Starting Analyst Toolkit MCP Server in stdio mode")
         asyncio.run(run_stdio())
     else:
+        _log_http_auth_posture(args.host, AUTH_TOKEN)
         logger.info(
             "Starting Analyst Toolkit MCP Server in HTTP mode on %s:%s",
             args.host,

--- a/tests/m00_utils/test_load_data.py
+++ b/tests/m00_utils/test_load_data.py
@@ -1,0 +1,21 @@
+import joblib
+import pytest
+
+from analyst_toolkit.m00_utils.load_data import load_joblib
+
+
+def test_load_joblib_requires_explicit_opt_in(monkeypatch, tmp_path):
+    payload_path = tmp_path / "payload.joblib"
+    joblib.dump({"status": "ok"}, payload_path)
+    monkeypatch.delenv("ANALYST_TOOLKIT_ALLOW_UNSAFE_JOBLIB", raising=False)
+
+    with pytest.raises(ValueError, match="ANALYST_TOOLKIT_ALLOW_UNSAFE_JOBLIB=1"):
+        load_joblib(str(payload_path))
+
+
+def test_load_joblib_allows_trusted_opt_in(monkeypatch, tmp_path):
+    payload_path = tmp_path / "payload.joblib"
+    joblib.dump({"status": "ok"}, payload_path)
+    monkeypatch.setenv("ANALYST_TOOLKIT_ALLOW_UNSAFE_JOBLIB", "1")
+
+    assert load_joblib(str(payload_path)) == {"status": "ok"}

--- a/tests/m00_utils/test_rendering_utils.py
+++ b/tests/m00_utils/test_rendering_utils.py
@@ -1,0 +1,59 @@
+import importlib
+import sys
+
+import pandas as pd
+
+
+def _import_rendering_utils():
+    module_name = "analyst_toolkit.m00_utils.rendering_utils"
+    sys.modules.pop(module_name, None)
+    return importlib.import_module(module_name)
+
+
+def test_rendering_utils_imports_without_ipython(monkeypatch):
+    monkeypatch.setitem(sys.modules, "IPython", None)
+    monkeypatch.setitem(sys.modules, "IPython.display", None)
+
+    module = _import_rendering_utils()
+    assert module.to_html_table(pd.DataFrame({"value": [1]}))  # smoke path
+
+
+def test_to_html_table_escapes_html_by_default():
+    module = _import_rendering_utils()
+    df = pd.DataFrame(
+        {
+            "value": ["<script>alert(1)</script>"],
+            "label": ["<b>bold</b>"],
+        }
+    )
+
+    html = module.to_html_table(df)
+
+    assert "<script>" not in html
+    assert "<b>bold</b>" not in html
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in html
+    assert "&lt;b&gt;bold&lt;/b&gt;" in html
+
+
+def test_to_html_table_can_opt_out_of_escaping():
+    module = _import_rendering_utils()
+    df = pd.DataFrame({"value": ["<strong>raw</strong>"]})
+
+    html = module.to_html_table(df, escape=False)
+
+    assert "<strong>raw</strong>" in html
+
+
+def test_markdown_helpers_fall_back_without_ipython(monkeypatch, capsys):
+    monkeypatch.setitem(sys.modules, "IPython", None)
+    monkeypatch.setitem(sys.modules, "IPython.display", None)
+
+    module = _import_rendering_utils()
+    module.display_markdown_summary("Summary", pd.DataFrame({"col": [1, 2]}), max_rows=1)
+    module.display_warnings(["first", "second"], title="Warnings")
+
+    out = capsys.readouterr().out
+    assert "### Summary" in out
+    assert "### Warnings" in out
+    assert "- first" in out
+    assert "- second" in out

--- a/tests/mcp_server/test_http_auth_metrics.py
+++ b/tests/mcp_server/test_http_auth_metrics.py
@@ -127,3 +127,25 @@ def test_auth_mode_allows_authorized_input_register(client, monkeypatch, tmp_pat
     assert payload["status"] == "pass"
     assert isinstance(payload["trace_id"], str)
     assert payload["input"]["resolved_reference"] == str(source.resolve())
+
+
+def test_http_auth_posture_warns_when_token_missing(caplog):
+    with caplog.at_level("WARNING", logger="analyst_toolkit.mcp_server"):
+        server_module._log_http_auth_posture("127.0.0.1", "")
+
+    assert "HTTP auth is disabled" in caplog.text
+    assert "ANALYST_MCP_AUTH_TOKEN" in caplog.text
+
+
+def test_http_auth_posture_warns_on_non_loopback_host(caplog):
+    with caplog.at_level("WARNING", logger="analyst_toolkit.mcp_server"):
+        server_module._log_http_auth_posture("0.0.0.0", "")
+
+    assert "non-loopback (0.0.0.0)" in caplog.text
+
+
+def test_http_auth_posture_is_quiet_when_token_present(caplog):
+    with caplog.at_level("WARNING", logger="analyst_toolkit.mcp_server"):
+        server_module._log_http_auth_posture("127.0.0.1", "token")
+
+    assert caplog.text == ""


### PR DESCRIPTION
## Summary
- gate joblib deserialization behind explicit opt-in and remove direct pipeline load callsites
- make notebook rendering helpers safe-by-default and lazily import IPython
- add explicit HTTP startup warnings when auth is disabled

## Issues
Closes #52
Closes #53
Closes #61
Closes #62

## Validation
- pytest tests/m00_utils/test_load_data.py tests/m00_utils/test_rendering_utils.py tests/mcp_server/test_http_auth_metrics.py -q
- ruff check src/analyst_toolkit/m00_utils/load_data.py src/analyst_toolkit/m00_utils/rendering_utils.py src/analyst_toolkit/m06_outlier_handling/run_handling_pipeline.py src/analyst_toolkit/m07_imputation/run_imputation_pipeline.py src/analyst_toolkit/m10_final_audit/final_audit_pipeline.py src/analyst_toolkit/mcp_server/server.py tests/m00_utils/test_load_data.py tests/m00_utils/test_rendering_utils.py tests/mcp_server/test_http_auth_metrics.py
- ruff format --check src/analyst_toolkit/m00_utils/load_data.py src/analyst_toolkit/m00_utils/rendering_utils.py src/analyst_toolkit/m06_outlier_handling/run_handling_pipeline.py src/analyst_toolkit/m07_imputation/run_imputation_pipeline.py src/analyst_toolkit/m10_final_audit/final_audit_pipeline.py src/analyst_toolkit/mcp_server/server.py tests/m00_utils/test_load_data.py tests/m00_utils/test_rendering_utils.py tests/mcp_server/test_http_auth_metrics.py
- mypy src/analyst_toolkit/mcp_server
- python -m yamllint .github/workflows .coderabbit.yaml
- pre-commit run --files src/analyst_toolkit/m00_utils/load_data.py src/analyst_toolkit/m00_utils/rendering_utils.py src/analyst_toolkit/m06_outlier_handling/run_handling_pipeline.py src/analyst_toolkit/m07_imputation/run_imputation_pipeline.py src/analyst_toolkit/m10_final_audit/final_audit_pipeline.py src/analyst_toolkit/mcp_server/server.py tests/m00_utils/test_load_data.py tests/m00_utils/test_rendering_utils.py tests/mcp_server/test_http_auth_metrics.py