### PR TITLE
fix: harden input ids and client error codes

### DIFF
--- a/src/analyst_toolkit/mcp_server/input/errors.py
+++ b/src/analyst_toolkit/mcp_server/input/errors.py
@@ -4,6 +4,16 @@ from __future__ import annotations
 
 from typing import Optional
 
+CLIENT_SAFE_INPUT_ERROR_CODES = {
+    "INPUT_ERROR",
+    "INPUT_NOT_SUPPORTED",
+    "INPUT_PATH_NOT_FOUND",
+    "INPUT_PATH_DENIED",
+    "INPUT_PAYLOAD_TOO_LARGE",
+    "INPUT_CONFLICT",
+    "INPUT_NOT_FOUND",
+}
+
 
 class InputError(Exception):
     """Base error for input ingest and resolution surfaces."""
@@ -38,3 +48,8 @@ class InputConflictError(InputError):
 
 class InputNotFoundError(InputError):
     code = "INPUT_NOT_FOUND"
+
+
+def client_safe_input_error_code(code: str | None) -> str:
+    normalized = str(code or "").strip().upper()
+    return normalized if normalized in CLIENT_SAFE_INPUT_ERROR_CODES else "INPUT_ERROR"

--- a/src/analyst_toolkit/mcp_server/input/ingest.py
+++ b/src/analyst_toolkit/mcp_server/input/ingest.py
@@ -12,7 +12,12 @@ import pandas as pd
 from analyst_toolkit.mcp_server.input.adapters import resolve_source_reference
 from analyst_toolkit.mcp_server.input.errors import InputNotFoundError
 from analyst_toolkit.mcp_server.input.loaders import load_dataframe_from_descriptor
-from analyst_toolkit.mcp_server.input.models import InputDescriptor, InputSourceType
+from analyst_toolkit.mcp_server.input.models import (
+    INPUT_ID_HEX_LENGTH,
+    INPUT_ID_PREFIX,
+    InputDescriptor,
+    InputSourceType,
+)
 from analyst_toolkit.mcp_server.input.registry import (
     bind_session_input,
     get_descriptor,
@@ -24,10 +29,16 @@ from analyst_toolkit.mcp_server.state import StateStore
 
 
 def _new_input_id(stable_key: str | None = None) -> str:
+    """Return canonical input IDs with a 64-bit hex suffix.
+
+    Sixteen hex characters gives 64 bits of entropy, which is a safer long-term
+    collision budget for the bounded in-memory registry while preserving stable,
+    deterministic IDs for idempotent register/upload flows.
+    """
     if stable_key:
         digest = hashlib.sha256(stable_key.encode("utf-8")).hexdigest()
-        return f"input_{digest[:12]}"
-    return f"input_{uuid.uuid4().hex[:12]}"
+        return f"{INPUT_ID_PREFIX}{digest[:INPUT_ID_HEX_LENGTH]}"
+    return f"{INPUT_ID_PREFIX}{uuid.uuid4().hex[:INPUT_ID_HEX_LENGTH]}"
 
 
 def get_input_descriptor(input_id: str) -> InputDescriptor | None:

--- a/src/analyst_toolkit/mcp_server/input/models.py
+++ b/src/analyst_toolkit/mcp_server/input/models.py
@@ -7,6 +7,9 @@ from types import MappingProxyType
 from typing import Any, Literal, Mapping
 
 InputSourceType = Literal["upload", "server_path", "gcs", "gdrive"]
+INPUT_ID_PREFIX = "input_"
+INPUT_ID_HEX_LENGTH = 16
+INPUT_ID_PATTERN = rf"^{INPUT_ID_PREFIX}[a-f0-9]{{{INPUT_ID_HEX_LENGTH}}}$"
 _UNSET = object()
 
 

--- a/src/analyst_toolkit/mcp_server/schemas.py
+++ b/src/analyst_toolkit/mcp_server/schemas.py
@@ -8,6 +8,8 @@ and document tool inputs.
 
 from typing import TypedDict
 
+from analyst_toolkit.mcp_server.input.models import INPUT_ID_HEX_LENGTH, INPUT_ID_PATTERN
+
 
 class ToolResponse(TypedDict):
     status: str  # "pass" | "warn" | "fail" | "error"
@@ -38,10 +40,11 @@ _SESSION_ID_PROP = {
 INPUT_ID_PROP = {
     "input_id": {
         "type": "string",
-        "pattern": "^input_[a-f0-9]{12}$",
+        "pattern": INPUT_ID_PATTERN,
         "description": (
             "Optional: Canonical server-managed input reference returned by input "
-            "ingest/register flows. If provided, gcs_path and session_id are ignored."
+            "ingest/register flows. Uses a stable 16-hex suffix collision budget. "
+            "If provided, gcs_path and session_id are ignored."
         ),
     }
 }

--- a/src/analyst_toolkit/mcp_server/server.py
+++ b/src/analyst_toolkit/mcp_server/server.py
@@ -40,6 +40,7 @@ from analyst_toolkit.mcp_server.input.errors import (
     InputError,
     InputNotSupportedError,
     InputPayloadTooLargeError,
+    client_safe_input_error_code,
 )
 from analyst_toolkit.mcp_server.input.ingest import (
     get_input_descriptor,
@@ -164,7 +165,7 @@ def _input_error_http_status(exc: InputError) -> int:
 def _input_error_detail(exc: InputError, trace_id: str) -> dict[str, str]:
     return {
         "error": exc.message,
-        "code": exc.code,
+        "code": client_safe_input_error_code(exc.code),
         "trace_id": trace_id,
     }
 

--- a/src/analyst_toolkit/mcp_server/tools/input_ingest.py
+++ b/src/analyst_toolkit/mcp_server/tools/input_ingest.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from functools import partial
 
-from analyst_toolkit.mcp_server.input.errors import InputError
+from analyst_toolkit.mcp_server.input.errors import InputError, client_safe_input_error_code
 from analyst_toolkit.mcp_server.input.ingest import get_input_descriptor, register_input_source
 from analyst_toolkit.mcp_server.input.models import InputSourceType
 from analyst_toolkit.mcp_server.registry import register_tool
@@ -42,11 +42,11 @@ async def _toolkit_register_input(
         result: dict = {
             "status": "error",
             "module": "register_input",
-            "code": exc.code,
+            "code": client_safe_input_error_code(exc.code),
             "message": exc.message,
             "trace_id": trace_id,
         }
-        if exc.code == "INPUT_PATH_DENIED":
+        if client_safe_input_error_code(exc.code) == "INPUT_PATH_DENIED":
             safe_name = uri.rsplit("/", 1)[-1] if uri else "<filename>"
             result["next_actions"] = [
                 {

--- a/src/analyst_toolkit/mcp_server/tools/upload_input.py
+++ b/src/analyst_toolkit/mcp_server/tools/upload_input.py
@@ -5,7 +5,7 @@ import base64
 import logging
 from functools import partial
 
-from analyst_toolkit.mcp_server.input.errors import InputError
+from analyst_toolkit.mcp_server.input.errors import InputError, client_safe_input_error_code
 from analyst_toolkit.mcp_server.input.ingest import ingest_uploaded_bytes
 from analyst_toolkit.mcp_server.registry import register_tool
 from analyst_toolkit.mcp_server.response_utils import new_trace_id
@@ -114,7 +114,7 @@ async def _toolkit_upload_input(
         return {
             "status": "error",
             "module": "upload_input",
-            "code": exc.code,
+            "code": client_safe_input_error_code(exc.code),
             "message": exc.message,
             "trace_id": trace_id,
         }

--- a/tests/mcp_server/test_input_ingest.py
+++ b/tests/mcp_server/test_input_ingest.py
@@ -3,8 +3,9 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+import analyst_toolkit.mcp_server.server as server_module
 from analyst_toolkit.mcp_server.input import registry as input_registry
-from analyst_toolkit.mcp_server.input.errors import InputPathDeniedError
+from analyst_toolkit.mcp_server.input.errors import InputError, InputPathDeniedError
 from analyst_toolkit.mcp_server.input.storage import validate_server_visible_path
 from analyst_toolkit.mcp_server.state import StateStore
 from analyst_toolkit.mcp_server.tools import diagnostics as diagnostics_tool
@@ -282,7 +283,7 @@ def test_get_input_descriptor_tool_returns_not_found_for_unknown_input_id(client
         "method": "tools/call",
         "params": {
             "name": "get_input_descriptor",
-            "arguments": {"input_id": "input_deadbeefcafe"},
+            "arguments": {"input_id": "input_deadbeefcafebabe"},
         },
     }
 
@@ -293,6 +294,27 @@ def test_get_input_descriptor_tool_returns_not_found_for_unknown_input_id(client
     assert result["module"] == "get_input_descriptor"
     assert result["code"] == "INPUT_NOT_FOUND"
     assert isinstance(result["trace_id"], str)
+
+
+def test_inputs_register_falls_back_to_allowlisted_error_code(client, monkeypatch, clean_input_env):
+    class FutureInputError(InputError):
+        code = "INPUT_FUTURE_MODE"
+
+    def raise_future_error(*args, **kwargs):
+        raise FutureInputError("Unexpected future input error")
+
+    monkeypatch.setattr(server_module, "register_input_source", raise_future_error)
+
+    response = client.post(
+        "/inputs/register",
+        json={"uri": "gs://bucket/dirty_penguins.csv", "load_into_session": False},
+    )
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    assert detail["code"] == "INPUT_ERROR"
+    assert detail["error"] == "Unexpected future input error"
+    assert isinstance(detail["trace_id"], str)
 
 
 def test_register_input_tool_and_diagnostics_input_id_flow(client, mocker, clean_input_env):

--- a/tests/mcp_server/test_input_registry.py
+++ b/tests/mcp_server/test_input_registry.py
@@ -109,3 +109,12 @@ def test_get_registry_stats_reports_current_counts(clean_registry):
     assert stats["session_binding_count"] == 1
     assert stats["max_entries"] == 8
     assert stats["ttl_sec"] == 3600.0
+
+
+def test_new_input_id_uses_16_hex_entropy_budget():
+    from analyst_toolkit.mcp_server.input.ingest import _new_input_id
+
+    generated = _new_input_id("stable-key")
+    assert generated == _new_input_id("stable-key")
+    assert generated.startswith("input_")
+    assert len(generated) == len("input_") + 16

--- a/tests/mcp_server/test_rpc_tools.py
+++ b/tests/mcp_server/test_rpc_tools.py
@@ -61,7 +61,7 @@ def test_rpc_tools_list_exposes_data_dictionary_input_id_schema(client):
     data_dictionary = next(tool for tool in tools if tool["name"] == "data_dictionary")
     input_schema = data_dictionary["inputSchema"]
 
-    assert input_schema["properties"]["input_id"]["pattern"] == "^input_[a-f0-9]{12}$"
+    assert input_schema["properties"]["input_id"]["pattern"] == "^input_[a-f0-9]{16}$"
     assert input_schema["properties"]["input_id"]["description"].endswith(
         "If provided, gcs_path and session_id are ignored."
     )
@@ -80,7 +80,7 @@ def test_rpc_tools_list_standardizes_input_id_pattern_across_tool_schemas(client
     for tool_name in ("infer_configs", "auto_heal", "get_input_descriptor"):
         assert tool_name in tools, f"Expected tool '{tool_name}' not found in tools/list response"
         input_id_schema = tools[tool_name]["inputSchema"]["properties"]["input_id"]
-        assert input_id_schema["pattern"] == "^input_[a-f0-9]{12}$"
+        assert input_id_schema["pattern"] == "^input_[a-f0-9]{16}$"
         assert "Canonical server-managed input reference" in input_id_schema["description"]
 
 
@@ -956,7 +956,7 @@ def test_rpc_data_dictionary_tool_passes_explicit_input_id(client, mocker, tmp_p
             "name": "data_dictionary",
             "arguments": {
                 "gcs_path": "gs://bucket/data.csv",
-                "input_id": "input_deadbeefcafe",
+                "input_id": "input_deadbeefcafebabe",
                 "run_id": "dictionary_prelaunch_002",
             },
         },
@@ -968,7 +968,7 @@ def test_rpc_data_dictionary_tool_passes_explicit_input_id(client, mocker, tmp_p
     load_input.assert_called_once_with(
         "gs://bucket/data.csv",
         session_id=None,
-        input_id="input_deadbeefcafe",
+        input_id="input_deadbeefcafebabe",
     )
 
 

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -1875,6 +1875,29 @@ async def test_auto_heal_accepts_input_id_without_internal_error(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_register_input_tool_falls_back_to_allowlisted_error_code(monkeypatch):
+    from analyst_toolkit.mcp_server.input.errors import InputError
+
+    class FutureInputError(InputError):
+        code = "INPUT_FUTURE_MODE"
+
+    async def run():
+        return await input_ingest_tool._toolkit_register_input(uri="gs://bucket/data.csv")
+
+    def raise_future_error(*args, **kwargs):
+        raise FutureInputError("Unexpected future input error")
+
+    import analyst_toolkit.mcp_server.tools.input_ingest as input_ingest_tool
+
+    monkeypatch.setattr(input_ingest_tool, "register_input_source", raise_future_error)
+
+    result = await run()
+
+    assert result["status"] == "error"
+    assert result["code"] == "INPUT_ERROR"
+
+
+@pytest.mark.asyncio
 async def test_infer_configs_persists_configs_to_session(monkeypatch, mocker):
     """infer_configs should store inferred configs in StateStore for downstream tools."""
     df = pd.DataFrame({"id": [1, 2], "value": ["a", "b"]})


### PR DESCRIPTION
## Summary
- enforce an allowlist for client-facing input-domain error codes and fall back to `INPUT_ERROR` for unexpected future values
- raise canonical `input_id` entropy from 12 to 16 hex characters and centralize the shared contract constants
- update shared schemas and regressions so HTTP, MCP tools, and registry/idempotency flows agree on the new input-id contract

Closes #81
Closes #82

## Validation
- pytest tests/mcp_server/test_input_ingest.py tests/mcp_server/test_input_registry.py tests/mcp_server/test_rpc_tools.py tests/test_mcp_tool_regressions.py tests/mcp_server/test_rpc_resources.py tests/test_template_contracts.py -q
- ruff check src/ tests/
- ruff format --check src/ tests/
- mypy src/analyst_toolkit/mcp_server
- python -m yamllint .github/workflows .coderabbit.yaml
- pre-commit run --all-files

## CodeRabbit
- attempted local `coderabbit review --plain --no-color --type uncommitted`
- it reached `Reviewing` and then stopped returning findings or a completion marker
- documenting that as a local tooling blocker rather than treating it as a clean review