### PR TITLE
Fix final artifact delivery follow-ups

### DIFF
--- a/src/analyst_toolkit/mcp_server/destination_routing.py
+++ b/src/analyst_toolkit/mcp_server/destination_routing.py
@@ -53,17 +53,21 @@ def _local_relative_path(local_path: str) -> Path:
     if any(part == ".." for part in path.parts):
         raise ValueError("Local artifact path must not contain parent-directory traversal.")
     resolved = path.resolve(strict=False)
+
+    def _strip_leading_exports(candidate: Path) -> Path:
+        if candidate.parts and candidate.parts[0] == "exports" and len(candidate.parts) > 1:
+            return Path(*candidate.parts[1:])
+        return candidate
+
     if not path.is_absolute():
         # Strip a leading "exports" segment so that combining with a
         # local_output_root that already points to "exports" doesn't
         # produce "exports/exports/...".
-        if path.parts and path.parts[0] == "exports" and len(path.parts) > 1:
-            return Path(*path.parts[1:])
-        return path
+        return _strip_leading_exports(path)
 
     cwd = Path.cwd()
     try:
-        return resolved.relative_to(cwd.resolve(strict=False))
+        return _strip_leading_exports(resolved.relative_to(cwd.resolve(strict=False)))
     except ValueError:
         if "exports" in resolved.parts:
             exports_index = resolved.parts.index("exports")
@@ -165,7 +169,11 @@ def deliver_artifact(
                 local_root,
                 exc,
             )
-            result["destinations"]["local"] = {"status": "rejected", "path": ""}
+            result["destinations"]["local"] = {
+                "status": "available",
+                "path": effective_local_path,
+                "requested_root_status": "rejected",
+            }
             result["warnings"].append(str(exc))
 
     drive_folder_id = str(config.get("drive_folder_id") or "").strip()

--- a/src/analyst_toolkit/mcp_server/destination_routing.py
+++ b/src/analyst_toolkit/mcp_server/destination_routing.py
@@ -97,7 +97,7 @@ def _resolve_local_output_root(root: str) -> Path:
 
 
 def _copy_to_local_root(local_path: str, root: str) -> str:
-    source = Path(local_path)
+    source = Path(local_path).resolve(strict=False)
     relative = _local_relative_path(local_path)
     resolved_root = _resolve_local_output_root(root)
     destination = (resolved_root / relative).resolve(strict=False)
@@ -107,6 +107,8 @@ def _copy_to_local_root(local_path: str, root: str) -> str:
         raise ValueError(
             "Resolved local artifact destination escapes the configured root."
         ) from exc
+    if destination == source:
+        return str(source)
     destination.parent.mkdir(parents=True, exist_ok=True)
     shutil.copy2(source, destination)
     return str(destination)

--- a/src/analyst_toolkit/mcp_server/tools/final_audit.py
+++ b/src/analyst_toolkit/mcp_server/tools/final_audit.py
@@ -274,7 +274,12 @@ async def _toolkit_final_audit(
     artifact_url = artifact_delivery["url"]
     warnings.extend(artifact_delivery["warnings"])
 
-    xlsx_path = f"exports/reports/final_audit/{run_id}_final_audit_report.xlsx"
+    xlsx_path = (
+        module_cfg.get("final_audit", {})
+        .get("settings", {})
+        .get("paths", {})
+        .get("report_excel", "exports/reports/final_audit/{run_id}_final_audit_report.xlsx")
+    ).format(run_id=run_id)
     xlsx_expected = Path(xlsx_path).exists()
     xlsx_url = ""
     if xlsx_expected:

--- a/src/analyst_toolkit/mcp_server/tools/final_audit.py
+++ b/src/analyst_toolkit/mcp_server/tools/final_audit.py
@@ -275,16 +275,18 @@ async def _toolkit_final_audit(
     warnings.extend(artifact_delivery["warnings"])
 
     xlsx_path = f"exports/reports/final_audit/{run_id}_final_audit_report.xlsx"
-    xlsx_delivery = deliver_artifact(
-        xlsx_path,
-        run_id,
-        "final_audit",
-        config=kwargs,
-        session_id=session_id,
-    )
-    xlsx_url = xlsx_delivery["url"]
-    warnings.extend(xlsx_delivery["warnings"])
-    xlsx_expected = bool(xlsx_delivery.get("local_path")) or Path(xlsx_path).exists()
+    xlsx_expected = Path(xlsx_path).exists()
+    xlsx_url = ""
+    if xlsx_expected:
+        xlsx_delivery = deliver_artifact(
+            xlsx_path,
+            run_id,
+            "final_audit",
+            config=kwargs,
+            session_id=session_id,
+        )
+        xlsx_url = xlsx_delivery["url"]
+        warnings.extend(xlsx_delivery["warnings"])
 
     cert_cfg = base_cfg.get("certification", {})
     schema_cfg = cert_cfg.get("schema_validation", {})

--- a/tests/mcp_server/test_destination_routing.py
+++ b/tests/mcp_server/test_destination_routing.py
@@ -62,7 +62,9 @@ def test_deliver_artifact_rejects_local_root_traversal(tmp_path, monkeypatch):
         logger=logging.getLogger("test"),
     )
 
-    assert delivery["destinations"]["local"]["status"] == "rejected"
+    assert delivery["destinations"]["local"]["status"] == "available"
+    assert delivery["destinations"]["local"]["path"] == str(source)
+    assert delivery["destinations"]["local"]["requested_root_status"] == "rejected"
     assert any(
         "must not contain parent-directory traversal" in warning for warning in delivery["warnings"]
     )
@@ -84,7 +86,9 @@ def test_deliver_artifact_rejects_local_root_absolute_path(tmp_path, monkeypatch
         logger=logging.getLogger("test"),
     )
 
-    assert delivery["destinations"]["local"]["status"] == "rejected"
+    assert delivery["destinations"]["local"]["status"] == "available"
+    assert delivery["destinations"]["local"]["path"] == str(source)
+    assert delivery["destinations"]["local"]["requested_root_status"] == "rejected"
     assert any(
         "must be relative to the configured local output base" in warning
         for warning in delivery["warnings"]
@@ -208,3 +212,27 @@ def test_deliver_artifact_no_doubled_exports_path(tmp_path, monkeypatch):
     # The routed path should be under exports/reports, not exports/exports/reports
     assert "exports/exports" not in str(routed)
     assert routed == tmp_path / "exports" / "reports" / "run1_report.html"
+
+
+def test_local_relative_path_strips_exports_for_absolute_path_inside_cwd(tmp_path, monkeypatch):
+    """Absolute paths under the workspace exports root should also avoid doubled exports."""
+    monkeypatch.chdir(tmp_path)
+    source = tmp_path / "exports" / "reports" / "data_dictionary" / "run1_report.html"
+    source.parent.mkdir(parents=True, exist_ok=True)
+    source.write_text("<html>dictionary</html>", encoding="utf-8")
+    monkeypatch.setenv("ANALYST_MCP_LOCAL_OUTPUT_BASE", str(tmp_path))
+
+    delivery = deliver_artifact(
+        str(source),
+        run_id="run1",
+        module="data_dictionary",
+        config={"local_output_root": "exports"},
+        session_id=None,
+        resolve_path_root=lambda run_id, session_id: f"paths/{run_id}",
+        logger=logging.getLogger("test"),
+    )
+
+    routed = Path(delivery["local_path"])
+    assert routed.exists()
+    assert "exports/exports" not in str(routed)
+    assert routed == tmp_path / "exports" / "reports" / "data_dictionary" / "run1_report.html"

--- a/tests/mcp_server/test_destination_routing.py
+++ b/tests/mcp_server/test_destination_routing.py
@@ -214,8 +214,11 @@ def test_deliver_artifact_no_doubled_exports_path(tmp_path, monkeypatch):
     assert routed == tmp_path / "exports" / "reports" / "run1_report.html"
 
 
-def test_local_relative_path_strips_exports_for_absolute_path_inside_cwd(tmp_path, monkeypatch):
+def test_local_relative_path_strips_exports_for_absolute_path_inside_cwd(
+    tmp_path, monkeypatch, caplog
+):
     """Absolute paths under the workspace exports root should also avoid doubled exports."""
+    caplog.set_level(logging.WARNING)
     monkeypatch.chdir(tmp_path)
     source = tmp_path / "exports" / "reports" / "data_dictionary" / "run1_report.html"
     source.parent.mkdir(parents=True, exist_ok=True)
@@ -236,3 +239,5 @@ def test_local_relative_path_strips_exports_for_absolute_path_inside_cwd(tmp_pat
     assert routed.exists()
     assert "exports/exports" not in str(routed)
     assert routed == tmp_path / "exports" / "reports" / "data_dictionary" / "run1_report.html"
+    assert "requested_root_status" not in delivery["destinations"]["local"]
+    assert not any("rejected" in rec.getMessage().lower() for rec in caplog.records)

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -1650,6 +1650,7 @@ async def test_final_audit_disables_xlsx_expectation_when_no_xlsx_artifact(mocke
 
     assert result["artifact_matrix"]["xlsx_report"]["expected"] is False
     assert result["artifact_matrix"]["xlsx_report"]["status"] == "disabled"
+    assert not any("Artifact not found for routing" in warning for warning in result["warnings"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- stop final_audit from routing or warning on a missing XLSX report when no XLSX artifact was generated
- preserve local artifact availability when an optional mirror-to-local-output-root request is rejected
- strip the leading `exports/` segment for absolute workspace artifact paths so local routing does not produce `exports/exports/...`

## Validation
- `pytest tests/mcp_server/test_destination_routing.py tests/test_mcp_tool_regressions.py -q -k "destination_routing or final_audit_disables_xlsx_expectation_when_no_xlsx_artifact or local_relative_path"`
- `pytest tests/mcp_server/test_rpc_tools.py -q -k "data_dictionary or final_audit"`
- `pytest tests/hardening/test_history_and_contracts.py tests/mcp_server/test_destination_routing.py -q`
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `python -m yamllint .github/workflows .coderabbit.yaml`
- `mypy src/analyst_toolkit/mcp_server`
- `pre-commit run --all-files`

## CodeRabbit
- attempted `coderabbit review --plain --no-color --type uncommitted`
- local CLI progressed to `Reviewing` and then stopped returning output, so there were no findings to triage locally for this slice