### PR TITLE
Align public workflow templates with MCP contracts

### DIFF
--- a/config/auto_heal_request_template.yaml
+++ b/config/auto_heal_request_template.yaml
@@ -1,3 +1,9 @@
+gcs_path: "gs://bucket/path/to/input.csv"
+session_id: null
+input_id: null
+run_id: "auto_heal_run_001"
+async_mode: false
+
 runtime:
   run:
     run_id: "auto_heal_run_001"
@@ -12,12 +18,3 @@ runtime:
       prefix: "auto_heal"
   execution:
     upload_artifacts: true
-
-auto_heal:
-  session_id: ""
-  gcs_path: ""
-  mode: "sync"
-  notes:
-    - "Provide either runtime.run.input_path, gcs_path, or session_id."
-    - "Use auto_heal for one-shot remediation only when the user explicitly requests automation."
-    - "Treat dashboard_url or dashboard_path as the main operator review surface after execution."

--- a/config/data_dictionary_request_template.yaml
+++ b/config/data_dictionary_request_template.yaml
@@ -1,19 +1,20 @@
-data_dictionary:
-  gcs_path: gs://bucket/path/to/data.csv
-  session_id: null
-  run_id: data_dictionary_prelaunch_001
-  profile_depth: standard
-  include_examples: true
-  prelaunch_report: true
-  runtime:
-    run:
-      input_path: gs://bucket/path/to/data.csv
-      run_id: data_dictionary_prelaunch_001
-    artifacts:
-      export_html: true
-      plotting: false
-    destinations:
-      gcs:
-        enabled: false
-        bucket_uri: gs://bucket
-        prefix: reports/data_dictionary
+gcs_path: "gs://bucket/path/to/data.csv"
+session_id: null
+input_id: null
+run_id: "data_dictionary_prelaunch_001"
+profile_depth: "standard"
+include_examples: true
+prelaunch_report: true
+
+runtime:
+  run:
+    input_path: "gs://bucket/path/to/data.csv"
+    run_id: "data_dictionary_prelaunch_001"
+  artifacts:
+    export_html: true
+    plotting: false
+  destinations:
+    gcs:
+      enabled: false
+      bucket_uri: "gs://bucket"
+      prefix: "reports/data_dictionary"

--- a/src/analyst_toolkit/mcp_server/templates.py
+++ b/src/analyst_toolkit/mcp_server/templates.py
@@ -88,11 +88,6 @@ CONFIG_TEMPLATE_SPECS: tuple[TemplateSpec, ...] = (
         config_root="outlier_detection",
     ),
     TemplateSpec(
-        filename="handling_config_template.yaml",
-        description="Module config template: outlier handling",
-        category="module_config",
-    ),
-    TemplateSpec(
         filename="imputation_config_template.yaml",
         description="Module config template: imputation",
         category="module_config",
@@ -105,11 +100,6 @@ CONFIG_TEMPLATE_SPECS: tuple[TemplateSpec, ...] = (
         category="module_config",
         tool="final_audit",
         config_root="final_audit",
-    ),
-    TemplateSpec(
-        filename="certification_config_template.yaml",
-        description="Module config template: certification",
-        category="module_config",
     ),
     TemplateSpec(
         filename="runtime_overlay_template.yaml",

--- a/tests/test_template_contracts.py
+++ b/tests/test_template_contracts.py
@@ -15,6 +15,10 @@ from analyst_toolkit.mcp_server.templates import (
     list_template_resources,
     read_template_resource,
 )
+from analyst_toolkit.mcp_server.tools.auto_heal import _INPUT_SCHEMA as AUTO_HEAL_INPUT_SCHEMA
+from analyst_toolkit.mcp_server.tools.data_dictionary import (
+    DATA_DICTIONARY_INPUT_SCHEMA,
+)
 from analyst_toolkit.mcp_server.tools.preflight_config import (
     _shape_warnings,
     _unknown_effective_keys,
@@ -41,6 +45,8 @@ def test_template_resource_uris_cover_template_files():
     # These are concrete local/internal run configs, not user-facing template resources.
     assert "analyst://templates/config/nightly_silver_qa_config.yaml" not in uris
     assert "analyst://templates/config/run_toolkit_config.yaml" not in uris
+    assert "analyst://templates/config/handling_config_template.yaml" not in uris
+    assert "analyst://templates/config/certification_config_template.yaml" not in uris
 
 
 def test_all_template_resources_parse_as_yaml_mapping():
@@ -87,3 +93,19 @@ def test_public_module_templates_match_current_config_contracts():
         assert not _shape_warnings(module_name, normalized), spec.filename
         assert not _unknown_effective_keys(module_name, normalized), spec.filename
         CONFIG_MODELS[module_name].model_validate(normalized)
+
+
+def test_workflow_request_templates_match_public_tool_input_contracts():
+    cases = [
+        ("auto_heal_request_template.yaml", AUTO_HEAL_INPUT_SCHEMA),
+        ("data_dictionary_request_template.yaml", DATA_DICTIONARY_INPUT_SCHEMA),
+    ]
+
+    for filename, schema in cases:
+        raw = yaml.safe_load(
+            (Path(__file__).resolve().parent.parent / "config" / filename).read_text()
+        )
+        assert isinstance(raw, dict), filename
+        assert all(key in schema["properties"] for key in raw), filename
+        assert "runtime" in raw, filename
+        assert not any(key in raw for key in ("auto_heal", "data_dictionary")), filename


### PR DESCRIPTION
## Summary
- reshape the exposed `auto_heal` and `data_dictionary` request templates so they match real MCP tool-call arguments instead of nested wrapper configs
- stop advertising internal-only pipeline-stage templates that do not correspond to public MCP tool contracts
- add regression coverage for the public workflow template contract and hidden internal template inventory

## Validation
- `pytest tests/test_template_contracts.py tests/mcp_server/test_rpc_resources.py tests/mcp_server/test_rpc_tools.py -q -k "template or capability_catalog or resources_list or resources_read_auto_heal_template or resources_read_data_dictionary_template"`
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `python -m yamllint .github/workflows .coderabbit.yaml`
- `mypy src/analyst_toolkit/mcp_server`
- `pre-commit run --all-files`

## CodeRabbit
- attempted `coderabbit review --plain --no-color --type uncommitted`
- local CLI progressed to `Reviewing` and then stopped returning output, so there were no findings to triage locally for this slice