### PR TITLE
fix: bound long-running state growth

### DIFF
--- a/src/analyst_toolkit/mcp_server/io.py
+++ b/src/analyst_toolkit/mcp_server/io.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import threading
+from collections import OrderedDict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -57,12 +58,15 @@ def _env_bool(name: str, default: bool) -> bool:
 RUN_ID_OVERRIDE_ALLOWED = _env_bool("ANALYST_MCP_ALLOW_RUN_ID_OVERRIDE", False)
 DEDUP_RUN_ID_WARNINGS = _env_bool("ANALYST_MCP_DEDUP_RUN_ID_WARNINGS", True)
 _HISTORY_LOCKS_GUARD = threading.Lock()
-_HISTORY_LOCKS: dict[str, threading.Lock] = {}
+_MAX_HISTORY_LOCKS = 256
+_HISTORY_LOCKS: OrderedDict[str, threading.Lock] = OrderedDict()
 _LIFECYCLE_WARNINGS_GUARD = threading.Lock()
+_MAX_LIFECYCLE_WARNING_KEYS = 512
 _SEEN_LIFECYCLE_WARNING_KEYS: set[tuple[str, str]] = set()
 ALLOW_EMPTY_CERT_RULES = _env_bool("ANALYST_MCP_ALLOW_EMPTY_CERT_RULES", False)
 _HISTORY_READ_META_GUARD = threading.Lock()
-_LAST_HISTORY_READ_META: dict[tuple[str, Optional[str]], dict[str, Any]] = {}
+_MAX_HISTORY_READ_META = 256
+_LAST_HISTORY_READ_META: OrderedDict[tuple[str, Optional[str]], dict[str, Any]] = OrderedDict()
 
 
 def coerce_config(config: Optional[dict], module: str) -> dict:
@@ -434,9 +438,13 @@ def _history_lock_for(path: Path) -> threading.Lock:
     key = str(path.resolve())
     with _HISTORY_LOCKS_GUARD:
         lock = _HISTORY_LOCKS.get(key)
-        if lock is None:
-            lock = threading.Lock()
-            _HISTORY_LOCKS[key] = lock
+        if lock is not None:
+            _HISTORY_LOCKS.move_to_end(key)
+            return lock
+        if len(_HISTORY_LOCKS) >= _MAX_HISTORY_LOCKS:
+            _HISTORY_LOCKS.popitem(last=False)
+        lock = threading.Lock()
+        _HISTORY_LOCKS[key] = lock
         return lock
 
 
@@ -447,6 +455,8 @@ def _should_emit_lifecycle_warning(session_id: str, requested_run_id: str) -> bo
     with _LIFECYCLE_WARNINGS_GUARD:
         if key in _SEEN_LIFECYCLE_WARNING_KEYS:
             return False
+        if len(_SEEN_LIFECYCLE_WARNING_KEYS) >= _MAX_LIFECYCLE_WARNING_KEYS:
+            _SEEN_LIFECYCLE_WARNING_KEYS.clear()
         _SEEN_LIFECYCLE_WARNING_KEYS.add(key)
         return True
 
@@ -454,7 +464,11 @@ def _should_emit_lifecycle_warning(session_id: str, requested_run_id: str) -> bo
 def _set_last_history_meta(run_id: str, session_id: Optional[str], meta: dict[str, Any]) -> None:
     key = (run_id, session_id)
     with _HISTORY_READ_META_GUARD:
+        if key in _LAST_HISTORY_READ_META:
+            _LAST_HISTORY_READ_META.move_to_end(key)
         _LAST_HISTORY_READ_META[key] = {
             "parse_errors": list(meta.get("parse_errors", [])),
             "skipped_records": int(meta.get("skipped_records", 0)),
         }
+        while len(_LAST_HISTORY_READ_META) > _MAX_HISTORY_READ_META:
+            _LAST_HISTORY_READ_META.popitem(last=False)

--- a/src/analyst_toolkit/mcp_server/job_state.py
+++ b/src/analyst_toolkit/mcp_server/job_state.py
@@ -17,6 +17,28 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+def _env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _env_float(name: str, default: float) -> float:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    try:
+        parsed = float(value)
+    except ValueError:
+        return default
+    return parsed if parsed >= 0 else default
+
+
 class JobStore:
     """
     Thread-safe job store with best-effort local persistence.
@@ -29,6 +51,8 @@ class JobStore:
     _lock: threading.Lock = threading.Lock()
     _jobs: dict[str, dict[str, Any]] = {}
     _loaded: bool = False
+    _max_jobs: int = _env_int("ANALYST_MCP_MAX_JOBS", 512)
+    _job_ttl_sec: float = _env_float("ANALYST_MCP_JOB_TTL_SEC", 86400.0)
 
     @classmethod
     def _state_path(cls) -> Path:
@@ -72,6 +96,36 @@ class JobStore:
         tmp.replace(path)
 
     @classmethod
+    def _prune_unsafe(cls, now: float) -> None:
+        ttl = cls._job_ttl_sec
+        if ttl > 0:
+            expired = []
+            for job_id, job in list(cls._jobs.items()):
+                if str(job.get("state")) not in {"succeeded", "failed"}:
+                    continue
+                anchor = float(job.get("finished_at") or job.get("updated_at") or 0)
+                if anchor and now - anchor > ttl:
+                    expired.append(job_id)
+            for job_id in expired:
+                cls._jobs.pop(job_id, None)
+
+        overflow = len(cls._jobs) - cls._max_jobs
+        if overflow <= 0:
+            return
+
+        def sort_key(item: tuple[str, dict[str, Any]]) -> tuple[int, float]:
+            _, job = item
+            state = str(job.get("state"))
+            terminal_rank = 0 if state in {"succeeded", "failed"} else 1
+            timestamp = float(job.get("finished_at") or job.get("updated_at") or 0)
+            return terminal_rank, timestamp
+
+        for job_id, _job in sorted(cls._jobs.items(), key=sort_key):
+            if len(cls._jobs) <= cls._max_jobs:
+                break
+            cls._jobs.pop(job_id, None)
+
+    @classmethod
     def create(
         cls,
         module: str,
@@ -82,6 +136,7 @@ class JobStore:
         job_id = f"job_{uuid.uuid4().hex[:12]}"
         with cls._lock:
             cls._ensure_loaded_unsafe()
+            cls._prune_unsafe(now)
             cls._jobs[job_id] = {
                 "job_id": job_id,
                 "module": module,
@@ -103,6 +158,7 @@ class JobStore:
         now = time.time()
         with cls._lock:
             cls._ensure_loaded_unsafe()
+            cls._prune_unsafe(now)
             job = cls._jobs.get(job_id)
             if not job:
                 return
@@ -116,6 +172,7 @@ class JobStore:
         now = time.time()
         with cls._lock:
             cls._ensure_loaded_unsafe()
+            cls._prune_unsafe(now)
             job = cls._jobs.get(job_id)
             if not job:
                 return
@@ -124,6 +181,7 @@ class JobStore:
             job["updated_at"] = now
             job["result"] = cls._to_json_safe(deepcopy(result or {}))
             job["error"] = None
+            cls._prune_unsafe(now)
             cls._persist_unsafe()
 
     @classmethod
@@ -131,6 +189,7 @@ class JobStore:
         now = time.time()
         with cls._lock:
             cls._ensure_loaded_unsafe()
+            cls._prune_unsafe(now)
             job = cls._jobs.get(job_id)
             if not job:
                 return
@@ -138,12 +197,14 @@ class JobStore:
             job["finished_at"] = now
             job["updated_at"] = now
             job["error"] = cls._to_json_safe(deepcopy(error))
+            cls._prune_unsafe(now)
             cls._persist_unsafe()
 
     @classmethod
     def get(cls, job_id: str) -> dict[str, Any] | None:
         with cls._lock:
             cls._ensure_loaded_unsafe()
+            cls._prune_unsafe(time.time())
             job = cls._jobs.get(job_id)
             return deepcopy(job) if job else None
 
@@ -151,6 +212,7 @@ class JobStore:
     def list(cls, limit: int = 20, state: str | None = None) -> list[dict[str, Any]]:
         with cls._lock:
             cls._ensure_loaded_unsafe()
+            cls._prune_unsafe(time.time())
             rows = list(cls._jobs.values())
         if state:
             rows = [r for r in rows if str(r.get("state")) == state]

--- a/src/analyst_toolkit/mcp_server/tools/cockpit.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit.py
@@ -889,7 +889,9 @@ async def _toolkit_get_pipeline_dashboard(run_id: str, session_id: str | None = 
     res = with_dashboard_artifact(
         res, artifact_path=artifact_path, artifact_url=artifact_url, label="Pipeline dashboard"
     )
-    append_to_run_history(run_id, res, session_id=effective_session_id or None)
+    existing_pipeline_dashboard = latest_by_module.get("pipeline_dashboard", {})
+    if not existing_pipeline_dashboard:
+        append_to_run_history(run_id, res, session_id=effective_session_id or None)
     res = with_next_actions(
         res,
         [

--- a/tests/hardening/test_history_and_contracts.py
+++ b/tests/hardening/test_history_and_contracts.py
@@ -2,6 +2,7 @@ import threading
 
 import pandas as pd
 
+import analyst_toolkit.mcp_server.io as io_module
 from analyst_toolkit.mcp_server.io import (
     _resolve_path_root,
     append_to_run_history,
@@ -138,3 +139,29 @@ def test_build_artifact_contract_warns_for_server_local_export(tmp_path, monkeyp
     assert contract["artifact_matrix"]["data_export"]["status"] == "available"
     assert contract["artifact_matrix"]["data_export"]["reason"] == "server_local_path"
     assert any("server runtime filesystem" in w for w in contract["artifact_warnings"])
+
+
+def test_history_lock_cache_is_bounded(tmp_path, monkeypatch):
+    monkeypatch.setattr(io_module, "_HISTORY_LOCKS", io_module.OrderedDict())
+
+    first_path = tmp_path / "history_0.json"
+    first_lock = io_module._history_lock_for(first_path)
+    for idx in range(io_module._MAX_HISTORY_LOCKS + 25):
+        io_module._history_lock_for(tmp_path / f"history_{idx}.json")
+
+    assert len(io_module._HISTORY_LOCKS) == io_module._MAX_HISTORY_LOCKS
+    refreshed_lock = io_module._history_lock_for(first_path)
+    assert refreshed_lock is not first_lock
+    assert len(io_module._HISTORY_LOCKS) == io_module._MAX_HISTORY_LOCKS
+
+
+def test_last_history_meta_cache_is_bounded(monkeypatch):
+    monkeypatch.setattr(io_module, "_LAST_HISTORY_READ_META", io_module.OrderedDict())
+
+    for idx in range(io_module._MAX_HISTORY_READ_META + 10):
+        io_module._set_last_history_meta(
+            f"run_{idx}", None, {"parse_errors": [], "skipped_records": idx}
+        )
+
+    assert len(io_module._LAST_HISTORY_READ_META) == io_module._MAX_HISTORY_READ_META
+    assert ("run_0", None) not in io_module._LAST_HISTORY_READ_META

--- a/tests/mcp_server/test_rpc_tools.py
+++ b/tests/mcp_server/test_rpc_tools.py
@@ -496,6 +496,48 @@ async def test_toolkit_get_pipeline_dashboard_uses_session_specific_artifact_pat
 
 
 @pytest.mark.asyncio
+async def test_toolkit_get_pipeline_dashboard_does_not_append_duplicate_history_on_retry(mocker):
+    history = [
+        {
+            "module": "pipeline_dashboard",
+            "status": "pass",
+            "session_id": "",
+            "artifact_path": "exports/reports/pipeline/run-pipeline-001_pipeline_dashboard.html",
+            "artifact_url": "https://example.com/pipeline.html",
+            "summary": {"health_score": 95},
+        }
+    ]
+    mocker.patch.object(cockpit_module, "get_run_history", return_value=history)
+    mocker.patch.object(
+        cockpit_module,
+        "get_last_history_read_meta",
+        return_value={"parse_errors": [], "skipped_records": 0},
+    )
+    mocker.patch.object(
+        cockpit_module,
+        "export_html_report",
+        return_value="/tmp/run-pipeline-001_pipeline_dashboard.html",
+    )
+    append_history = mocker.patch.object(cockpit_module, "append_to_run_history")
+    mocker.patch.object(
+        cockpit_module,
+        "deliver_artifact",
+        return_value={
+            "reference": "https://example.com/pipeline.html",
+            "local_path": "/tmp/run-pipeline-001_pipeline_dashboard.html",
+            "url": "https://example.com/pipeline.html",
+            "warnings": [],
+            "destinations": {},
+        },
+    )
+
+    result = await cockpit_module._toolkit_get_pipeline_dashboard(run_id="run-pipeline-001")
+
+    assert result["status"] == "pass"
+    append_history.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_toolkit_get_cockpit_dashboard_builds_operator_hub(mocker):
     mocker.patch.object(cockpit_module, "_trusted_history_enabled", return_value=True)
     mocker.patch.object(

--- a/tests/test_job_state.py
+++ b/tests/test_job_state.py
@@ -1,6 +1,7 @@
 """test_job_state.py — persistence and concurrency checks for async job store."""
 
 import threading
+import time
 
 from analyst_toolkit.mcp_server.job_state import JobStore
 
@@ -61,3 +62,40 @@ def test_job_store_thread_safe_under_concurrent_creates(tmp_path, monkeypatch):
     assert len(set(created)) == 25
     jobs = JobStore.list(limit=50)
     assert len(jobs) >= 25
+
+
+def test_job_store_prunes_old_terminal_jobs_by_ttl(tmp_path, monkeypatch):
+    _reset_job_store(tmp_path, monkeypatch)
+    monkeypatch.setattr(JobStore, "_job_ttl_sec", 5.0)
+
+    now = 1000.0
+    monkeypatch.setattr(time, "time", lambda: now)
+    old_job = JobStore.create(module="auto_heal", run_id="run_old")
+    JobStore.mark_running(old_job)
+    JobStore.mark_succeeded(old_job, result={"status": "pass"})
+
+    now = 1007.0
+    fresh_job = JobStore.create(module="auto_heal", run_id="run_fresh")
+
+    assert JobStore.get(old_job) is None
+    assert JobStore.get(fresh_job) is not None
+
+
+def test_job_store_caps_retained_jobs(tmp_path, monkeypatch):
+    _reset_job_store(tmp_path, monkeypatch)
+    monkeypatch.setattr(JobStore, "_max_jobs", 3)
+    monkeypatch.setattr(JobStore, "_job_ttl_sec", 0.0)
+
+    created: list[str] = []
+    for idx in range(5):
+        job_id = JobStore.create(module="auto_heal", run_id=f"run_{idx}")
+        JobStore.mark_running(job_id)
+        JobStore.mark_succeeded(job_id, result={"idx": idx})
+        created.append(job_id)
+
+    jobs = JobStore.list(limit=10)
+    job_ids = {job["job_id"] for job in jobs}
+
+    assert len(jobs) == 3
+    assert created[0] not in job_ids
+    assert created[1] not in job_ids


### PR DESCRIPTION
## Summary
- bound long-lived MCP history caches in io.py with deterministic eviction
- add TTL and hard-cap pruning to JobStore so async job retention does not grow without bound
- make synthetic pipeline dashboard history appends idempotent on retry

## Issues
Closes #59
Closes #60
Closes #67

## Validation
- pytest tests/hardening/test_history_and_contracts.py tests/test_job_state.py tests/mcp_server/test_rpc_tools.py -q
- pytest tests/hardening/test_history_and_contracts.py tests/test_job_state.py tests/mcp_server/test_rpc_tools.py -q -k 'history_lock_cache_is_bounded or last_history_meta_cache_is_bounded or job_store_prunes_old_terminal_jobs_by_ttl or job_store_caps_retained_jobs or pipeline_dashboard_does_not_append_duplicate_history_on_retry'
- ruff check src/analyst_toolkit/mcp_server/io.py src/analyst_toolkit/mcp_server/job_state.py src/analyst_toolkit/mcp_server/tools/cockpit.py tests/hardening/test_history_and_contracts.py tests/test_job_state.py tests/mcp_server/test_rpc_tools.py
- ruff format --check src/analyst_toolkit/mcp_server/io.py src/analyst_toolkit/mcp_server/job_state.py src/analyst_toolkit/mcp_server/tools/cockpit.py tests/hardening/test_history_and_contracts.py tests/test_job_state.py tests/mcp_server/test_rpc_tools.py
- mypy src/analyst_toolkit/mcp_server
- pre-commit run --files src/analyst_toolkit/mcp_server/io.py src/analyst_toolkit/mcp_server/job_state.py src/analyst_toolkit/mcp_server/tools/cockpit.py tests/hardening/test_history_and_contracts.py tests/test_job_state.py tests/mcp_server/test_rpc_tools.py

## CodeRabbit
- attempted locally, but the CLI hung after 'Reviewing' without returning findings or a completion marker
- treated as a local tooling blocker rather than a code blocker for this slice