### PR TITLE
fix: harden infer config contracts

### DIFF
--- a/src/analyst_toolkit/mcp_server/config_normalizers.py
+++ b/src/analyst_toolkit/mcp_server/config_normalizers.py
@@ -5,6 +5,10 @@ config_normalizers.py — Shared config normalization helpers for MCP tools.
 from copy import deepcopy
 from typing import Any
 
+INFER_CONFIG_REQUIRED_WARNING = (
+    "No inferred or explicit config found. Run infer_configs first for meaningful results."
+)
+
 
 def normalize_validation_config(config: dict[str, Any]) -> dict[str, Any]:
     """
@@ -170,3 +174,65 @@ def normalize_module_config(module_name: str, config: dict[str, Any]) -> dict[st
         return deepcopy(config[module_name])
 
     return deepcopy(config)
+
+
+def has_actionable_validation_config(config: dict[str, Any]) -> bool:
+    """Return True when validation rules contain at least one meaningful constraint."""
+    normalized = normalize_validation_config(config)
+    schema_cfg = normalized.get("schema_validation", {})
+    if not isinstance(schema_cfg, dict):
+        return False
+    rules = schema_cfg.get("rules", {})
+    if not isinstance(rules, dict):
+        return False
+    return any(
+        bool(rules.get(key))
+        for key in (
+            "expected_columns",
+            "expected_types",
+            "categorical_values",
+            "numeric_ranges",
+            "disallowed_null_columns",
+        )
+    )
+
+
+def has_actionable_normalization_config(config: dict[str, Any]) -> bool:
+    """Return True when normalization contains at least one transformation rule."""
+    if "normalization" in config and isinstance(config.get("normalization"), dict):
+        normalized = deepcopy(config["normalization"])
+    else:
+        normalized = deepcopy(config)
+    if not isinstance(normalized, dict):
+        return False
+    rules = normalized.get("rules", {})
+    return isinstance(rules, dict) and any(bool(value) for value in rules.values())
+
+
+def has_actionable_imputation_config(config: dict[str, Any]) -> bool:
+    """Return True when imputation contains at least one executable strategy or rule."""
+    if "imputation" in config and isinstance(config.get("imputation"), dict):
+        normalized = deepcopy(config["imputation"])
+    else:
+        normalized = deepcopy(config)
+    if not isinstance(normalized, dict):
+        return False
+    rules = normalized.get("rules", {})
+    if not isinstance(rules, dict):
+        return False
+    strategies = rules.get("strategies", {})
+    if isinstance(strategies, dict) and any(bool(value) for value in strategies.values()):
+        return True
+    return any(bool(value) for key, value in rules.items() if key != "strategies")
+
+
+def has_actionable_outliers_config(config: dict[str, Any]) -> bool:
+    """Return True when outlier detection contains at least one detection spec."""
+    if "outlier_detection" in config and isinstance(config.get("outlier_detection"), dict):
+        normalized = normalize_outliers_config(config["outlier_detection"])
+    else:
+        normalized = normalize_outliers_config(config)
+    detection_specs = normalized.get("detection_specs", {})
+    return isinstance(detection_specs, dict) and any(
+        bool(spec) for spec in detection_specs.values()
+    )

--- a/src/analyst_toolkit/mcp_server/io.py
+++ b/src/analyst_toolkit/mcp_server/io.py
@@ -256,6 +256,14 @@ def get_inferred_config(session_id: str | None, module: str) -> dict:
     return parsed
 
 
+def missing_config_warning(runtime_meta: dict[str, Any]) -> str | None:
+    """Return a user-facing warning when no executable config layers were supplied."""
+    resolved_layers = runtime_meta.get("resolved_layers", {})
+    if any(resolved_layers.get(layer) for layer in ("inferred", "provided", "explicit")):
+        return None
+    return "No inferred or explicit config found. Run infer_configs first for meaningful results."
+
+
 def get_session_run_id(session_id: str) -> Optional[str]:
     return StateStore.get_run_id(session_id)
 

--- a/src/analyst_toolkit/mcp_server/tools/duplicates.py
+++ b/src/analyst_toolkit/mcp_server/tools/duplicates.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 from analyst_toolkit.m04_duplicates.run_dupes_pipeline import run_duplicates_pipeline
+from analyst_toolkit.mcp_server.config_normalizers import INFER_CONFIG_REQUIRED_WARNING
 from analyst_toolkit.mcp_server.io import (
     append_to_run_history,
     build_artifact_contract,
@@ -16,6 +17,7 @@ from analyst_toolkit.mcp_server.io import (
     get_inferred_config,
     get_session_metadata,
     load_input,
+    missing_config_warning,
     resolve_run_context,
     save_output,
     save_to_session,
@@ -143,11 +145,17 @@ async def _toolkit_duplicates(
     artifact_delivery: dict[str, Any] = empty_delivery_state()
     xlsx_delivery: dict[str, Any] = empty_delivery_state()
     plot_delivery: dict[str, dict] = {}
-    warnings: list = []
-    warnings.extend(lifecycle["warnings"])
-    warnings.extend(runtime_warnings)
-    warnings.extend(runtime_meta["runtime_warnings"])
-    warnings.extend(export_delivery["warnings"])
+    status_warnings: list = []
+    advisory_warnings: list = []
+    status_warnings.extend(lifecycle["warnings"])
+    status_warnings.extend(runtime_warnings)
+    status_warnings.extend(runtime_meta["runtime_warnings"])
+    if not base_cfg:
+        advisory_warnings.append(INFER_CONFIG_REQUIRED_WARNING)
+    status_warnings.extend(export_delivery["warnings"])
+    config_warning = missing_config_warning(runtime_meta)
+    if config_warning:
+        advisory_warnings.append(config_warning)
 
     if should_export_html(config):
         artifact_path = f"exports/reports/duplicates/{run_id}_duplicates_report.html"
@@ -160,7 +168,7 @@ async def _toolkit_duplicates(
         )
         artifact_path = artifact_delivery["local_path"]
         artifact_url = artifact_delivery["url"]
-        warnings.extend(artifact_delivery["warnings"])
+        status_warnings.extend(artifact_delivery["warnings"])
 
         xlsx_path = f"exports/reports/duplicates/{run_id}_duplicates_report.xlsx"
         xlsx_delivery = deliver_artifact(
@@ -171,7 +179,7 @@ async def _toolkit_duplicates(
             session_id=session_id,
         )
         xlsx_url = xlsx_delivery["url"]
-        warnings.extend(xlsx_delivery["warnings"])
+        status_warnings.extend(xlsx_delivery["warnings"])
 
         # Upload plots - search both root and run_id subdir
         plot_dirs = [Path("exports/plots/duplicates"), Path(f"exports/plots/duplicates/{run_id}")]
@@ -186,7 +194,7 @@ async def _toolkit_duplicates(
                         session_id=session_id,
                     )
                     plot_delivery[plot_file.name] = delivered
-                    warnings.extend(delivered["warnings"])
+                    status_warnings.extend(delivered["warnings"])
                     if delivered["url"]:
                         plot_urls[plot_file.name] = delivered["url"]
 
@@ -207,9 +215,9 @@ async def _toolkit_duplicates(
         required_html=should_export_html(config),
         probe_local_paths=True,
     )
-    warnings.extend(artifact_contract["artifact_warnings"])
+    warnings = status_warnings + advisory_warnings + artifact_contract["artifact_warnings"]
     base_status = "pass" if duplicate_count == 0 else "warn"
-    if warnings and base_status == "pass":
+    if status_warnings and base_status == "pass":
         base_status = "warn"
     status = fold_status_with_artifacts(
         base_status, artifact_contract["missing_required_artifacts"]

--- a/src/analyst_toolkit/mcp_server/tools/imputation.py
+++ b/src/analyst_toolkit/mcp_server/tools/imputation.py
@@ -8,6 +8,10 @@ import pandas as pd
 from analyst_toolkit.m07_imputation.run_imputation_pipeline import (
     run_imputation_pipeline,
 )
+from analyst_toolkit.mcp_server.config_normalizers import (
+    INFER_CONFIG_REQUIRED_WARNING,
+    has_actionable_imputation_config,
+)
 from analyst_toolkit.mcp_server.io import (
     append_to_run_history,
     build_artifact_contract,
@@ -144,11 +148,13 @@ async def _toolkit_imputation(
     plot_delivery: dict[str, dict] = {}
 
     status_warnings: list = []
+    advisory_warnings: list = []
     status_warnings.extend(lifecycle["warnings"])
     status_warnings.extend(runtime_warnings)
     status_warnings.extend(runtime_meta["runtime_warnings"])
+    if not has_actionable_imputation_config(base_cfg):
+        advisory_warnings.append(INFER_CONFIG_REQUIRED_WARNING)
     status_warnings.extend(export_delivery["warnings"])
-
     artifact_warnings: list = []
 
     # Only expect report artifacts when imputation actually filled nulls
@@ -217,7 +223,7 @@ async def _toolkit_imputation(
         probe_local_paths=True,
     )
     artifact_warnings.extend(artifact_contract["artifact_warnings"])
-    warnings = status_warnings + artifact_warnings
+    warnings = status_warnings + advisory_warnings + artifact_warnings
     base_status = "warn" if status_warnings else "pass"
     status = fold_status_with_artifacts(
         base_status, artifact_contract["missing_required_artifacts"]

--- a/src/analyst_toolkit/mcp_server/tools/infer_configs.py
+++ b/src/analyst_toolkit/mcp_server/tools/infer_configs.py
@@ -4,10 +4,12 @@ import inspect
 import os
 import tempfile
 from pathlib import Path
+from typing import Any
 
 import yaml
 
 from analyst_toolkit.mcp_server.input.ingest import get_input_descriptor
+from analyst_toolkit.mcp_server.input.registry import get_session_input_id
 from analyst_toolkit.mcp_server.io import (
     load_input,
     resolve_run_context,
@@ -32,12 +34,14 @@ _SUPPORTED_INFER_MODULES = {
     "final_audit",
 }
 
-_INFER_MODULE_ALIASES = {
+_REQUEST_MODULE_ALIASES = {
     "dups": "duplicates",
     "duplicate": "duplicates",
     "outlier": "outliers",
     "handling": "outliers",
+    "outlier_handling": "outliers",
 }
+_TRANSIENT_PATH_KEYS = ("raw_data_path", "input_path", "input_df_path")
 
 
 def _call_external_infer_configs(
@@ -88,8 +92,7 @@ def _module_name_from_generated_file(path: Path) -> str | None:
             stem = stem[: -len(suffix)]
             break
 
-    normalized = _INFER_MODULE_ALIASES.get(stem, stem)
-    return normalized if normalized in _SUPPORTED_INFER_MODULES else None
+    return stem if stem in _SUPPORTED_INFER_MODULES else None
 
 
 def _module_name_from_generated_yaml(raw_yaml: str) -> str | None:
@@ -102,7 +105,9 @@ def _module_name_from_generated_yaml(raw_yaml: str) -> str | None:
     for key in loaded:
         if not isinstance(key, str):
             continue
-        module_name = _module_name_from_generated_file(Path(f"{key}.yaml"))
+        module_name = key if key in _SUPPORTED_INFER_MODULES else None
+        if module_name is None and key == "outlier_detection":
+            module_name = "outliers"
         if module_name is not None:
             return module_name
     return None
@@ -120,10 +125,114 @@ def _trusted_generated_config_root() -> Path:
     return (Path.cwd() / "config").resolve()
 
 
+def _normalize_requested_modules(modules: list[str] | None) -> list[str] | None:
+    if modules is None:
+        return sorted(_SUPPORTED_INFER_MODULES)
+
+    normalized: list[str] = []
+    for module in modules:
+        candidate = _REQUEST_MODULE_ALIASES.get(module, module)
+        if candidate in _SUPPORTED_INFER_MODULES and candidate not in normalized:
+            normalized.append(candidate)
+    return normalized
+
+
+def _replace_transient_paths(
+    value: Any,
+    *,
+    stable_input_path: str | None,
+    temp_input_path: str,
+) -> Any:
+    temp_dir = tempfile.gettempdir()
+    if isinstance(value, dict):
+        cleaned: dict[str, Any] = {}
+        for key, child in value.items():
+            cleaned_child = _replace_transient_paths(
+                child,
+                stable_input_path=stable_input_path,
+                temp_input_path=temp_input_path,
+            )
+            if key in _TRANSIENT_PATH_KEYS and isinstance(child, str):
+                child_path = child.strip()
+                is_temp_snapshot = child_path == temp_input_path
+                is_ephemeral_tmp = child_path.startswith("/tmp/") or child_path.startswith(
+                    temp_dir + os.sep
+                )
+                if is_temp_snapshot or is_ephemeral_tmp:
+                    if key in {"raw_data_path", "input_path"} and stable_input_path:
+                        cleaned[key] = stable_input_path
+                    continue
+            if cleaned_child is not None:
+                cleaned[key] = cleaned_child
+        if "outlier_handling" in cleaned and "outlier_detection" not in cleaned:
+            cleaned["outlier_detection"] = cleaned.pop("outlier_handling")
+        return cleaned
+    if isinstance(value, list):
+        return [
+            item
+            for item in (
+                _replace_transient_paths(
+                    child,
+                    stable_input_path=stable_input_path,
+                    temp_input_path=temp_input_path,
+                )
+                for child in value
+            )
+            if item is not None
+        ]
+    return value
+
+
+def _sanitize_generated_yaml(
+    raw_yaml: str,
+    *,
+    stable_input_path: str | None,
+    temp_input_path: str,
+) -> str:
+    try:
+        loaded = yaml.safe_load(raw_yaml)
+    except yaml.YAMLError:
+        return raw_yaml
+    if not isinstance(loaded, dict):
+        return raw_yaml
+    sanitized = _replace_transient_paths(
+        loaded,
+        stable_input_path=stable_input_path,
+        temp_input_path=temp_input_path,
+    )
+    return yaml.safe_dump(sanitized, sort_keys=False, allow_unicode=True)
+
+
+def _stable_input_path(
+    *,
+    gcs_path: str | None,
+    input_id: str | None,
+    descriptor,
+    session_id: str | None,
+) -> str | None:
+    if gcs_path and Path(gcs_path).exists():
+        return gcs_path
+    if descriptor and descriptor.source_type != "gcs":
+        resolved = descriptor.resolved_reference
+        if resolved and Path(resolved).exists():
+            return resolved
+    if session_id:
+        bound_input_id = get_session_input_id(session_id)
+        if bound_input_id:
+            bound_descriptor = get_input_descriptor(bound_input_id)
+            if bound_descriptor and bound_descriptor.source_type != "gcs":
+                resolved = bound_descriptor.resolved_reference
+                if resolved and Path(resolved).exists():
+                    return resolved
+    return None
+
+
 def _normalize_external_configs_result(
     configs_result,
     *,
     trusted_config_root: Path,
+    stable_input_path: str | None,
+    temp_input_path: str,
 ) -> tuple[dict[str, str], list[str], str | None]:
     """Normalize external infer_configs output into module->yaml mapping."""
     if isinstance(configs_result, dict):
@@ -138,7 +247,11 @@ def _normalize_external_configs_result(
             if module_name is None:
                 warnings.append(f"Ignored unsupported inferred module key: {module}.")
                 continue
-            normalized[module_name] = str(config_yaml)
+            normalized[module_name] = _sanitize_generated_yaml(
+                str(config_yaml),
+                stable_input_path=stable_input_path,
+                temp_input_path=temp_input_path,
+            )
         return normalized, warnings, None
 
     if isinstance(configs_result, str):
@@ -171,7 +284,11 @@ def _normalize_external_configs_result(
             ) or _module_name_from_generated_file(resolved_path)
             if module_name is None:
                 continue
-            configs[module_name] = raw_yaml
+            configs[module_name] = _sanitize_generated_yaml(
+                raw_yaml,
+                stable_input_path=stable_input_path,
+                temp_input_path=temp_input_path,
+            )
 
         warnings = []
         if not configs:
@@ -242,10 +359,13 @@ async def _toolkit_infer_configs(
         }
 
     # Resolve session_id from input descriptor if not provided
+    descriptor = None
     if not session_id and input_id:
         descriptor = get_input_descriptor(input_id)
         if descriptor and descriptor.session_id:
             session_id = descriptor.session_id
+    elif input_id:
+        descriptor = get_input_descriptor(input_id)
 
     # If we still don't have a session, start one
     if not session_id:
@@ -257,6 +377,13 @@ async def _toolkit_infer_configs(
     df.to_csv(temp_file.name, index=False)
     input_path = temp_file.name
     trusted_config_root = _trusted_generated_config_root()
+    stable_input_path = _stable_input_path(
+        gcs_path=gcs_path,
+        input_id=input_id,
+        descriptor=descriptor,
+        session_id=session_id,
+    )
+    normalized_modules = _normalize_requested_modules(modules)
 
     try:
         try:
@@ -282,12 +409,14 @@ async def _toolkit_infer_configs(
             infer_configs,
             input_path=input_path,
             options=options,
-            modules=modules,
+            modules=normalized_modules,
             sample_rows=sample_rows,
         )
         configs, normalization_warnings, generated_config_dir = _normalize_external_configs_result(
             raw_configs,
             trusted_config_root=trusted_config_root,
+            stable_input_path=stable_input_path,
+            temp_input_path=input_path,
         )
         external_warnings.extend(normalization_warnings)
     finally:
@@ -305,22 +434,35 @@ async def _toolkit_infer_configs(
         "outliers",
         "imputation",
         "validation",
-        "certification",
         "final_audit",
     ]
-    apply_actions = [
-        next_action(
-            module,
-            f"Apply inferred config for {module}.",
-            {
-                "session_id": session_id,
-                "run_id": "<set_run_id>",
-                "config": f"<configs.{module}>",
-            },
+    apply_actions = []
+    for module in module_order:
+        if module not in configs:
+            continue
+        params = {"session_id": session_id, "run_id": "<set_run_id>"}
+        if module == "final_audit":
+            params["config"] = f"<configs.{module}>"
+        else:
+            params["config"] = f"<configs.{module}>"
+        apply_actions.append(
+            next_action(
+                module,
+                f"Apply inferred config for {module}.",
+                params,
+            )
         )
-        for module in module_order
-        if module in configs
-    ]
+    if "certification" in configs and "final_audit" not in configs:
+        apply_actions.append(
+            next_action(
+                "final_audit",
+                "Apply inferred certification rules through final_audit.",
+                {
+                    "session_id": session_id,
+                    "run_id": "<set_run_id>",
+                },
+            )
+        )
 
     capability_action = next_action(
         "get_capability_catalog",
@@ -341,14 +483,18 @@ async def _toolkit_infer_configs(
         next_steps = apply_actions + [capability_action]
 
     covered_modules = sorted(configs.keys())
-    if modules:
-        normalized_requested = {_INFER_MODULE_ALIASES.get(m, m) for m in modules}
+    if normalized_modules:
+        normalized_requested = set(normalized_modules)
     else:
         normalized_requested = set(_SUPPORTED_INFER_MODULES)
     unsupported_modules = sorted(normalized_requested - set(covered_modules))
     if unsupported_modules:
         external_warnings.append(
             f"Configs were not generated for: {', '.join(unsupported_modules)}."
+        )
+        external_warnings.append(
+            "infer_configs returned partial MCP workflow coverage. Review covered_modules and "
+            "unsupported_modules before running downstream tools."
         )
 
     return with_next_actions(
@@ -397,8 +543,10 @@ _INPUT_SCHEMA = {
             "items": {"type": "string"},
             "description": (
                 "Module names to generate configs for. Defaults to all. "
-                "Valid: validation, certification, outliers, diagnostics, "
-                "normalization, duplicates, handling, imputation, final_audit."
+                "Valid public modules: validation, certification, outliers, diagnostics, "
+                "normalization, duplicates, imputation, final_audit. Legacy aliases such as "
+                "duplicate, dups, outlier, and handling normalize to the public module names. "
+                "Certification is inferred-only and should be applied through final_audit."
             ),
         },
         "sample_rows": {

--- a/src/analyst_toolkit/mcp_server/tools/normalization.py
+++ b/src/analyst_toolkit/mcp_server/tools/normalization.py
@@ -6,6 +6,10 @@ from analyst_toolkit.m03_normalization.run_normalization_pipeline import (
     count_normalization_changes,
     run_normalization_pipeline,
 )
+from analyst_toolkit.mcp_server.config_normalizers import (
+    INFER_CONFIG_REQUIRED_WARNING,
+    has_actionable_normalization_config,
+)
 from analyst_toolkit.mcp_server.io import (
     append_to_run_history,
     build_artifact_contract,
@@ -134,11 +138,13 @@ async def _toolkit_normalization(
     xlsx_delivery: dict[str, Any] = empty_delivery_state()
 
     status_warnings: list = []
+    advisory_warnings: list = []
     status_warnings.extend(lifecycle["warnings"])
     status_warnings.extend(runtime_warnings)
     status_warnings.extend(runtime_meta["runtime_warnings"])
+    if not has_actionable_normalization_config(base_cfg):
+        advisory_warnings.append(INFER_CONFIG_REQUIRED_WARNING)
     status_warnings.extend(export_delivery["warnings"])
-
     # Artifact delivery warnings are informational — collected separately so they
     # appear in the response but do not escalate base_status when the artifacts
     # are non-required.
@@ -185,7 +191,7 @@ async def _toolkit_normalization(
         probe_local_paths=True,
     )
     artifact_warnings.extend(artifact_contract["artifact_warnings"])
-    warnings = status_warnings + artifact_warnings
+    warnings = status_warnings + advisory_warnings + artifact_warnings
     base_status = "warn" if status_warnings else "pass"
     status = fold_status_with_artifacts(
         base_status, artifact_contract["missing_required_artifacts"]

--- a/src/analyst_toolkit/mcp_server/tools/outliers.py
+++ b/src/analyst_toolkit/mcp_server/tools/outliers.py
@@ -6,7 +6,11 @@ from typing import Any
 from analyst_toolkit.m05_detect_outliers.run_detection_pipeline import (
     run_outlier_detection_pipeline,
 )
-from analyst_toolkit.mcp_server.config_normalizers import normalize_outliers_config
+from analyst_toolkit.mcp_server.config_normalizers import (
+    INFER_CONFIG_REQUIRED_WARNING,
+    has_actionable_outliers_config,
+    normalize_outliers_config,
+)
 from analyst_toolkit.mcp_server.io import (
     append_to_run_history,
     build_artifact_contract,
@@ -138,11 +142,13 @@ async def _toolkit_outliers(
     xlsx_delivery: dict[str, Any] = empty_delivery_state()
     plot_delivery: dict[str, dict] = {}
     status_warnings: list = []
+    advisory_warnings: list = []
     status_warnings.extend(lifecycle["warnings"])
     status_warnings.extend(runtime_warnings)
     status_warnings.extend(runtime_meta["runtime_warnings"])
+    if not has_actionable_outliers_config(base_cfg):
+        advisory_warnings.append(INFER_CONFIG_REQUIRED_WARNING)
     status_warnings.extend(export_delivery["warnings"])
-
     artifact_warnings: list = []
     # Only expect report artifacts when outliers were actually detected
     html_requested = should_export_html(config)
@@ -211,7 +217,7 @@ async def _toolkit_outliers(
         probe_local_paths=True,
     )
     artifact_warnings.extend(artifact_contract["artifact_warnings"])
-    warnings = status_warnings + artifact_warnings
+    warnings = status_warnings + advisory_warnings + artifact_warnings
     base_status = "pass" if outlier_count == 0 else "warn"
     if status_warnings and base_status == "pass":
         base_status = "warn"

--- a/src/analyst_toolkit/mcp_server/tools/validation.py
+++ b/src/analyst_toolkit/mcp_server/tools/validation.py
@@ -6,7 +6,11 @@ from analyst_toolkit.m02_validation.run_validation_pipeline import (
     run_validation_pipeline,
 )
 from analyst_toolkit.m02_validation.validate_data import run_validation_suite
-from analyst_toolkit.mcp_server.config_normalizers import normalize_validation_config
+from analyst_toolkit.mcp_server.config_normalizers import (
+    INFER_CONFIG_REQUIRED_WARNING,
+    has_actionable_validation_config,
+    normalize_validation_config,
+)
 from analyst_toolkit.mcp_server.io import (
     append_to_run_history,
     build_artifact_contract,
@@ -145,11 +149,14 @@ async def _toolkit_validation(
     xlsx_url = ""
     artifact_delivery: dict[str, Any] = empty_delivery_state()
     xlsx_delivery: dict[str, Any] = empty_delivery_state()
-    warnings: list = []
-    warnings.extend(lifecycle["warnings"])
-    warnings.extend(runtime_warnings)
-    warnings.extend(runtime_meta["runtime_warnings"])
-    warnings.extend(export_delivery["warnings"])
+    status_warnings: list = []
+    advisory_warnings: list = []
+    status_warnings.extend(lifecycle["warnings"])
+    status_warnings.extend(runtime_warnings)
+    status_warnings.extend(runtime_meta["runtime_warnings"])
+    if not has_actionable_validation_config(base_cfg):
+        advisory_warnings.append(INFER_CONFIG_REQUIRED_WARNING)
+    status_warnings.extend(export_delivery["warnings"])
     if should_export_html(config):
         artifact_path = f"exports/reports/validation/{run_id}_validation_report.html"
         artifact_delivery = deliver_artifact(
@@ -161,7 +168,7 @@ async def _toolkit_validation(
         )
         artifact_path = artifact_delivery["local_path"]
         artifact_url = artifact_delivery["url"]
-        warnings.extend(artifact_delivery["warnings"])
+        status_warnings.extend(artifact_delivery["warnings"])
 
         xlsx_path = f"exports/reports/validation/{run_id}_validation_report.xlsx"
         xlsx_delivery = deliver_artifact(
@@ -172,7 +179,7 @@ async def _toolkit_validation(
             session_id=session_id,
         )
         xlsx_url = xlsx_delivery["url"]
-        warnings.extend(xlsx_delivery["warnings"])
+        status_warnings.extend(xlsx_delivery["warnings"])
 
     artifact_contract = build_artifact_contract(
         export_url,
@@ -186,8 +193,8 @@ async def _toolkit_validation(
         required_html=should_export_html(config),
         probe_local_paths=True,
     )
-    warnings.extend(artifact_contract["artifact_warnings"])
-    base_status = "fail" if violations_found else ("warn" if warnings else "pass")
+    warnings = status_warnings + advisory_warnings + artifact_contract["artifact_warnings"]
+    base_status = "fail" if violations_found else ("warn" if status_warnings else "pass")
     status = fold_status_with_artifacts(
         base_status, artifact_contract["missing_required_artifacts"]
     )

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -257,6 +257,35 @@ async def test_toolkit_infer_configs_includes_apply_next_actions(monkeypatch, mo
 
 
 @pytest.mark.asyncio
+async def test_toolkit_infer_configs_routes_certification_to_final_audit(monkeypatch, mocker):
+    df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
+
+    mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
+
+    def fake_infer_configs(**kwargs):
+        return {
+            "certification": "validation:\n  schema_validation:\n    run: true\n",
+        }
+
+    infer_mod = types.ModuleType("analyst_toolkit_deploy.infer_configs")
+    setattr(infer_mod, "infer_configs", fake_infer_configs)
+    pkg_mod = types.ModuleType("analyst_toolkit_deploy")
+
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy", pkg_mod)
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy.infer_configs", infer_mod)
+
+    result = await infer_configs_tool._toolkit_infer_configs(
+        session_id="sess_cert_only",
+        modules=["certification"],
+    )
+
+    assert result["status"] == "pass"
+    actions = result["next_actions"]
+    assert all(action["tool"] != "certification" for action in actions)
+    assert any(action["tool"] == "final_audit" for action in actions)
+
+
+@pytest.mark.asyncio
 async def test_toolkit_infer_configs_ignores_unsupported_external_modules_kw(monkeypatch, mocker):
     df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
 
@@ -477,9 +506,54 @@ async def test_toolkit_infer_configs_normalizes_dict_module_aliases(monkeypatch,
     assert "certification" in result["configs"]
     # outlier → outliers alias still works
     assert "outliers" in result["configs"]
+    assert "outlier_detection" in result["configs"]["outliers"]
+    assert "outlier_handling" not in result["configs"]["outliers"]
     # dups → duplicates alias still works
     assert "duplicates" in result["configs"]
     assert result["unsupported_modules"] == []
+
+
+@pytest.mark.asyncio
+async def test_infer_configs_default_request_uses_public_module_surface(monkeypatch, mocker):
+    df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
+    captured = {}
+
+    mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
+
+    def fake_infer_configs(**kwargs):
+        captured["modules"] = kwargs["modules"]
+        return {
+            "validation": "validation:\n  schema_validation:\n    run: true\n",
+            "certification": "validation:\n  schema_validation:\n    run: true\n",
+            "outliers": "outlier_detection:\n  run: true\n",
+            "diagnostics": "diagnostics:\n  run: true\n",
+            "normalization": "normalization:\n  rules: {}\n",
+            "duplicates": "duplicates:\n  subset_columns: []\n",
+            "imputation": "imputation:\n  rules: {}\n",
+            "final_audit": "final_audit:\n  certification:\n    rules: {}\n",
+        }
+
+    infer_mod = types.ModuleType("analyst_toolkit_deploy.infer_configs")
+    setattr(infer_mod, "infer_configs", fake_infer_configs)
+    pkg_mod = types.ModuleType("analyst_toolkit_deploy")
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy", pkg_mod)
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy.infer_configs", infer_mod)
+
+    result = await infer_configs_tool._toolkit_infer_configs(session_id="sess_public_surface")
+
+    assert result["status"] == "pass"
+    assert set(captured["modules"]) == {
+        "certification",
+        "diagnostics",
+        "duplicates",
+        "final_audit",
+        "imputation",
+        "normalization",
+        "outliers",
+        "validation",
+    }
+    assert "handling" not in captured["modules"]
+    assert set(result["covered_modules"]) == set(captured["modules"])
 
 
 @pytest.mark.asyncio
@@ -799,6 +873,120 @@ async def test_infer_configs_gcs_path_uses_local_snapshot(monkeypatch, mocker):
 
 
 @pytest.mark.asyncio
+async def test_infer_configs_replaces_transient_final_audit_path_with_stable_input(
+    monkeypatch, mocker, tmp_path
+):
+    df = pd.DataFrame({"id": [1, 2], "value": ["a", "b"]})
+    source_path = tmp_path / "source.csv"
+    df.to_csv(source_path, index=False)
+
+    mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
+
+    def fake_infer_configs(**kwargs):
+        return {
+            "final_audit": (
+                "final_audit:\n"
+                "  raw_data_path: /tmp/transient-source.csv\n"
+                "  certification:\n"
+                "    schema_validation:\n"
+                "      rules:\n"
+                "        expected_columns: [id, value]\n"
+            )
+        }
+
+    infer_mod = types.ModuleType("analyst_toolkit_deploy.infer_configs")
+    setattr(infer_mod, "infer_configs", fake_infer_configs)
+    pkg_mod = types.ModuleType("analyst_toolkit_deploy")
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy", pkg_mod)
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy.infer_configs", infer_mod)
+
+    result = await infer_configs_tool._toolkit_infer_configs(
+        gcs_path=str(source_path),
+    )
+
+    assert result["status"] == "pass"
+    assert "/tmp/transient-source.csv" not in result["configs"]["final_audit"]
+    assert str(source_path) in result["configs"]["final_audit"]
+
+
+@pytest.mark.asyncio
+async def test_infer_configs_strips_temp_paths_from_generated_yaml(monkeypatch, mocker):
+    df = pd.DataFrame({"id": [1, 2], "value": ["a", "b"]})
+
+    mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
+
+    def fake_infer_configs(**kwargs):
+        temp_input_path = kwargs["input_path"]
+        return {
+            "validation": (
+                "validation:\n"
+                f"  input_path: {temp_input_path}\n"
+                "  schema_validation:\n"
+                "    run: true\n"
+            ),
+            "final_audit": (
+                "final_audit:\n"
+                f"  raw_data_path: {temp_input_path}\n"
+                f"  input_path: {temp_input_path}\n"
+                f"  input_df_path: {temp_input_path}\n"
+                "  certification:\n"
+                "    schema_validation:\n"
+                "      rules:\n"
+                "        expected_columns: [id, value]\n"
+            ),
+        }
+
+    infer_mod = types.ModuleType("analyst_toolkit_deploy.infer_configs")
+    setattr(infer_mod, "infer_configs", fake_infer_configs)
+    pkg_mod = types.ModuleType("analyst_toolkit_deploy")
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy", pkg_mod)
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy.infer_configs", infer_mod)
+
+    result = await infer_configs_tool._toolkit_infer_configs(
+        session_id="sess_strip_paths",
+        modules=["validation", "final_audit"],
+    )
+
+    assert result["status"] == "pass"
+    final_yaml = result["configs"]["final_audit"]
+    assert "/tmp/" not in final_yaml
+    assert "input_df_path" not in final_yaml
+    assert "raw_data_path" not in final_yaml
+    validation_yaml = result["configs"]["validation"]
+    assert "/tmp/" not in validation_yaml
+    assert "input_path" not in validation_yaml
+
+
+@pytest.mark.asyncio
+async def test_infer_configs_ignores_internal_handling_output(monkeypatch, mocker):
+    df = pd.DataFrame({"id": [1, 2], "value": [1.0, 2.0]})
+
+    mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
+
+    def fake_infer_configs(**kwargs):
+        return {
+            "outliers": "outlier_detection:\n  detection_specs:\n    value:\n      method: iqr\n",
+            "handling": "outlier_handling:\n  handling_specs:\n    value:\n      strategy: median\n",
+        }
+
+    infer_mod = types.ModuleType("analyst_toolkit_deploy.infer_configs")
+    setattr(infer_mod, "infer_configs", fake_infer_configs)
+    pkg_mod = types.ModuleType("analyst_toolkit_deploy")
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy", pkg_mod)
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy.infer_configs", infer_mod)
+
+    result = await infer_configs_tool._toolkit_infer_configs(
+        session_id="sess_outlier_contract",
+        modules=["outliers"],
+    )
+
+    assert result["status"] == "pass"
+    assert result["covered_modules"] == ["outliers"]
+    assert "outlier_detection" in result["configs"]["outliers"]
+    assert "outlier_handling" not in result["configs"]["outliers"]
+
+
+@pytest.mark.asyncio
 async def test_infer_configs_surfaces_covered_and_unsupported_modules(monkeypatch, mocker):
     df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
 
@@ -868,6 +1056,7 @@ async def test_infer_configs_reports_unsupported_when_partial(monkeypatch, mocke
     assert result["covered_modules"] == ["outliers", "validation"]
     assert result["unsupported_modules"] == ["normalization"]
     assert any("not generated for" in w for w in result["warnings"])
+    assert any("partial MCP workflow coverage" in w for w in result["warnings"])
 
 
 @pytest.mark.asyncio
@@ -898,6 +1087,40 @@ async def test_infer_configs_aliased_requests_resolve_before_unsupported_check(m
     assert "outliers" in result["configs"]
     # handling resolves to outliers, certification is its own module — neither unsupported
     assert result["unsupported_modules"] == []
+
+
+@pytest.mark.asyncio
+async def test_infer_configs_routes_certification_next_action_through_final_audit(
+    monkeypatch, mocker
+):
+    df = pd.DataFrame({"id": [1, 2], "name": ["a", "b"]})
+    mocker.patch.object(infer_configs_tool, "load_input", return_value=df)
+
+    def fake_infer_configs(**kwargs):
+        return {
+            "certification": (
+                "validation:\n"
+                "  schema_validation:\n"
+                "    rules:\n"
+                "      expected_columns: [id, name]\n"
+            )
+        }
+
+    infer_mod = types.ModuleType("analyst_toolkit_deploy.infer_configs")
+    setattr(infer_mod, "infer_configs", fake_infer_configs)
+    pkg_mod = types.ModuleType("analyst_toolkit_deploy")
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy", pkg_mod)
+    monkeypatch.setitem(sys.modules, "analyst_toolkit_deploy.infer_configs", infer_mod)
+
+    result = await infer_configs_tool._toolkit_infer_configs(
+        session_id="sess_cert_next_action",
+        modules=["certification"],
+    )
+
+    assert result["status"] == "pass"
+    tools = [action["tool"] for action in result["next_actions"]]
+    assert "certification" not in tools
+    assert "final_audit" in tools
 
 
 @pytest.mark.asyncio
@@ -1031,6 +1254,7 @@ async def test_normalization_disabled_html_when_no_changes(mocker):
     assert result["artifact_matrix"]["html_report"]["expected"] is False
     assert result["artifact_matrix"]["html_report"]["status"] == "disabled"
     assert result["artifact_matrix"]["xlsx_report"]["status"] == "disabled"
+    assert any("Run infer_configs first" in warning for warning in result["warnings"])
 
 
 @pytest.mark.asyncio
@@ -1073,6 +1297,7 @@ async def test_imputation_disabled_html_when_no_nulls_filled(mocker):
     assert result["artifact_matrix"]["html_report"]["expected"] is False
     assert result["artifact_matrix"]["html_report"]["status"] == "disabled"
     assert result["artifact_matrix"]["xlsx_report"]["status"] == "disabled"
+    assert any("Run infer_configs first" in warning for warning in result["warnings"])
 
 
 @pytest.mark.asyncio
@@ -1115,6 +1340,7 @@ async def test_outliers_disabled_html_when_no_outliers(mocker):
     assert result["artifact_matrix"]["html_report"]["expected"] is False
     assert result["artifact_matrix"]["html_report"]["status"] == "disabled"
     assert result["artifact_matrix"]["xlsx_report"]["status"] == "disabled"
+    assert any("Run infer_configs first" in warning for warning in result["warnings"])
 
 
 @pytest.mark.asyncio
@@ -1142,6 +1368,32 @@ async def test_toolkit_validation_runtime_can_disable_html_artifacts(mocker):
     assert result["runtime_applied"] is True
     assert result["artifact_path"] == ""
     assert result["artifact_matrix"]["html_report"]["status"] == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_toolkit_validation_warns_without_inferred_or_explicit_config(mocker):
+    df = pd.DataFrame({"value": [1, 2]})
+
+    mocker.patch.object(validation_tool, "load_input", return_value=df)
+    mocker.patch.object(validation_tool, "save_to_session", return_value="sess_val")
+    mocker.patch.object(validation_tool, "get_session_metadata", return_value={"row_count": 2})
+    mocker.patch.object(validation_tool, "save_output", return_value="gs://dummy/out.csv")
+    mocker.patch.object(validation_tool, "run_validation_pipeline", return_value=df)
+    mocker.patch.object(validation_tool, "append_to_run_history", return_value=None)
+    mocker.patch.object(validation_tool, "should_export_html", return_value=False)
+    mocker.patch.object(
+        validation_tool,
+        "run_validation_suite",
+        return_value={"schema_conformity": {"passed": True, "details": {}}},
+    )
+
+    result = await validation_tool._toolkit_validation(
+        session_id="sess_val",
+        run_id="val_missing_config",
+        config={},
+    )
+
+    assert any("Run infer_configs first" in warning for warning in result["warnings"])
 
 
 @pytest.mark.asyncio
@@ -1178,6 +1430,27 @@ async def test_toolkit_duplicates_runtime_can_override_input_and_html(mocker):
     assert captured["input_path"] == "gs://bucket/dup.csv"
     assert captured["input_id"] is None
     assert result["artifact_matrix"]["html_report"]["status"] == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_toolkit_duplicates_warns_without_inferred_or_explicit_config(mocker):
+    df = pd.DataFrame({"id": [1, 2], "value": [10, 20]})
+
+    mocker.patch.object(duplicates_tool, "load_input", return_value=df)
+    mocker.patch.object(duplicates_tool, "run_duplicates_pipeline", return_value=df)
+    mocker.patch.object(duplicates_tool, "save_to_session", return_value="sess_dup")
+    mocker.patch.object(duplicates_tool, "get_session_metadata", return_value={"row_count": 2})
+    mocker.patch.object(duplicates_tool, "save_output", return_value="gs://dummy/out.csv")
+    mocker.patch.object(duplicates_tool, "append_to_run_history", return_value=None)
+    mocker.patch.object(duplicates_tool, "should_export_html", return_value=False)
+
+    result = await duplicates_tool._toolkit_duplicates(
+        session_id="sess_dup",
+        run_id="dup_missing_config",
+        config={},
+    )
+
+    assert any("Run infer_configs first" in warning for warning in result["warnings"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- sanitize inferred YAML so transient temp snapshot paths are stripped or replaced with stable source paths before configs are returned or persisted
- keep infer_configs on the public MCP surface by routing certification guidance through final_audit and by excluding internal handling output from outliers
- surface actionable module-config warnings without breaking no-op tool runs, and add regression coverage around infer-config contracts

## Issues
- closes #65
- closes #91
- closes #112
- closes #113
- closes #120

## Validation
- pytest tests/test_mcp_tool_regressions.py tests/mcp_server/test_rpc_tools.py -q
- ruff check src/ tests/
- ruff format --check src/ tests/
- mypy src/analyst_toolkit/mcp_server
- python -m yamllint .github/workflows .coderabbit.yaml
- pre-commit run --all-files

## CodeRabbit
- local CodeRabbit review was attempted
- the CLI advanced through setup and reached Reviewing, then hung without returning findings
- no local findings were available to triage because the run never completed