### PR TITLE
fix: harden cockpit history contracts

### DIFF
--- a/src/analyst_toolkit/mcp_server/tools/cockpit.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit.py
@@ -26,6 +26,7 @@ from analyst_toolkit.mcp_server.local_artifact_server import (
 )
 from analyst_toolkit.mcp_server.registry import register_tool
 from analyst_toolkit.mcp_server.response_utils import (
+    new_trace_id,
     next_action,
     with_dashboard_artifact,
     with_next_actions,
@@ -277,6 +278,7 @@ def _trusted_history_denial() -> dict[str, Any]:
     return {
         "status": "error",
         "code": "COCKPIT_HISTORY_DISABLED",
+        "trace_id": new_trace_id(),
         "message": (
             "Cockpit history access is disabled. Enable ANALYST_MCP_ENABLE_TRUSTED_HISTORY_TOOL=1 "
             "or use trusted/local stdio mode."
@@ -337,6 +339,25 @@ def _dashboard_ref(entry: dict[str, Any]) -> str:
     )
 
 
+def _discover_local_dashboard_ref(
+    module: str,
+    run_id: str,
+    session_id: str | None = None,
+) -> str:
+    candidates: list[str] = []
+    if module == "pipeline_dashboard":
+        candidates.append(_pipeline_dashboard_artifact_path(run_id, session_id))
+    elif module == "auto_heal":
+        candidates.append(f"exports/reports/auto_heal/{run_id}_auto_heal_report.html")
+    elif module == "final_audit":
+        candidates.append(f"exports/reports/final_audit/{run_id}_final_audit_report.html")
+
+    for candidate in candidates:
+        if Path(candidate).exists():
+            return build_local_artifact_url(candidate) or candidate
+    return ""
+
+
 def _export_ref(entry: dict[str, Any]) -> str:
     export_path = str(entry.get("export_path") or entry.get("xlsx_path") or "")
     return str(
@@ -380,10 +401,19 @@ def _build_recent_run_cards(limit: int) -> list[dict[str, Any]]:
             ),
             last_entry,
         )
-        pipeline_path = _pipeline_dashboard_artifact_path(run_id, session_id or None)
         pipeline_dashboard = _dashboard_ref(pipeline_entry)
-        if not pipeline_dashboard and Path(pipeline_path).exists():
-            pipeline_dashboard = pipeline_path
+        if not pipeline_dashboard:
+            pipeline_dashboard = _discover_local_dashboard_ref(
+                "pipeline_dashboard",
+                run_id,
+                session_id or None,
+            )
+        auto_heal_dashboard = _dashboard_ref(auto_heal)
+        if not auto_heal_dashboard:
+            auto_heal_dashboard = _discover_local_dashboard_ref("auto_heal", run_id)
+        final_audit_dashboard = _dashboard_ref(final_audit)
+        if not final_audit_dashboard:
+            final_audit_dashboard = _discover_local_dashboard_ref("final_audit", run_id)
         cards.append(
             {
                 "run_id": run_id,
@@ -401,10 +431,10 @@ def _build_recent_run_cards(limit: int) -> list[dict[str, Any]]:
                 "health_score": health.get("health_score", "N/A"),
                 "health_status": health.get("health_status", "unknown"),
                 "pipeline_dashboard": pipeline_dashboard,
-                "auto_heal_dashboard": _dashboard_ref(auto_heal),
-                "final_audit_dashboard": _dashboard_ref(final_audit),
-                "best_dashboard": _dashboard_ref(final_audit)
-                or _dashboard_ref(auto_heal)
+                "auto_heal_dashboard": auto_heal_dashboard,
+                "final_audit_dashboard": final_audit_dashboard,
+                "best_dashboard": final_audit_dashboard
+                or auto_heal_dashboard
                 or _dashboard_ref(latest_non_synthetic),
                 "best_export": _export_ref(final_audit)
                 or _export_ref(auto_heal)

--- a/tests/mcp_server/test_rpc_tools.py
+++ b/tests/mcp_server/test_rpc_tools.py
@@ -565,8 +565,61 @@ async def test_toolkit_get_cockpit_dashboard_denies_when_untrusted(mocker):
 
     assert result["status"] == "error"
     assert result["code"] == "COCKPIT_HISTORY_DISABLED"
+    assert isinstance(result["trace_id"], str)
+    assert result["trace_id"]
     export_html.assert_not_called()
     deliver.assert_not_called()
+
+
+def test_build_recent_run_cards_discovers_local_dashboards(mocker, tmp_path, monkeypatch):
+    history_file = tmp_path / "exports" / "reports" / "history" / "run_local_history.json"
+    history_file.parent.mkdir(parents=True, exist_ok=True)
+    history_file.write_text("[]", encoding="utf-8")
+    run_id = "run_local"
+    auto_heal_path = (
+        tmp_path / "exports" / "reports" / "auto_heal" / f"{run_id}_auto_heal_report.html"
+    )
+    final_audit_path = (
+        tmp_path / "exports" / "reports" / "final_audit" / f"{run_id}_final_audit_report.html"
+    )
+    pipeline_path = (
+        tmp_path / "exports" / "reports" / "pipeline" / f"{run_id}_pipeline_dashboard.html"
+    )
+    for artifact in (auto_heal_path, final_audit_path, pipeline_path):
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_text("<html></html>", encoding="utf-8")
+
+    mocker.patch.object(cockpit_module, "_iter_recent_history_files", return_value=[history_file])
+    mocker.patch.object(
+        cockpit_module,
+        "_read_history_entries",
+        return_value=[
+            {
+                "run_id": run_id,
+                "session_id": "",
+                "module": "diagnostics",
+                "status": "pass",
+                "timestamp": "2026-03-22T12:00:00Z",
+                "warnings": [],
+            }
+        ],
+    )
+    mocker.patch.object(
+        cockpit_module,
+        "build_data_health_report",
+        return_value={"health_score": 94.0, "health_status": "green"},
+    )
+    mocker.patch.object(cockpit_module, "_WORKSPACE_ROOT", tmp_path)
+    monkeypatch.chdir(tmp_path)
+
+    cards = cockpit_module._build_recent_run_cards(limit=5)
+
+    assert len(cards) == 1
+    card = cards[0]
+    assert card["pipeline_dashboard"].endswith(f"{run_id}_pipeline_dashboard.html")
+    assert card["auto_heal_dashboard"].endswith(f"{run_id}_auto_heal_report.html")
+    assert card["final_audit_dashboard"].endswith(f"{run_id}_final_audit_report.html")
+    assert card["best_dashboard"] == card["final_audit_dashboard"]
 
 
 def test_rpc_data_dictionary_tool(client, mocker, tmp_path):


### PR DESCRIPTION
## Summary
- add trace_id to the trusted-history denial response for cockpit access failures
- backfill cockpit recent-run cards from local pipeline, auto-heal, and final-audit dashboard artifacts when history entries are missing the dashboard refs
- add focused regression coverage for denial and local artifact discovery behavior

## Issues
Closes #64
Closes #66

## Validation
- pytest tests/mcp_server/test_rpc_tools.py -q
- pytest tests/mcp_server/test_rpc_tools.py -q -k 'cockpit_dashboard_denies_when_untrusted or build_recent_run_cards_discovers_local_dashboards'
- ruff check src/analyst_toolkit/mcp_server/tools/cockpit.py tests/mcp_server/test_rpc_tools.py
- ruff format --check src/analyst_toolkit/mcp_server/tools/cockpit.py tests/mcp_server/test_rpc_tools.py
- mypy src/analyst_toolkit/mcp_server
- pre-commit run --files src/analyst_toolkit/mcp_server/tools/cockpit.py tests/mcp_server/test_rpc_tools.py

## CodeRabbit
- attempted locally, but the CLI hung after 'Reviewing' without returning findings or a completion marker
- treated as a local tooling blocker rather than a code blocker for this slice