### PR TITLE
fix: harden pipeline core regressions

### DIFF
--- a/src/analyst_toolkit/m01_diagnostics/data_diag.py
+++ b/src/analyst_toolkit/m01_diagnostics/data_diag.py
@@ -131,7 +131,7 @@ def generate_data_profile(
     return {"for_display": profile_for_display, "for_export": profile_for_export}
 
 
-def run_data_profile(df: pd.DataFrame, config: dict = {}, **kwargs):
+def run_data_profile(df: pd.DataFrame, config: dict | None = None, **kwargs):
     """
     Orchestrates data profiling using config-driven settings.
 
@@ -143,5 +143,5 @@ def run_data_profile(df: pd.DataFrame, config: dict = {}, **kwargs):
     Returns:
         dict: Structured profile output containing display and export blocks.
     """
-    profile_cfg = config.get("profile", {})
+    profile_cfg = (config or {}).get("profile", {})
     return generate_data_profile(df, **profile_cfg.get("settings", {}))

--- a/src/analyst_toolkit/m01_diagnostics/run_diag_pipeline.py
+++ b/src/analyst_toolkit/m01_diagnostics/run_diag_pipeline.py
@@ -30,15 +30,6 @@ from analyst_toolkit.m00_utils.export_utils import (
 )
 from analyst_toolkit.m00_utils.load_data import load_csv
 from analyst_toolkit.m01_diagnostics.data_diag import run_data_profile
-from analyst_toolkit.m08_visuals.distributions import (
-    plot_categorical_distribution,
-    plot_continuous_distribution,
-)
-from analyst_toolkit.m08_visuals.summary_plots import (
-    plot_correlation_heatmap,
-    plot_dtype_summary,
-    plot_missingness,
-)
 
 
 def configure_logging(notebook: bool = True, logging_mode: str = "auto"):
@@ -49,6 +40,26 @@ def configure_logging(notebook: bool = True, logging_mode: str = "auto"):
         logging.basicConfig(
             level=level, format="%(asctime)s - %(levelname)s - %(message)s", force=True
         )
+
+
+def _load_plotting_functions():
+    from analyst_toolkit.m08_visuals.distributions import (
+        plot_categorical_distribution,
+        plot_continuous_distribution,
+    )
+    from analyst_toolkit.m08_visuals.summary_plots import (
+        plot_correlation_heatmap,
+        plot_dtype_summary,
+        plot_missingness,
+    )
+
+    return {
+        "plot_categorical_distribution": plot_categorical_distribution,
+        "plot_continuous_distribution": plot_continuous_distribution,
+        "plot_correlation_heatmap": plot_correlation_heatmap,
+        "plot_dtype_summary": plot_dtype_summary,
+        "plot_missingness": plot_missingness,
+    }
 
 
 def run_diag_pipeline(
@@ -83,14 +94,15 @@ def run_diag_pipeline(
         if plotting_cfg.get("run", False):
             logging.info("Generating diagnostic plots...")
             save_dir = Path(plotting_cfg.get("save_dir", "exports/plots/diagnostics/")) / run_id
+            plotting = _load_plotting_functions()
 
             # Generate high-level summary plots (Fast and high-value)
             plot_paths["Summary Plots"] = [
                 p
                 for p in [
-                    plot_missingness(df, save_dir, run_id),
-                    plot_correlation_heatmap(df, save_dir, run_id),
-                    plot_dtype_summary(df, save_dir, run_id),
+                    plotting["plot_missingness"](df, save_dir, run_id),
+                    plotting["plot_correlation_heatmap"](df, save_dir, run_id),
+                    plotting["plot_dtype_summary"](df, save_dir, run_id),
                 ]
                 if p is not None
             ]
@@ -111,10 +123,11 @@ def run_diag_pipeline(
                     )
 
                 dist_num_paths = [
-                    plot_continuous_distribution(df[col], save_dir, run_id) for col in numeric_cols
+                    plotting["plot_continuous_distribution"](df[col], save_dir, run_id)
+                    for col in numeric_cols
                 ]
                 dist_cat_paths = [
-                    plot_categorical_distribution(df[col], save_dir, run_id)
+                    plotting["plot_categorical_distribution"](df[col], save_dir, run_id)
                     for col in categorical_cols
                 ]
 

--- a/src/analyst_toolkit/m03_normalization/normalize_data.py
+++ b/src/analyst_toolkit/m03_normalization/normalize_data.py
@@ -59,10 +59,11 @@ def apply_normalization(df: pd.DataFrame, config: dict) -> tuple[pd.DataFrame, p
             mapped_info = []
             for col, mapping in value_maps.items():
                 if col in df_normalized.columns:
-                    if "null" in mapping:
-                        mapping[np.nan] = mapping.pop("null")
-                    df_normalized[col] = df_normalized[col].replace(mapping)
-                    mapped_info.append({"Column": col, "Mappings Applied": len(mapping)})
+                    effective_mapping = dict(mapping)
+                    if "null" in effective_mapping:
+                        effective_mapping[np.nan] = effective_mapping.pop("null")
+                    df_normalized[col] = df_normalized[col].replace(effective_mapping)
+                    mapped_info.append({"Column": col, "Mappings Applied": len(effective_mapping)})
             if mapped_info:
                 changelog["values_mapped"] = pd.DataFrame(mapped_info)
     except Exception as e:

--- a/src/analyst_toolkit/m05_detect_outliers/detect_outliers.py
+++ b/src/analyst_toolkit/m05_detect_outliers/detect_outliers.py
@@ -71,7 +71,9 @@ def detect_outliers(df: pd.DataFrame, config: dict) -> dict:
                     "outlier_examples": str(outlier_values[:5]),
                 }
             )
-            outlier_flags[f"{col}_{method}_outlier"] = is_outlier
+            outlier_flags[f"{col}_{method}_outlier"] = is_outlier.reindex(
+                df.index, fill_value=False
+            )
 
     outlier_log_df = pd.DataFrame(outlier_log_entries)
 

--- a/src/analyst_toolkit/m07_imputation/impute_data.py
+++ b/src/analyst_toolkit/m07_imputation/impute_data.py
@@ -51,7 +51,9 @@ def apply_imputation(df: pd.DataFrame, config: dict) -> tuple[pd.DataFrame, pd.D
             elif strategy == "median":
                 fill_value = df_imputed[column].median()
             elif strategy == "mode":
-                fill_value = df_imputed[column].mode()[0]
+                mode_values = df_imputed[column].mode(dropna=True)
+                if not mode_values.empty:
+                    fill_value = mode_values.iloc[0]
             elif strategy == "constant":
                 fill_value = spec.get("value") if isinstance(spec, dict) else None
             elif strategy == "none":

--- a/src/analyst_toolkit/m10_final_audit/final_audit_producer.py
+++ b/src/analyst_toolkit/m10_final_audit/final_audit_producer.py
@@ -43,10 +43,31 @@ def _apply_final_edits(df: pd.DataFrame, config: dict) -> tuple[pd.DataFrame, pd
 
     dtype_map = config.get("coerce_dtypes", {})
     if dtype_map:
-        df_out = df_out.astype(dtype_map)
-        changelog.append(
-            {"Action": "coerce_dtypes", "Details": f"Changed types for {len(dtype_map)} columns"}
-        )
+        coerced_columns = []
+        failed_columns = []
+        for column, dtype in dtype_map.items():
+            if column not in df_out.columns:
+                failed_columns.append(f"{column} (missing)")
+                continue
+            try:
+                df_out[column] = df_out[column].astype(dtype)
+                coerced_columns.append(column)
+            except (TypeError, ValueError) as exc:
+                failed_columns.append(f"{column} ({dtype}): {exc}")
+        if coerced_columns:
+            changelog.append(
+                {
+                    "Action": "coerce_dtypes",
+                    "Details": f"Changed types for {len(coerced_columns)} columns",
+                }
+            )
+        if failed_columns:
+            changelog.append(
+                {
+                    "Action": "coerce_dtypes_failed",
+                    "Details": "; ".join(failed_columns),
+                }
+            )
 
     return df_out, pd.DataFrame(changelog)
 

--- a/tests/hardening/test_pipeline_integrations.py
+++ b/tests/hardening/test_pipeline_integrations.py
@@ -1,3 +1,7 @@
+import importlib
+import inspect
+import sys
+
 import pandas as pd
 
 
@@ -38,6 +42,17 @@ def test_normalization_no_rules_returns_unchanged():
     assert changelog == {}
 
 
+def test_normalization_value_mapping_does_not_mutate_config():
+    from analyst_toolkit.m03_normalization.normalize_data import apply_normalization
+
+    df = pd.DataFrame({"status": ["ok", None]})
+    config = {"rules": {"value_mappings": {"status": {"null": "UNKNOWN", "ok": "OK"}}}}
+
+    apply_normalization(df, config)
+
+    assert config["rules"]["value_mappings"]["status"] == {"null": "UNKNOWN", "ok": "OK"}
+
+
 def test_imputation_empty_strategies_returns_unchanged():
     """Empty strategy map should be treated as no-op, not an error."""
     from analyst_toolkit.m07_imputation.run_imputation_pipeline import run_imputation_pipeline
@@ -47,6 +62,17 @@ def test_imputation_empty_strategies_returns_unchanged():
 
     out = run_imputation_pipeline(config=cfg, df=df, notebook=False, run_id="run_imp_empty")
     pd.testing.assert_frame_equal(out, df)
+
+
+def test_imputation_mode_all_nan_column_is_noop():
+    from analyst_toolkit.m07_imputation.impute_data import apply_imputation
+
+    df = pd.DataFrame({"score": [None, None, None]})
+
+    out, changelog = apply_imputation(df, {"rules": {"strategies": {"score": "mode"}}})
+
+    pd.testing.assert_frame_equal(out, df)
+    assert changelog.empty
 
 
 def test_validation_suite_passes_with_correct_schema():
@@ -125,3 +151,68 @@ def test_validation_suite_fails_categorical_violation():
     }
     results = run_validation_suite(df, config)
     assert results["categorical_values"]["passed"] is False
+
+
+def test_run_data_profile_uses_none_default_config():
+    from analyst_toolkit.m01_diagnostics.data_diag import run_data_profile
+
+    default = inspect.signature(run_data_profile).parameters["config"].default
+
+    assert default is None
+
+
+def test_run_diag_pipeline_does_not_import_plotting_stack_when_disabled(monkeypatch):
+    module_name = "analyst_toolkit.m01_diagnostics.run_diag_pipeline"
+    plotting_modules = (
+        "analyst_toolkit.m08_visuals.distributions",
+        "analyst_toolkit.m08_visuals.summary_plots",
+    )
+    for name in plotting_modules:
+        sys.modules.pop(name, None)
+    sys.modules.pop(module_name, None)
+
+    diag_module = importlib.import_module(module_name)
+    diag_module = importlib.reload(diag_module)
+
+    monkeypatch.setattr(
+        diag_module,
+        "run_data_profile",
+        lambda df, config: {
+            "for_display": {"shape": pd.DataFrame([{"Rows": len(df), "Columns": len(df.columns)}])},
+            "for_export": {"shape": pd.DataFrame([{"Rows": len(df), "Columns": len(df.columns)}])},
+        },
+    )
+    monkeypatch.setattr(diag_module, "export_dataframes", lambda *args, **kwargs: None)
+    monkeypatch.setattr(diag_module, "export_html_report", lambda *args, **kwargs: None)
+
+    df = pd.DataFrame({"value": [1, 2, 3]})
+    diag_module.run_diag_pipeline(
+        config={
+            "diagnostics": {
+                "profile": {"run": True, "settings": {"export": False}},
+                "plotting": {"run": False},
+                "logging": "off",
+            }
+        },
+        df=df,
+        notebook=False,
+        run_id="diag_no_plots",
+    )
+
+    for name in plotting_modules:
+        assert name not in sys.modules
+
+
+def test_apply_final_edits_handles_dtype_coercion_failures():
+    from analyst_toolkit.m10_final_audit.final_audit_producer import _apply_final_edits
+
+    df = pd.DataFrame({"score": ["bad", "2"], "flag": ["1", "0"]})
+
+    out, changelog = _apply_final_edits(
+        df,
+        {"coerce_dtypes": {"score": "float64", "flag": "int64"}},
+    )
+
+    assert out["flag"].dtype == "int64"
+    assert out["score"].tolist() == ["bad", "2"]
+    assert set(changelog["Action"]) == {"coerce_dtypes", "coerce_dtypes_failed"}

--- a/tests/test_outliers.py
+++ b/tests/test_outliers.py
@@ -44,6 +44,7 @@ def test_empty_dataframe_handling():
 
 
 def test_outlier_flags_fill_false_for_null_rows():
+    """Verify that null values produce False outlier flags instead of NaN."""
     df = pd.DataFrame({"val": [1.0, None, 2.0, 3.0, 4.0, 100.0]})
     config = {"detection_specs": {"val": {"method": "iqr", "iqr_multiplier": 1.5}}}
 

--- a/tests/test_outliers.py
+++ b/tests/test_outliers.py
@@ -41,3 +41,14 @@ def test_empty_dataframe_handling():
 
     assert results["outlier_log"].empty
     assert results["outlier_flags"].empty
+
+
+def test_outlier_flags_fill_false_for_null_rows():
+    df = pd.DataFrame({"val": [1.0, None, 2.0, 3.0, 4.0, 100.0]})
+    config = {"detection_specs": {"val": {"method": "iqr", "iqr_multiplier": 1.5}}}
+
+    results = detect_outliers(df, config)
+    flags = results["outlier_flags"]
+
+    assert list(flags.columns) == ["val_iqr_outlier"]
+    assert flags["val_iqr_outlier"].tolist() == [False, False, False, False, False, True]


### PR DESCRIPTION
## Summary
- remove mutable/default and in-place config mutation pitfalls in pipeline helpers
- lazy-load diagnostics plotting imports and harden edge cases in imputation, outlier flags, and final dtype coercion
- add focused regression coverage for the affected pipeline behaviors

## Issues
Closes #54
Closes #55
Closes #56
Closes #57
Closes #58
Closes #63

## Notes
- #65 remains open because infer_configs still publishes temp snapshot paths; that contract issue will be handled in a later infer/config slice.

## Validation
- 17 focused tests passed for the slice
- 92 adjacent regression tests passed
- pre-commit, ruff check, ruff format --check, yamllint, and mypy src/analyst_toolkit/mcp_server passed before the commit was prepared