### PR TITLE
fix: align cockpit health and template contracts

### DIFF
--- a/config/dups_config_template.yaml
+++ b/config/dups_config_template.yaml
@@ -1,58 +1,10 @@
-# ------------------------------------------------------------------------------
-# 📄 Config File: run_duplicates_config.yaml
-# 🧩 Module: Duplicates (M04)
-# 📌 Purpose: Detects and handles duplicate rows based on configured logic.
-# ------------------------------------------------------------------------------
-# This module can flag or remove duplicates depending on the `mode` setting.
-# ------------------------------------------------------------------------------
-
-# 📥 Execution context
-notebook: true
-run_id: "0002_QA"             # A unique ID for the run, used in export paths.
-
-# 🔎 Duplicate detection settings
 duplicates:
-  logging: "auto"           # Options: 'on', 'off', or 'auto'
   run: true
 
-  # 🎯 Target subset for identifying duplicates.
-  # Use a list of column names, or set to null to use all columns.
   subset_columns: ['tag_id', 'species', 'capture_date']
-
-  # 🧭 Deduplication logic
-  keep: 'first'             # In 'remove' mode, which duplicate to keep.
-                            # Options: 'first', 'last', or False (to drop all duplicates).
-
-  mode: 'flag'            # 'remove': Finds and deletes duplicates, returning a smaller DataFrame.
-                            # 'flag': Finds duplicates and adds an 'is_duplicate' boolean column,
-                            #         but does not remove any rows.
-
-  # 📂 Input source
-  input_path: "exports/joblib/{run_id}/{run_id}_m02_certified.joblib"
-
-  # ⚙️ Operational settings (required by pipeline)
+  keep: 'first'
+  mode: 'flag'
+  input_path: "data/processed/example.csv"
   settings:
-    checkpoint:
-      run: true
-      # Path for the final processed DataFrame (either smaller or with flags).
-      checkpoint_path: "exports/joblib/{run_id}/{run_id}_m04_df_deduped.joblib"
-      # Optional: In 'remove' mode, save a joblib of the *flagged* DataFrame before rows are dropped.
-      flagged_checkpoint_path: "exports/joblib/{run_id}/{run_id}_m04_df_flagged_before_removal.joblib"
-
-    export: true
-    export_path: "exports/reports/duplicates/duplicates_report.xlsx"
-    as_csv: false          # false = single XLSX report with multiple sheets
     export_html: true
     export_html_path: "exports/reports/duplicates/{run_id}_duplicates_report.html"
-
-    show_inline: true
-
-    plotting:
-      run: true
-      save_dir: "exports/plots/duplicates/"
-
-  # 🧼 Optional preview cleanup for schema-variant files
-  preview_drop_columns:
-    - "timestamp"
-    - "script_name"
-    - "user"

--- a/config/final_audit_config_template.yaml
+++ b/config/final_audit_config_template.yaml
@@ -1,28 +1,9 @@
-# ------------------------------------------------------------------------------
-# 📄 Config File: run_final_audit_config.yaml
-# 🧩 Module: Final Audit & Certification (M10)
-# 📌 Purpose: Applies final edits, runs a certification pass, and produces
-#            a capstone report summarizing the pipeline's data transformations.
-# ------------------------------------------------------------------------------
-# This module is the last quality gate before dataset delivery.
-# It compares raw vs cleaned data, drops artifacts, certifies schema, 
-# and generates final reports and lifecycle stats.
-# ------------------------------------------------------------------------------
-
-# 📥 Execution context
-run_id: "0002_QA"
-notebook: true
-logging: "auto"                # Options: 'on', 'off', or 'auto'
-
-# 🧮 Final audit configuration
 final_audit:
   run: true
 
-  # 📂 Input paths
-  input_df_path: "exports/joblib/{run_id}/{run_id}_m07_df_imputed.joblib"
-  raw_data_path: "data/raw/synthetic_penguins_v3.5.csv"
+  input_df_path: "data/processed/example_cleaned.joblib"
+  raw_data_path: "data/raw/example.csv"
 
-  # 🧼 Final edits before certification
   final_edits:
     run: true
     drop_columns:
@@ -31,15 +12,13 @@ final_audit:
     rename_columns: {}
     coerce_dtypes: {}
 
-  # ✅ Certification block (invokes validation logic in strict mode)
   certification:
     run: true
-    fail_on_error: true
-    
-    # This block re-uses the validation module's structure for consistency.
     schema_validation:
+      run: true
+      fail_on_error: true
       rules:
-        expected_columns: 
+        expected_columns:
           - "tag_id"
           - "species"
           - "bill_length_mm"
@@ -81,7 +60,6 @@ final_audit:
           age_group: ["Juvenile", "Adult", "Chick", "UNKNOWN"]
           health_status: ["Healthy", "Critical", "Underweight", "Sick", "Overweight", "UNKNOWN"]
 
-        # 🚫 Columns that must not contain nulls
         disallowed_null_columns:
           - 'tag_id'
           - 'species'
@@ -89,16 +67,11 @@ final_audit:
           - 'sex'
           - 'body_mass_g'
 
-  # 📤 Reporting and checkpoint settings
   settings:
-    show_inline: true
-    export_report: true
     export_html: true
-
     paths:
-      report_excel: "exports/reports/final_audit/{run_id}_FinalAuditReport.xlsx"
-      report_joblib: "exports/reports/final_audit/{run_id}_FinalAuditReport.joblib"
+      report_excel: "exports/reports/final_audit/{run_id}_final_audit_report.xlsx"
+      report_joblib: "exports/reports/final_audit/{run_id}_final_audit_report.joblib"
       report_html: "exports/reports/final_audit/{run_id}_final_audit_report.html"
-      checkpoint_csv: "data/processed/{run_id}_penguins_certified.csv"
-      checkpoint_joblib: "exports/joblib/{run_id}/{run_id}_penguins_certified.joblib"
-      plot_save_dir: "exports/plots/final_audit/{run_id}/"
+      checkpoint_csv: "exports/data/final_audit/{run_id}_certified.csv"
+      checkpoint_joblib: "exports/joblib/{run_id}/{run_id}_certified.joblib"

--- a/config/imputation_config_template.yaml
+++ b/config/imputation_config_template.yaml
@@ -1,37 +1,17 @@
-# ------------------------------------------------------------------------------
-# 📄 Config File: run_imputation_config.yaml
-# 🧩 Module: Imputation (M07)
-# 📌 Purpose: Fills missing (NaN) values using rule-based strategies.
-# ------------------------------------------------------------------------------
-# This module supports column-wise imputation strategies including mean, median,
-# mode, or constant values. Output is visualized, exported, and checkpointed.
-# ------------------------------------------------------------------------------
-
-# 📥 Execution context
-notebook: true
-run_id: "0002_QA"
-logging: "on"               # Options: 'on', 'off', or 'auto'
-
-# 🧩 Imputation configuration
 imputation:
   run: true
 
-  # 📂 Input path (typically the result of M06 outlier handling)
-  input_path: "exports/joblib/{run_id}_m06_df_handled.joblib"
+  input_path: "data/processed/example.csv"
 
-  # 🔧 Column-specific imputation rules
   rules:
     strategies:
-      # 🔢 Numeric imputations
       bill_length_mm: 'mean'
       body_mass_g: 'mean'
       bill_depth_mm: 'median'
       flipper_length_mm: 'median'
 
-      # 🧬 Categorical imputations
       sex: 'mode'
 
-      # 🧱 Constant value fallbacks
       tag_id:
         strategy: 'constant'
         value: 'UNKNOWN'
@@ -63,21 +43,6 @@ imputation:
         strategy: 'constant'
         value: 'UNKNOWN'
 
-  # ⚙️ Output, visualization, and persistence settings
   settings:
-    show_inline: true
-
-    export:
-      run: true
-      as_csv: false
-      export_path: "exports/reports/imputation/imputation_report.xlsx"
-      export_html: true
-      export_html_path: "exports/reports/imputation/{run_id}_imputation_report.html"
-
-    plotting:
-      run: true
-      save_dir: "exports/plots/imputation/"
-
-    checkpoint:
-      run: true
-      checkpoint_path: "exports/joblib/{run_id}/{run_id}_m07_df_imputed.joblib"
+    export_html: true
+    export_html_path: "exports/reports/imputation/{run_id}_imputation_report.html"

--- a/config/normalization_config_template.yaml
+++ b/config/normalization_config_template.yaml
@@ -1,36 +1,17 @@
-# ------------------------------------------------------------------------------
-# 📄 Config File: run_normalization_config.yaml
-# 🧩 Module: Normalization (M03)
-# 📌 Purpose: Cleans and standardizes data using rule-based transformations.
-# ------------------------------------------------------------------------------
-# This module is designed to resolve data quality issues identified in validation.
-# It performs column renaming, value mapping, fuzzy matching, and type coercion.
-# ------------------------------------------------------------------------------
-
-# 📥 Execution context
-notebook: true
-run_id: "0002_QA"
-logging: "auto"            # Options: 'on', 'off', or 'auto'
-
-# 🔧 Normalization settings
 normalization:
   run: true
 
-  # Optionally define input_path if this is the first module in a run
-  # input_path: "path/to/input.csv"
+  input_path: "data/processed/example_validated.csv"
 
   rules:
-    # ✏️ Rename columns
     rename_columns:
       'bill length (mm)': 'bill_length_mm'
       'bill depth (mm)': 'bill_depth_mm'
 
-    # 🧹 Standardize categorical text columns
     standardize_text_columns:
       - 'clutch_completion'
       - 'sex'
 
-    # 🧩 Explicit value mappings for cleanup
     value_mappings:
       sex:
         '.': null
@@ -80,7 +61,6 @@ normalization:
         'PAPR2023': 'PAPRI2023'
         'PAPRI20X9': 'UNKNOWN'
 
-    # 🤖 Fuzzy string matching for typo correction
     fuzzy_matching:
       run: true
       settings:
@@ -91,26 +71,17 @@ normalization:
           master_list: ["Torgersen", "Biscoe", "Dream", "Shortcut", "Cormorant"]
           score_cutoff: 85
 
-    # 📅 Date parsing for timestamp fields
     parse_datetimes:
       capture_date:
         format: '%Y-%m-%d'
         errors: 'coerce'
-        # Optional timezone/format controls
-        # If your inputs include time zones and you want to normalize to UTC, set utc: true
-        # If downstream expects tz-naive timestamps (no timezone), set make_naive: true
         utc: false
         make_naive: true
-        # Optionally support multiple input formats (tried in order)
-        # formats: ['%Y-%m-%d', '%m/%d/%Y', '%Y.%m.%d']
       date_egg:
         format: '%Y-%m-%d'
         errors: 'coerce'
         utc: false
         make_naive: true
-        # formats: ['%Y-%m-%d', '%m/%d/%Y']
-
-    # 🔬 Columns to preview in the report
     preview_columns:
       - 'sex'
       - 'island'
@@ -123,20 +94,10 @@ normalization:
       - 'date_egg'
       - 'clutch_completion'
 
-    # 🧪 Coerce data types explicitly
     coerce_dtypes:
       bill_length_mm: 'float64'
       flipper_length_mm: 'float64'
 
-  # 📤 Output and display controls
   settings:
-    show_inline: true
-    export: true
     export_html: true
     export_html_path: "exports/reports/normalization/{run_id}_normalization_report.html"
-    as_csv: false
-    export_path: "exports/reports/normalization/normalization_report.xlsx"
-
-    checkpoint:
-      run: true
-      checkpoint_path: "exports/joblib/{run_id}/{run_id}_m03_df_normalized.joblib"

--- a/config/validation_config_template.yaml
+++ b/config/validation_config_template.yaml
@@ -1,20 +1,5 @@
-# ------------------------------------------------------------------------------
-# 📄 Config File: run_validation_config.yaml
-# 🧩 Module: Validation (M02)
-# 📌 Purpose: Performs the first-pass audit on raw input data.
-# ------------------------------------------------------------------------------
-# This configuration identifies issues in the dataset without halting the pipeline.
-# All rules are based on the `synthetic_penguins_v3.5.csv` structure and expectations.
-# ------------------------------------------------------------------------------
-
-# 📥 Execution context
-notebook: true
-run_id: "0002_QA"
-logging: "auto"            # 'on', 'off', or 'auto' (auto = enabled in notebook mode)
-
-# 🔎 Validation settings
 validation:
-  input_path: "data/raw/synthetic_penguins_v3.5.csv"
+  input_path: "data/raw/example.csv"
 
   # ✅ Schema and content validation rules
   schema_validation:
@@ -22,12 +7,11 @@ validation:
     fail_on_error: false   # Set to false in audit mode to detect all issues
 
     rules:
-      # 📐 Expected schema (column names and order)
-      expected_columns: 
+      expected_columns:
         - "tag_id"
         - "species"
         - "bill_length_mm"
-        - "bill depth_mm"
+        - "bill_depth_mm"
         - "flipper_length_mm"
         - "body_mass_g"
         - "age_group"
@@ -40,12 +24,11 @@ validation:
         - "clutch_completion"
         - "date_egg"
 
-      # 🔢 Expected data types per column
       expected_types:
         tag_id: "object"
         species: "object"
-        bill length (mm): "float64"
-        bill depth (mm): "float64"
+        bill_length_mm: "float64"
+        bill_depth_mm: "float64"
         flipper_length_mm: "int64"
         body_mass_g: "float64"
         age_group: "object"
@@ -58,23 +41,21 @@ validation:
         clutch_completion: "object"
         date_egg: "object"
 
-      # 🧬 Categorical value checks
       categorical_values:
         species: ["Adelie", "Chinstrap", "Gentoo"]
         island: ["Dream", "Biscoe", "Torgersen", "Cormorant", "Shortcut"]
-        sex: ["male", "female", "UNKNOWN"]
+        sex: ["MALE", "FEMALE", "UNKNOWN"]
         colony_id: ["Biscoe West", "Cormorant East", "Dream South", "Shortcut Point", "Torgersen North"]
         clutch_completion: ["Yes", "No"]
         age_group: ["Juvenile", "Adult", "Chick", "UNKNOWN"]
-        health_status: ["Healthy", "Critically Ill", "Underweight", "Unwell", "Overweight", "Unknown"]
+        health_status: ["Healthy", "Critical", "Underweight", "Sick", "Overweight", "UNKNOWN"]
         study_name: ["PAPRI2019", "PAPRI2020", "PAPRI2021", "PAPRI2022", "PAPRI2023", "PAPRI2024"]
 
-      # 📏 Numeric range checks (min/max thresholds)
       numeric_ranges:
-        bill length (mm):
+        bill_length_mm:
           min: 30.0
           max: 65.0
-        bill depth (mm):
+        bill_depth_mm:
           min: 12.0
           max: 23.5
         flipper_length_mm:
@@ -84,13 +65,6 @@ validation:
           min: 2300.0
           max: 7500.0
 
-  # 📤 Output and display settings
   settings:
-    checkpoint: false
-    checkpoint_path: "exports/joblib/{run_id}/{run_id}_m02_validation.joblib"
-    export: true
-    as_csv: false
-    export_path: "exports/reports/validation/validation_report.xlsx"
     export_html: true
     export_html_path: "exports/reports/validation/{run_id}_validation_report.html"
-    show_inline: true

--- a/src/analyst_toolkit/m00_utils/dashboard_views.py
+++ b/src/analyst_toolkit/m00_utils/dashboard_views.py
@@ -185,6 +185,12 @@ def _render_cockpit_recent_runs(recent_runs: list[dict[str, Any]]) -> str:
     for run in recent_runs:
         dashboard_ref = run.get("pipeline_dashboard") or run.get("best_dashboard")
         export_ref = run.get("best_export")
+        health_note = html.escape(str(run.get("health_status", "unknown")).upper())
+        if bool(run.get("health_advisory", False)):
+            certification_status = html.escape(
+                str(run.get("certification_status", "unknown")).upper()
+            )
+            health_note = f"ADVISORY · {health_note} · FINAL_AUDIT {certification_status}"
         recent_run_cards.append(
             "<div class='resource-card'>"
             f"<p class='resource-meta'>{html.escape(str(run.get('timestamp') or 'Recent run'))}</p>"
@@ -196,7 +202,7 @@ def _render_cockpit_recent_runs(recent_runs: list[dict[str, Any]]) -> str:
             f"<p class='subtle'>Latest module: {html.escape(str(run.get('latest_module', 'unknown')))}</p></div>"
             "<div class='module-mini-card'><h3>Health</h3>"
             f"{_metric_value(run.get('health_score', 'N/A'))}"
-            f"<p class='subtle'>{html.escape(str(run.get('health_status', 'unknown')).upper())}</p></div>"
+            f"<p class='subtle'>{health_note}</p></div>"
             "<div class='module-mini-card'><h3>Warnings</h3>"
             f"{_metric_value(run.get('warning_count', 0))}"
             f"<p class='subtle'>Modules observed: {html.escape(str(run.get('module_count', 0)))}</p></div>"
@@ -622,6 +628,9 @@ def render_pipeline_dashboard(report: dict[str, Any], run_id: str) -> str:
     session_id = str(report.get("session_id", ""))
     health_score = report.get("health_score", "N/A")
     health_status = str(report.get("health_status", "unknown")).upper()
+    health_advisory = bool(report.get("health_advisory", False))
+    health_message = str(report.get("health_message", "")).strip()
+    certification_status = str(report.get("certification_status", "not_run")).upper()
     ready_modules = int(report.get("ready_modules", 0))
     warned_modules = int(report.get("warned_modules", 0))
     failed_modules = int(report.get("failed_modules", 0))
@@ -639,16 +648,26 @@ def render_pipeline_dashboard(report: dict[str, Any], run_id: str) -> str:
         )
     module_ledger_df = pd.DataFrame(module_ledger_rows)
 
-    banner_class = "ok" if failed_modules == 0 else "warn"
+    banner_class = "ok" if failed_modules == 0 and not health_advisory else "warn"
     banner = (
         f"<div class='banner {banner_class}'>"
         "<div class='banner-item'><strong>Stage:</strong> Pipeline Review Shell</div>"
         f"<div class='banner-item'><strong>Final Status:</strong> {html.escape(final_status.upper())}</div>"
         f"<div class='banner-item'><strong>Health:</strong> {html.escape(str(health_score))} ({html.escape(health_status)})</div>"
+        f"<div class='banner-item'><strong>Health Mode:</strong> {'ADVISORY' if health_advisory else 'STANDARD'}</div>"
         f"<div class='banner-item'><strong>Session:</strong> {html.escape(session_id or 'Unavailable')}</div>"
         f"<div class='banner-item'><strong>Modules:</strong> {len(module_order)}</div>"
         "</div>"
     )
+    advisory_card = ""
+    if health_advisory:
+        advisory_card = (
+            "<div class='card'>"
+            "<h3>Health Score Is Advisory</h3>"
+            f"<p class='subtle'>{html.escape(health_message or 'Final audit failed certification for this run.')}</p>"
+            f"<p class='subtle'><strong>Certification Status:</strong> {html.escape(certification_status)}</p>"
+            "</div>"
+        )
 
     executive = (
         "<div class='stack'>"
@@ -667,6 +686,7 @@ def render_pipeline_dashboard(report: dict[str, Any], run_id: str) -> str:
         "<p class='subtle'>Pipeline stages not observed in the current run history.</p></div>"
         "</div>"
         "<div class='cert-ledger'>"
+        f"{advisory_card}"
         "<div class='card'><h3>Final References</h3>"
         f"{_render_terminal_references(final_dashboard=final_dashboard, final_export=final_export, final_status=final_status, failed_modules=failed_modules, modules=modules, module_order=module_order)}"
         "</div>"

--- a/src/analyst_toolkit/mcp_server/config_models.py
+++ b/src/analyst_toolkit/mcp_server/config_models.py
@@ -41,6 +41,10 @@ class NormalizationRules(BaseModel):
     parse_datetimes: Dict[str, Any] = Field(
         default_factory=dict, description="Datetime parsing rules."
     )
+    preview_columns: List[str] = Field(
+        default_factory=list,
+        description="Optional columns to highlight in normalization report previews.",
+    )
     coerce_dtypes: Dict[str, str] = Field(
         default_factory=dict, description="Final type coercion mapping."
     )
@@ -148,6 +152,10 @@ class FinalAuditConfig(BaseModel):
     """
 
     run: bool = Field(True, description="Master final_audit toggle.")
+    input_df_path: Optional[str] = Field(
+        None,
+        description="Optional cleaned input path used by final_audit pipeline wrappers.",
+    )
     raw_data_path: Optional[str] = Field(
         None,
         description="Optional path to raw source data for before/after reporting.",

--- a/src/analyst_toolkit/mcp_server/tools/cockpit.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit.py
@@ -429,6 +429,8 @@ def _build_recent_run_cards(limit: int) -> list[dict[str, Any]]:
                 "timestamp": str(latest_non_synthetic.get("timestamp", "")),
                 "health_score": health.get("health_score", "N/A"),
                 "health_status": health.get("health_status", "unknown"),
+                "health_advisory": bool(health.get("health_advisory", False)),
+                "certification_status": str(health.get("certification_status", "not_run")),
                 "pipeline_dashboard": pipeline_dashboard,
                 "auto_heal_dashboard": auto_heal_dashboard,
                 "final_audit_dashboard": final_audit_dashboard,
@@ -825,6 +827,10 @@ async def _toolkit_get_pipeline_dashboard(run_id: str, session_id: str | None = 
         "final_status": final_status,
         "health_score": health.get("health_score", "N/A"),
         "health_status": health.get("health_status", "unknown"),
+        "health_advisory": bool(health.get("health_advisory", False)),
+        "health_message": str(health.get("message", "")),
+        "certification_status": str(health.get("certification_status", "not_run")),
+        "certification_passed": health.get("certification_passed"),
         "ready_modules": ready_modules,
         "warned_modules": warned_modules,
         "failed_modules": failed_modules,
@@ -864,6 +870,9 @@ async def _toolkit_get_pipeline_dashboard(run_id: str, session_id: str | None = 
     artifact_path = str(artifact_delivery.get("local_path", output_path))
     artifact_url = str(artifact_delivery.get("url", ""))
 
+    warnings = list(artifact_delivery.get("warnings", []))
+    warnings.extend(str(item) for item in health.get("warnings", []) if str(item).strip())
+
     res = {
         "status": "pass",
         "module": "pipeline_dashboard",
@@ -872,6 +881,8 @@ async def _toolkit_get_pipeline_dashboard(run_id: str, session_id: str | None = 
         "summary": {
             "health_score": report["health_score"],
             "health_status": report["health_status"],
+            "health_advisory": report["health_advisory"],
+            "certification_status": report["certification_status"],
             "ready_modules": ready_modules,
             "warned_modules": warned_modules,
             "failed_modules": failed_modules,
@@ -882,7 +893,7 @@ async def _toolkit_get_pipeline_dashboard(run_id: str, session_id: str | None = 
         "destination_delivery": {
             "html_report": compact_destination_metadata(artifact_delivery["destinations"])
         },
-        "warnings": list(artifact_delivery.get("warnings", [])),
+        "warnings": warnings,
     }
     res = with_dashboard_artifact(
         res, artifact_path=artifact_path, artifact_url=artifact_url, label="Pipeline dashboard"

--- a/src/analyst_toolkit/mcp_server/tools/cockpit_runtime.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit_runtime.py
@@ -112,7 +112,8 @@ def build_data_health_report(
 
     for entry in history:
         module = entry.get("module")
-        summary = entry.get("summary", {})
+        summary_raw = entry.get("summary", {})
+        summary = summary_raw if isinstance(summary_raw, dict) else {}
         row_count = summary.get("row_count")
 
         if module == "diagnostics":
@@ -129,7 +130,10 @@ def build_data_health_report(
     score_res = calculate_health_score(metrics)
     final_audit_entry = _latest_module_entry(history, "final_audit")
     final_audit_status = str(final_audit_entry.get("status", "not_run") or "not_run")
-    final_audit_summary = final_audit_entry.get("summary", {})
+    final_audit_summary_raw = final_audit_entry.get("summary", {})
+    final_audit_summary = (
+        final_audit_summary_raw if isinstance(final_audit_summary_raw, dict) else {}
+    )
     final_audit_passed = (
         final_audit_summary.get("passed")
         if isinstance(final_audit_summary.get("passed"), bool)

--- a/src/analyst_toolkit/mcp_server/tools/cockpit_runtime.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit_runtime.py
@@ -4,6 +4,15 @@ from typing import Any
 
 from analyst_toolkit.m00_utils.scoring import calculate_health_score
 
+_CERT_FAILURE_STATUSES = {"fail", "error"}
+
+
+def _latest_module_entry(history: list[dict[str, Any]], module_name: str) -> dict[str, Any]:
+    for entry in reversed(history):
+        if str(entry.get("module", "")).strip() == module_name:
+            return entry
+    return {}
+
 
 def build_run_history_result(
     *,
@@ -118,15 +127,43 @@ def build_data_health_report(
             metrics["outlier_ratio"] = count / row_count if row_count else min(0.2, count / 1000)
 
     score_res = calculate_health_score(metrics)
-    status = "warn" if history_meta.get("parse_errors") else "pass"
+    final_audit_entry = _latest_module_entry(history, "final_audit")
+    final_audit_status = str(final_audit_entry.get("status", "not_run") or "not_run")
+    final_audit_summary = final_audit_entry.get("summary", {})
+    final_audit_passed = (
+        final_audit_summary.get("passed")
+        if isinstance(final_audit_summary.get("passed"), bool)
+        else None
+    )
+    health_advisory = bool(
+        final_audit_entry
+        and (final_audit_status.lower() in _CERT_FAILURE_STATUSES or final_audit_passed is False)
+    )
+    warnings: list[str] = []
+    message = (
+        f"Data Health Score is {score_res['overall_score']}/100 ({score_res['status'].upper()})"
+    )
+    if health_advisory:
+        warnings.append(
+            "Health score is advisory only because final_audit reported certification failures."
+        )
+        message = (
+            f"Advisory Data Health Score is {score_res['overall_score']}/100 "
+            f"({score_res['status'].upper()}). Final audit failed certification for this run."
+        )
+    status = "warn" if history_meta.get("parse_errors") or health_advisory else "pass"
     return {
         "status": status,
         "run_id": run_id,
         "session_id": session_id,
         "health_score": score_res["overall_score"],
         "health_status": score_res["status"],
+        "health_advisory": health_advisory,
+        "certification_status": final_audit_status,
+        "certification_passed": final_audit_passed,
         "breakdown": score_res["breakdown"],
-        "message": f"Data Health Score is {score_res['overall_score']}/100 ({score_res['status'].upper()})",
+        "message": message,
+        "warnings": warnings,
         "skipped_records": int(history_meta.get("skipped_records", 0)),
         "parse_errors": list(history_meta.get("parse_errors", [])),
     }

--- a/src/analyst_toolkit/mcp_server/tools/preflight_config.py
+++ b/src/analyst_toolkit/mcp_server/tools/preflight_config.py
@@ -38,6 +38,7 @@ def _allowed_keys(module_name: str) -> set[str]:
     if module_name == "final_audit":
         return common | {
             "final_audit",
+            "input_df_path",
             "raw_data_path",
             "final_edits",
             "certification",
@@ -97,6 +98,7 @@ def _unknown_effective_keys(module_name: str, config: dict[str, Any]) -> list[st
                 "value_mappings",
                 "fuzzy_matching",
                 "parse_datetimes",
+                "preview_columns",
                 "coerce_dtypes",
             }
             _add_unknown("rules", rules, rules_allowed)
@@ -124,6 +126,7 @@ def _unknown_effective_keys(module_name: str, config: dict[str, Any]) -> list[st
             "run",
             "logging",
             "input_path",
+            "input_df_path",
             "settings",
             "raw_data_path",
             "final_edits",

--- a/tests/m00_utils/test_dashboard_html.py
+++ b/tests/m00_utils/test_dashboard_html.py
@@ -635,6 +635,52 @@ def test_generate_pipeline_dashboard_surfaces_terminal_fallback_when_final_artif
     assert "exports/reports/validation/sample_validation.html" in html
 
 
+def test_generate_pipeline_dashboard_marks_health_as_advisory_when_final_audit_failed():
+    report = {
+        "final_status": "fail",
+        "session_id": "sess_pipeline",
+        "health_score": 94.7,
+        "health_status": "green",
+        "health_advisory": True,
+        "health_message": "Advisory Data Health Score is 94.7/100 (GREEN). Final audit failed certification for this run.",
+        "certification_status": "fail",
+        "ready_modules": 4,
+        "warned_modules": 1,
+        "failed_modules": 1,
+        "not_run_modules": 3,
+        "module_order": ["Validation", "Final Audit"],
+        "modules": {
+            "Validation": {
+                "status": "pass",
+                "summary": {"passed": True},
+                "dashboard_url": "",
+                "dashboard_path": "",
+                "artifact_url": "",
+                "export_url": "",
+                "warnings": [],
+            },
+            "Final Audit": {
+                "status": "fail",
+                "summary": {"passed": False},
+                "dashboard_url": "",
+                "dashboard_path": "exports/reports/final_audit/run_final.html",
+                "artifact_url": "",
+                "export_url": "gs://bucket/final.csv",
+                "warnings": [],
+            },
+        },
+        "final_dashboard_url": "",
+        "final_dashboard_path": "exports/reports/final_audit/run_final.html",
+        "final_export_url": "gs://bucket/final.csv",
+    }
+
+    html = generate_html_report(report, "Pipeline Dashboard", "run-pipeline-advisory")
+
+    assert "Health Mode:</strong> ADVISORY" in html
+    assert "Health Score Is Advisory" in html
+    assert "Certification Status:</strong> FAIL" in html
+
+
 def test_generate_cockpit_dashboard_renders_operator_hub():
     report = {
         "overview": {

--- a/tests/mcp_server/test_rpc_tools.py
+++ b/tests/mcp_server/test_rpc_tools.py
@@ -465,6 +465,83 @@ async def test_toolkit_get_pipeline_dashboard_hides_internal_outlier_handling_st
     assert "Outlier Handling" not in report["modules"]
 
 
+def test_build_data_health_report_marks_failed_final_audit_as_advisory():
+    health = cockpit_module.build_data_health_report(
+        run_id="run-health-001",
+        session_id="sess-health-001",
+        history=[
+            {
+                "module": "diagnostics",
+                "status": "pass",
+                "summary": {"null_rate": 0.0, "row_count": 100},
+            },
+            {
+                "module": "validation",
+                "status": "pass",
+                "summary": {"passed": True, "row_count": 100},
+            },
+            {
+                "module": "final_audit",
+                "status": "fail",
+                "summary": {"passed": False, "row_count": 100},
+            },
+        ],
+        history_meta={"parse_errors": [], "skipped_records": 0},
+    )
+
+    assert health["status"] == "warn"
+    assert health["health_score"] == 100.0
+    assert health["health_advisory"] is True
+    assert health["certification_status"] == "fail"
+    assert health["certification_passed"] is False
+    assert "Advisory Data Health Score" in health["message"]
+    assert any("final_audit reported certification failures" in msg for msg in health["warnings"])
+
+
+@pytest.mark.asyncio
+async def test_toolkit_get_pipeline_dashboard_surfaces_advisory_health_when_final_audit_failed(
+    mocker,
+):
+    history = [
+        {
+            "module": "final_audit",
+            "status": "fail",
+            "summary": {"passed": False},
+            "dashboard_path": "exports/reports/final_audit/run_final.html",
+        }
+    ]
+    mocker.patch.object(cockpit_module, "get_run_history", return_value=history)
+    mocker.patch.object(
+        cockpit_module,
+        "get_last_history_read_meta",
+        return_value={"parse_errors": [], "skipped_records": 0},
+    )
+    mocker.patch.object(
+        cockpit_module,
+        "export_html_report",
+        return_value="/tmp/run-health-001_pipeline_dashboard.html",
+    )
+    append_history = mocker.patch.object(cockpit_module, "append_to_run_history")
+    mocker.patch.object(
+        cockpit_module,
+        "deliver_artifact",
+        return_value={
+            "reference": "https://example.com/pipeline.html",
+            "local_path": "/tmp/run-health-001_pipeline_dashboard.html",
+            "url": "https://example.com/pipeline.html",
+            "warnings": [],
+            "destinations": {},
+        },
+    )
+
+    result = await cockpit_module._toolkit_get_pipeline_dashboard(run_id="run-health-001")
+
+    assert result["summary"]["health_advisory"] is True
+    assert result["summary"]["certification_status"] == "fail"
+    assert any("Health score is advisory only" in warning for warning in result["warnings"])
+    append_history.assert_called_once()
+
+
 @pytest.mark.asyncio
 async def test_toolkit_get_pipeline_dashboard_sanitizes_run_id_for_artifact_path(mocker):
     mocker.patch.object(cockpit_module, "get_run_history", return_value=[])

--- a/tests/mcp_server/test_rpc_tools.py
+++ b/tests/mcp_server/test_rpc_tools.py
@@ -498,6 +498,26 @@ def test_build_data_health_report_marks_failed_final_audit_as_advisory():
     assert any("final_audit reported certification failures" in msg for msg in health["warnings"])
 
 
+def test_build_data_health_report_tolerates_malformed_final_audit_summary():
+    health = cockpit_module.build_data_health_report(
+        run_id="run-health-002",
+        session_id="sess-health-002",
+        history=[
+            {
+                "module": "final_audit",
+                "status": "fail",
+                "summary": ["unexpected", "shape"],
+            }
+        ],
+        history_meta={"parse_errors": [], "skipped_records": 0},
+    )
+
+    assert health["status"] == "warn"
+    assert health["health_advisory"] is True
+    assert health["certification_status"] == "fail"
+    assert health["certification_passed"] is None
+
+
 @pytest.mark.asyncio
 async def test_toolkit_get_pipeline_dashboard_surfaces_advisory_health_when_final_audit_failed(
     mocker,

--- a/tests/test_template_contracts.py
+++ b/tests/test_template_contracts.py
@@ -6,11 +6,18 @@ from pathlib import Path
 
 import yaml
 
+from analyst_toolkit.mcp_server.config_models import CONFIG_MODELS
+from analyst_toolkit.mcp_server.config_normalizers import normalize_module_config
+from analyst_toolkit.mcp_server.io import coerce_config
 from analyst_toolkit.mcp_server.templates import (
     get_golden_configs,
     list_config_template_specs,
     list_template_resources,
     read_template_resource,
+)
+from analyst_toolkit.mcp_server.tools.preflight_config import (
+    _shape_warnings,
+    _unknown_effective_keys,
 )
 
 
@@ -61,3 +68,22 @@ def test_golden_templates_have_known_top_level_sections():
         unknown = set(cfg.keys()) - allowed_keys
         assert not unknown, f"{name} has unknown top-level sections: {sorted(unknown)}"
         assert any(k != "description" for k in cfg), name
+
+
+def test_public_module_templates_match_current_config_contracts():
+    for spec in list_config_template_specs():
+        if not spec.tool or not spec.config_root or spec.tool not in CONFIG_MODELS:
+            continue
+
+        raw = yaml.safe_load(spec.path.read_text(encoding="utf-8"))
+        assert isinstance(raw, dict), spec.filename
+        assert isinstance(raw.get(spec.config_root), dict), spec.filename
+
+        module_name = spec.tool
+        coerce_key = "outlier_detection" if module_name == "outliers" else module_name
+        coerced = coerce_config(raw, coerce_key)
+        normalized = normalize_module_config(module_name, coerced)
+
+        assert not _shape_warnings(module_name, normalized), spec.filename
+        assert not _unknown_effective_keys(module_name, normalized), spec.filename
+        CONFIG_MODELS[module_name].model_validate(normalized)


### PR DESCRIPTION
## Summary
- mark health-score surfaces as advisory when final_audit fails so cockpit and pipeline views do not contradict certification outcomes
- align public YAML module templates with current MCP config contracts and remove stale pipeline-only assumptions
- add regression coverage that validates exposed module templates against the normalizer/schema layer

Closes #115
Closes #118

## Validation
- pytest tests/test_template_contracts.py tests/mcp_server/test_rpc_tools.py tests/m00_utils/test_dashboard_html.py tests/test_golden_template_execution.py tests/hardening/test_pipeline_integrations.py -q
- ruff check src/ tests/
- ruff format --check src/ tests/
- mypy src/analyst_toolkit/mcp_server
- python -m yamllint .github/workflows .coderabbit.yaml
- pre-commit run --all-files

## CodeRabbit
- attempted local `coderabbit review --plain --no-color --type uncommitted`
- it reached `Reviewing` and then hung without returning findings or a completion marker
- documenting that as a local tooling blocker rather than treating it as a clean review