### PR TITLE
Pin dependency ranges and replace MCP git install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Format:
 
 ### Changed
 
+- Pin core and optional dependency ranges to prevent silent breakage from future major-version releases (#69).
+- Replace the MCP git dependency with a pinned `analyst_toolkit_deploy` GitHub Release wheel (#70).
 - Rename `read_artifact` response field `content` → `artifact_content` to avoid MCP protocol collision.
 - Restrict `read_artifact` CWD access to stdio mode only; HTTP mode is limited to artifact root.
 - Update quickstart, playbook, and capability catalog to document `manage_session(action="clear")`.

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -11,7 +11,8 @@ FROM python:3.13-slim
 WORKDIR /app
 
 # Install dependencies from project metadata.
-# requirements-mcp.txt is a thin compatibility shim that resolves to .[mcp].
+# requirements-mcp.txt is a thin compatibility shim that resolves to .[mcp],
+# including the release-backed analyst_toolkit_deploy wheel pin from pyproject.toml.
 COPY pyproject.toml .
 COPY README.md .
 COPY requirements-mcp.txt .

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ make install-dev       # editable install + dev tooling + notebook extras
 pip install -e ".[mcp]"
 ```
 
+The `mcp` extra installs `analyst_toolkit_deploy` from a pinned GitHub Release wheel, so MCP builds do not rely on git checkouts during dependency resolution.
+
 **With notebook extras**
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,16 +35,16 @@ classifiers = [
 # Core Dependencies
 # ----------------------------------------
 dependencies = [
-  "pandas",
-  "numpy",
-  "scipy",
-  "matplotlib",
-  "seaborn",
-  "joblib",
-  "PyYAML",
-  "thefuzz",
-  "XlsxWriter",
-  "openpyxl",
+  "pandas>=2.0,<3",
+  "numpy>=1.24,<3",
+  "scipy>=1.10,<2",
+  "matplotlib>=3.7,<4",
+  "seaborn>=0.12,<1",
+  "joblib>=1.2,<2",
+  "PyYAML>=6.0,<7",
+  "thefuzz>=0.20,<1",
+  "XlsxWriter>=3.1,<4",
+  "openpyxl>=3.1,<4",
 ]
 
 # ----------------------------------------
@@ -52,31 +52,31 @@ dependencies = [
 # ----------------------------------------
 [project.optional-dependencies]
 notebook = [
-  "ipython",
-  "ipywidgets",
+  "ipython>=8,<9",
+  "ipywidgets>=8,<9",
 ]
 mcp = [
-  "fastapi>=0.111",
-  "uvicorn[standard]>=0.29",
-  "mcp>=1.2.1",
-  "pyarrow>=14.0",
-  "google-cloud-storage>=2.14",
-  "gcsfs>=2024.2.0",
-  "python-multipart>=0.0.9",
-  "pydantic>=2.0",
-  "analyst_toolkit_deploy @ git+https://github.com/G-Schumacher44/analyst_toolkit_deployment_utility.git@a27113c111e03a1084f02d6665d389a50102deca",
+  "fastapi>=0.111,<1",
+  "uvicorn[standard]>=0.29,<1",
+  "mcp>=1.2.1,<2",
+  "pyarrow>=14.0,<20",
+  "google-cloud-storage>=2.14,<4",
+  "gcsfs>=2024.2.0,<2026.0.0",
+  "python-multipart>=0.0.9,<1",
+  "pydantic>=2.0,<3",
+  "analyst_toolkit_deploy @ https://github.com/G-Schumacher44/analyst_toolkit_deployment_utility/releases/download/v0.2.5/analyst_toolkit_deploy-0.2.5-py3-none-any.whl",
 ]
 dev = [
-  "pytest>=7.0",
-  "pytest-asyncio",
-  "pytest-mock",
-  "ruff",
-  "pre-commit",
-  "yamllint",
-  "httpx",
-  "mypy",
-  "pandas-stubs",
-  "types-PyYAML",
+  "pytest>=7.0,<9",
+  "pytest-asyncio>=0.23,<2",
+  "pytest-mock>=3.12,<4",
+  "ruff>=0.6,<1",
+  "pre-commit>=3.7,<5",
+  "yamllint>=1.35,<2",
+  "httpx>=0.27,<1",
+  "mypy>=1.11,<2",
+  "pandas-stubs>=2.2,<3",
+  "types-PyYAML>=6.0,<7",
 ]
 
 # ----------------------------------------

--- a/requirements-mcp.txt
+++ b/requirements-mcp.txt
@@ -3,5 +3,7 @@
 #
 # Canonical dependency source:
 # - core + extras live in pyproject.toml
+# - the mcp extra pins analyst_toolkit_deploy to a GitHub Release wheel, not a git checkout
+# - bump the release URL in pyproject.toml only after that asset is published upstream
 # - this file remains as a thin wrapper for Docker/CI and operator familiarity
 .[mcp]

--- a/resource_hub/usage_guide.md
+++ b/resource_hub/usage_guide.md
@@ -37,6 +37,8 @@ make install-dev       # editable install + dev tooling + notebook extras
 pip install -e ".[mcp]"
 ```
 
+The `mcp` extra pulls `analyst_toolkit_deploy` from a pinned GitHub Release wheel, which keeps MCP installs off git checkouts while preserving an explicit released version.
+
 **With notebook extras**
 
 ```bash


### PR DESCRIPTION
## Summary
- pin core and optional dependency ranges in `pyproject.toml` to avoid silent major-version breakage
- replace the MCP git-based `analyst_toolkit_deploy` dependency with a pinned GitHub Release wheel
- document the release-backed MCP install path in the README, usage guide, changelog, Dockerfile, and requirements shim

Closes #69
Closes #70

## Validation
- `python -m pip download --no-deps "analyst_toolkit_deploy @ https://github.com/G-Schumacher44/analyst_toolkit_deployment_utility/releases/download/v0.2.5/analyst_toolkit_deploy-0.2.5-py3-none-any.whl" -d /tmp/analyst_toolkit_deploy_release_check`
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `python -m yamllint .github/workflows .coderabbit.yaml`
- `mypy src/analyst_toolkit/mcp_server`
- `pytest tests/test_mcp_tool_regressions.py -q -k infer_configs`
- `pytest tests/mcp_server/test_rpc_tools.py -q -k "infer_configs or agent_playbook or input_descriptor"`
- `pre-commit run --all-files`

## CodeRabbit
- attempted `coderabbit review --plain --no-color --type uncommitted`
- local CLI progressed to `Reviewing` and then stopped returning output, so there were no findings to triage locally for this slice