### PR TITLE
chore: dedupe input contract literals

### DIFF
--- a/src/analyst_toolkit/mcp_server/schemas.py
+++ b/src/analyst_toolkit/mcp_server/schemas.py
@@ -43,7 +43,7 @@ INPUT_ID_PROP = {
         "pattern": INPUT_ID_PATTERN,
         "description": (
             "Optional: Canonical server-managed input reference returned by input "
-            "ingest/register flows. Uses a stable 16-hex suffix collision budget. "
+            f"ingest/register flows. Uses a stable {INPUT_ID_HEX_LENGTH}-hex suffix collision budget. "
             "If provided, gcs_path and session_id are ignored."
         ),
     }

--- a/src/analyst_toolkit/mcp_server/tools/input_ingest.py
+++ b/src/analyst_toolkit/mcp_server/tools/input_ingest.py
@@ -39,14 +39,15 @@ async def _toolkit_register_input(
     except InputError as exc:
         trace_id = new_trace_id()
         logger.exception("Input registration failed (trace_id=%s, code=%s)", trace_id, exc.code)
+        normalized_code = client_safe_input_error_code(exc.code)
         result: dict = {
             "status": "error",
             "module": "register_input",
-            "code": client_safe_input_error_code(exc.code),
+            "code": normalized_code,
             "message": exc.message,
             "trace_id": trace_id,
         }
-        if client_safe_input_error_code(exc.code) == "INPUT_PATH_DENIED":
+        if normalized_code == "INPUT_PATH_DENIED":
             safe_name = uri.rsplit("/", 1)[-1] if uri else "<filename>"
             result["next_actions"] = [
                 {

--- a/tests/mcp_server/test_input_registry.py
+++ b/tests/mcp_server/test_input_registry.py
@@ -1,8 +1,14 @@
+import re
+
 import pytest
 
 from analyst_toolkit.mcp_server.input import registry as input_registry
 from analyst_toolkit.mcp_server.input.errors import InputConflictError
-from analyst_toolkit.mcp_server.input.models import InputDescriptor
+from analyst_toolkit.mcp_server.input.models import (
+    INPUT_ID_HEX_LENGTH,
+    INPUT_ID_PREFIX,
+    InputDescriptor,
+)
 
 
 @pytest.fixture
@@ -116,5 +122,6 @@ def test_new_input_id_uses_16_hex_entropy_budget():
 
     generated = _new_input_id("stable-key")
     assert generated == _new_input_id("stable-key")
-    assert generated.startswith("input_")
-    assert len(generated) == len("input_") + 16
+    assert generated.startswith(INPUT_ID_PREFIX)
+    assert len(generated) == len(INPUT_ID_PREFIX) + INPUT_ID_HEX_LENGTH
+    assert re.fullmatch(rf"{INPUT_ID_PREFIX}[0-9a-f]{{{INPUT_ID_HEX_LENGTH}}}", generated)

--- a/tests/mcp_server/test_rpc_tools.py
+++ b/tests/mcp_server/test_rpc_tools.py
@@ -5,6 +5,7 @@ from fastapi.testclient import TestClient
 import analyst_toolkit.mcp_server.local_artifact_server as artifact_server_module
 import analyst_toolkit.mcp_server.tools.cockpit as cockpit_module
 import analyst_toolkit.mcp_server.tools.data_dictionary as data_dictionary_tool
+from analyst_toolkit.mcp_server.input.models import INPUT_ID_PATTERN
 from analyst_toolkit.mcp_server.server import TOOL_REGISTRY, app
 
 
@@ -61,7 +62,7 @@ def test_rpc_tools_list_exposes_data_dictionary_input_id_schema(client):
     data_dictionary = next(tool for tool in tools if tool["name"] == "data_dictionary")
     input_schema = data_dictionary["inputSchema"]
 
-    assert input_schema["properties"]["input_id"]["pattern"] == "^input_[a-f0-9]{16}$"
+    assert input_schema["properties"]["input_id"]["pattern"] == INPUT_ID_PATTERN
     assert input_schema["properties"]["input_id"]["description"].endswith(
         "If provided, gcs_path and session_id are ignored."
     )
@@ -80,7 +81,7 @@ def test_rpc_tools_list_standardizes_input_id_pattern_across_tool_schemas(client
     for tool_name in ("infer_configs", "auto_heal", "get_input_descriptor"):
         assert tool_name in tools, f"Expected tool '{tool_name}' not found in tools/list response"
         input_id_schema = tools[tool_name]["inputSchema"]["properties"]["input_id"]
-        assert input_id_schema["pattern"] == "^input_[a-f0-9]{16}$"
+        assert input_id_schema["pattern"] == INPUT_ID_PATTERN
         assert "Canonical server-managed input reference" in input_id_schema["description"]
 
 

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -1895,6 +1895,9 @@ async def test_register_input_tool_falls_back_to_allowlisted_error_code(monkeypa
 
     assert result["status"] == "error"
     assert result["code"] == "INPUT_ERROR"
+    assert "trace_id" in result
+    assert isinstance(result["trace_id"], str)
+    assert result["trace_id"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- replace remaining hardcoded input-id literals in descriptions and tests with the shared contract constants
- normalize the allowlisted input error code once in `input_ingest` instead of recomputing it twice
- extend the regression coverage to assert the client-visible `trace_id` on the fallback error contract

## Validation
- pytest tests/mcp_server/test_input_registry.py tests/mcp_server/test_rpc_tools.py tests/test_mcp_tool_regressions.py -q
- ruff check src/ tests/
- ruff format --check src/ tests/
- mypy src/analyst_toolkit/mcp_server
- python -m yamllint .github/workflows .coderabbit.yaml
- pre-commit run --all-files

## CodeRabbit
- attempted local `coderabbit review --plain --no-color --type uncommitted`
- it reached `Reviewing` and then stopped returning findings or a completion marker
- documenting that as a local tooling blocker rather than treating it as a clean review