### PR TITLE
Fix cockpit resource group lookups

### DIFF
--- a/src/analyst_toolkit/mcp_server/tools/cockpit_templates.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit_templates.py
@@ -5,6 +5,18 @@ from __future__ import annotations
 from typing import Any
 
 
+def _require_resource_by_reference(
+    resources_by_reference: dict[str, dict[str, str]],
+    reference: str,
+) -> dict[str, str]:
+    try:
+        return resources_by_reference[reference]
+    except KeyError as exc:
+        raise ValueError(
+            f"build_cockpit_resource_groups missing resource reference: {reference}"
+        ) from exc
+
+
 def build_cockpit_resources() -> list[dict[str, str]]:
     return [
         {
@@ -47,6 +59,9 @@ def build_cockpit_resources() -> list[dict[str, str]]:
 
 
 def build_cockpit_resource_groups(resources: list[dict[str, str]]) -> list[dict[str, Any]]:
+    resources_by_reference = {
+        resource["Reference"]: resource for resource in resources if "Reference" in resource
+    }
     return [
         {
             "title": "Start Here",
@@ -54,7 +69,20 @@ def build_cockpit_resource_groups(resources: list[dict[str, str]]) -> list[dict[
                 "Open these first when you need orientation, a safe execution recipe, or a "
                 "human-readable guide before touching module-specific configs."
             ),
-            "items": [resources[0], resources[1], resources[3]],
+            "items": [
+                _require_resource_by_reference(
+                    resources_by_reference,
+                    "analyst://docs/quickstart",
+                ),
+                _require_resource_by_reference(
+                    resources_by_reference,
+                    "analyst://docs/agent-playbook",
+                ),
+                _require_resource_by_reference(
+                    resources_by_reference,
+                    "analyst://templates/config/runtime_overlay_template.yaml",
+                ),
+            ],
         },
         {
             "title": "Templates And Contracts",
@@ -62,7 +90,20 @@ def build_cockpit_resource_groups(resources: list[dict[str, str]]) -> list[dict[
                 "These are the copyable request shapes for runtime overlays, auto-heal, and the "
                 "data dictionary workflow."
             ),
-            "items": [resources[3], resources[4], resources[5]],
+            "items": [
+                _require_resource_by_reference(
+                    resources_by_reference,
+                    "analyst://templates/config/runtime_overlay_template.yaml",
+                ),
+                _require_resource_by_reference(
+                    resources_by_reference,
+                    "analyst://templates/config/auto_heal_request_template.yaml",
+                ),
+                _require_resource_by_reference(
+                    resources_by_reference,
+                    "analyst://templates/config/data_dictionary_request_template.yaml",
+                ),
+            ],
         },
         {
             "title": "Capability Surfaces",
@@ -70,7 +111,12 @@ def build_cockpit_resource_groups(resources: list[dict[str, str]]) -> list[dict[
                 "Use these to inspect what the toolkit can do right now and which knobs are safe "
                 "to edit without rewriting YAML by hand."
             ),
-            "items": [resources[2]],
+            "items": [
+                _require_resource_by_reference(
+                    resources_by_reference,
+                    "analyst://catalog/capabilities",
+                )
+            ],
         },
     ]
 

--- a/tests/mcp_server/test_rpc_tools.py
+++ b/tests/mcp_server/test_rpc_tools.py
@@ -7,6 +7,10 @@ import analyst_toolkit.mcp_server.tools.cockpit as cockpit_module
 import analyst_toolkit.mcp_server.tools.data_dictionary as data_dictionary_tool
 from analyst_toolkit.mcp_server.input.models import INPUT_ID_PATTERN
 from analyst_toolkit.mcp_server.server import TOOL_REGISTRY, app
+from analyst_toolkit.mcp_server.tools.cockpit_templates import (
+    build_cockpit_resource_groups,
+    build_cockpit_resources,
+)
 
 
 @pytest.fixture
@@ -83,6 +87,42 @@ def test_rpc_tools_list_standardizes_input_id_pattern_across_tool_schemas(client
         input_id_schema = tools[tool_name]["inputSchema"]["properties"]["input_id"]
         assert input_id_schema["pattern"] == INPUT_ID_PATTERN
         assert "Canonical server-managed input reference" in input_id_schema["description"]
+
+
+def test_build_cockpit_resource_groups_uses_reference_lookup_not_position() -> None:
+    resources = build_cockpit_resources()
+    reordered = [resources[5], resources[2], resources[0], resources[4], resources[1], resources[3]]
+
+    groups = build_cockpit_resource_groups(reordered)
+
+    assert [item["Reference"] for item in groups[0]["items"]] == [
+        "analyst://docs/quickstart",
+        "analyst://docs/agent-playbook",
+        "analyst://templates/config/runtime_overlay_template.yaml",
+    ]
+    assert [item["Reference"] for item in groups[1]["items"]] == [
+        "analyst://templates/config/runtime_overlay_template.yaml",
+        "analyst://templates/config/auto_heal_request_template.yaml",
+        "analyst://templates/config/data_dictionary_request_template.yaml",
+    ]
+    assert [item["Reference"] for item in groups[2]["items"]] == ["analyst://catalog/capabilities"]
+
+
+def test_build_cockpit_resource_groups_raises_clear_error_for_missing_reference() -> None:
+    resources = [
+        resource
+        for resource in build_cockpit_resources()
+        if resource["Reference"] != "analyst://docs/agent-playbook"
+    ]
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "build_cockpit_resource_groups missing resource reference: "
+            "analyst://docs/agent-playbook"
+        ),
+    ):
+        build_cockpit_resource_groups(resources)
 
 
 def test_rpc_capability_catalog_tool(client):


### PR DESCRIPTION
## Summary
- replace positional cockpit resource grouping with stable Reference-based lookups
- raise a clear ValueError when a required cockpit resource is missing
- add regression coverage for reordered resources and missing references

## Validation
- pytest tests/mcp_server/test_rpc_tools.py -q -k 'build_cockpit_resource_groups or cockpit'
- ruff check src/analyst_toolkit/mcp_server/tools/cockpit_templates.py tests/mcp_server/test_rpc_tools.py
- ruff format --check src/analyst_toolkit/mcp_server/tools/cockpit_templates.py tests/mcp_server/test_rpc_tools.py
- mypy src/analyst_toolkit/mcp_server
- python -m yamllint .github/workflows .coderabbit.yaml
- pre-commit run --all-files

## CodeRabbit
- local CodeRabbit review was attempted
- the CLI failed immediately with a rate-limit error instead of returning findings