### PR TITLE
chore: add CI coverage release gate

### DIFF
--- a/.github/workflows/analyst-toolkit-mcp-ci.yml
+++ b/.github/workflows/analyst-toolkit-mcp-ci.yml
@@ -154,6 +154,7 @@ jobs:
             --cov-fail-under=68
 
       - name: Upload coverage artifact
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report

--- a/.github/workflows/analyst-toolkit-mcp-ci.yml
+++ b/.github/workflows/analyst-toolkit-mcp-ci.yml
@@ -123,9 +123,45 @@ jobs:
           # shellcheck disable=SC2086
           pip-audit $IGNORE_FLAGS
 
+  coverage:
+    name: Coverage (py3.13)
+    needs: [secret-scan]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-mcp.txt
+          pip install -e ".[dev]"
+
+      - name: Run coverage gate
+        run: |
+          pytest tests/ \
+            --cov=src/analyst_toolkit \
+            --cov-report=xml \
+            --cov-report=term-missing:skip-covered \
+            --cov-fail-under=68
+
+      - name: Upload coverage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
+
   build-package:
     name: Build Wheel
-    needs: [quality, dependency-audit]
+    needs: [quality, dependency-audit, coverage]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -155,7 +191,7 @@ jobs:
 
   docker-smoke:
     name: Docker Build and Smoke Test
-    needs: [quality, dependency-audit]
+    needs: [quality, dependency-audit, coverage]
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,9 @@ CodeRabbit is included in the PR review loop. Triage its findings using the [Cod
 
 CI enforces linting, type checks, tests, and Docker smoke tests.
 
+The CI pipeline also enforces a Python 3.13 coverage floor. The current release
+gate is `68%` statement coverage for `src/analyst_toolkit`.
+
 ## Testing Guidance
 
 - Add or update tests for behavior changes.
@@ -84,6 +87,12 @@ CI enforces linting, type checks, tests, and Docker smoke tests.
 - Prefer additive MCP response changes over breaking shape changes.
 - If a contract break is unavoidable, call it out in the PR and release notes.
 - Keep docs and regression tests aligned with the actual public contract.
+
+## GitHub Actions Trust Model
+
+- CI currently uses maintained major-version action tags such as `@v4` and `@v5`.
+- Before introducing or upgrading an action, review the upstream action owner, release history, and required permissions.
+- Prefer official GitHub or Docker-maintained actions where possible, and document any new third-party action use in the PR.
 
 ## Commit Message Guidance
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ mcp = [
 ]
 dev = [
   "pytest>=7.0,<9",
+  "pytest-cov>=7.1,<8",
   "pytest-asyncio>=0.23,<2",
   "pytest-mock>=3.12,<4",
   "ruff>=0.6,<1",


### PR DESCRIPTION
## Summary
- add `pytest-cov` to the dev toolchain and enforce a dedicated Python 3.13 coverage job in CI
- gate release-path jobs on a 68% statement coverage floor and upload `coverage.xml` as a workflow artifact
- document the new coverage gate and current GitHub Actions trust model in CONTRIBUTING

## Validation
- ruff check src/ tests/
- ruff format --check src/ tests/
- python -m yamllint .github/workflows .coderabbit.yaml
- mypy src/analyst_toolkit/mcp_server
- pytest tests/ -q
- pytest tests/ --cov=src/analyst_toolkit --cov-report=xml --cov-report=term-missing:skip-covered --cov-fail-under=68 -q
- pre-commit run --all-files

## CodeRabbit
- attempted local `coderabbit review --plain --no-color --type uncommitted`
- it reached `Reviewing` and then stopped returning findings, so this is documented as a local tooling blocker rather than a clean local review