### PR TITLE
fix: bound MCP input loading

### DIFF
--- a/resource_hub/mcp_server_guide.md
+++ b/resource_hub/mcp_server_guide.md
@@ -697,6 +697,10 @@ In your FridAI `remote_manager` config, point to the running server:
 | `ANALYST_MCP_VERSION_FALLBACK` | No | `0.0.0+local` | Version string used when package metadata is unavailable in local/source execution |
 | `ANALYST_MCP_AUTH_TOKEN` | No | _(unset)_ | If set, require `Authorization: Bearer <token>` for `/rpc`, `/health`, `/ready`, and `/metrics` |
 | `ANALYST_MCP_RESOURCE_TIMEOUT_SEC` | No | `8.0` | Timeout for MCP `resources/list` and `resources/read` filesystem work |
+| `ANALYST_MCP_MAX_INPUT_BYTES` | No | `104857600` | Maximum single-input byte budget for local files, GCS objects, and cumulative GCS prefix loads |
+| `ANALYST_MCP_MAX_GCS_PREFIX_OBJECTS` | No | `32` | Maximum number of `.csv` / `.parquet` blobs loaded from a single GCS prefix |
+| `ANALYST_MCP_MAX_INPUT_ROWS` | No | `1000000` | Maximum row count allowed after an input is loaded into a DataFrame |
+| `ANALYST_MCP_MAX_INPUT_MEMORY_BYTES` | No | `268435456` | Maximum in-memory DataFrame size allowed after an input is loaded |
 | `ANALYST_MCP_ADVERTISE_RESOURCE_TEMPLATES` | No | `false` | If `true`, `resources/templates/list` returns URI templates (otherwise empty to avoid duplicate UI listings) |
 | `ANALYST_MCP_TEMPLATE_IO_TIMEOUT_SEC` | No | `8.0` | Timeout for cockpit template reads (`get_capability_catalog`, `get_golden_templates`) |
 | `ANALYST_MCP_STRUCTURED_LOGS` | No | `false` | Emit JSON-structured request lifecycle logs (`trace_id`, method, tool, duration) |
@@ -738,6 +742,11 @@ The server dispatches on path format:
 | `path/to/file.parquet` | `pd.read_parquet()` (local) |
 | `path/to/file.csv` | `pd.read_csv()` (local) |
 | `session_id` | Reads from in-memory `StateStore` (no I/O) |
+
+Boundary guards:
+- local files, single GCS objects, and cumulative GCS prefix loads respect `ANALYST_MCP_MAX_INPUT_BYTES`
+- GCS prefix scans stop once `ANALYST_MCP_MAX_GCS_PREFIX_OBJECTS` is exceeded
+- loaded DataFrames are rejected if they exceed `ANALYST_MCP_MAX_INPUT_ROWS` or `ANALYST_MCP_MAX_INPUT_MEMORY_BYTES`
 
 > **Note:** Partition-style directory paths must end with `/`. Direct file paths (ending in `.parquet` or `.csv`) are read without listing.
 

--- a/src/analyst_toolkit/mcp_server/input/__init__.py
+++ b/src/analyst_toolkit/mcp_server/input/__init__.py
@@ -1,11 +1,8 @@
 """Input ingest subsystem for MCP data sources."""
 
-from analyst_toolkit.mcp_server.input.ingest import (
-    get_input_descriptor,
-    ingest_uploaded_bytes,
-    load_dataframe,
-    register_input_source,
-)
+from __future__ import annotations
+
+from typing import Any
 
 __all__ = [
     "get_input_descriptor",
@@ -13,3 +10,27 @@ __all__ = [
     "load_dataframe",
     "register_input_source",
 ]
+
+
+def get_input_descriptor(*args: Any, **kwargs: Any):
+    from analyst_toolkit.mcp_server.input.ingest import get_input_descriptor as _impl
+
+    return _impl(*args, **kwargs)
+
+
+def ingest_uploaded_bytes(*args: Any, **kwargs: Any):
+    from analyst_toolkit.mcp_server.input.ingest import ingest_uploaded_bytes as _impl
+
+    return _impl(*args, **kwargs)
+
+
+def load_dataframe(*args: Any, **kwargs: Any):
+    from analyst_toolkit.mcp_server.input.ingest import load_dataframe as _impl
+
+    return _impl(*args, **kwargs)
+
+
+def register_input_source(*args: Any, **kwargs: Any):
+    from analyst_toolkit.mcp_server.input.ingest import register_input_source as _impl
+
+    return _impl(*args, **kwargs)

--- a/src/analyst_toolkit/mcp_server/input/limits.py
+++ b/src/analyst_toolkit/mcp_server/input/limits.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterable
 
 import pandas as pd
 
@@ -62,18 +63,53 @@ def enforce_gcs_prefix_object_limit(*, object_count: int, reference: str) -> Non
 
 
 def enforce_dataframe_limits(df: pd.DataFrame, *, reference: str) -> None:
+    enforce_tabular_limits(
+        row_count=len(df),
+        memory_usage_bytes=int(df.memory_usage(index=True, deep=True).sum()),
+        reference=reference,
+    )
+
+
+def enforce_tabular_limits(
+    *,
+    row_count: int,
+    memory_usage_bytes: int,
+    reference: str,
+    memory_env_name: str = "ANALYST_MCP_MAX_INPUT_MEMORY_BYTES",
+) -> None:
     row_limit = max_input_rows()
-    if row_limit and len(df) > row_limit:
+    if row_limit and row_count > row_limit:
         raise InputPayloadTooLargeError(
             f"Input '{reference}' exceeds ANALYST_MCP_MAX_INPUT_ROWS "
-            f"({len(df)} rows > {row_limit})."
+            f"({row_count} rows > {row_limit})."
         )
 
     memory_limit = max_input_memory_bytes()
-    if memory_limit:
-        memory_usage = int(df.memory_usage(index=True, deep=True).sum())
-        if memory_usage > memory_limit:
-            raise InputPayloadTooLargeError(
-                f"Input '{reference}' exceeds ANALYST_MCP_MAX_INPUT_MEMORY_BYTES "
-                f"({memory_usage} bytes > {memory_limit} bytes)."
-            )
+    if memory_limit and memory_usage_bytes > memory_limit:
+        raise InputPayloadTooLargeError(
+            f"Input '{reference}' exceeds {memory_env_name} "
+            f"({memory_usage_bytes} bytes > {memory_limit} bytes)."
+        )
+
+
+def materialize_chunked_frames(
+    frames: Iterable[pd.DataFrame], *, reference: str, copy: bool = False
+) -> pd.DataFrame:
+    collected: list[pd.DataFrame] = []
+    cumulative_rows = 0
+    cumulative_memory = 0
+    for frame in frames:
+        cumulative_rows += len(frame)
+        cumulative_memory += int(frame.memory_usage(index=True, deep=True).sum())
+        enforce_tabular_limits(
+            row_count=cumulative_rows,
+            memory_usage_bytes=cumulative_memory,
+            reference=reference,
+        )
+        collected.append(frame.copy() if copy else frame)
+
+    if not collected:
+        return pd.DataFrame()
+    if len(collected) == 1:
+        return collected[0]
+    return pd.concat(collected, ignore_index=True)

--- a/src/analyst_toolkit/mcp_server/input/limits.py
+++ b/src/analyst_toolkit/mcp_server/input/limits.py
@@ -1,0 +1,79 @@
+"""Input boundary limits for MCP dataset loading."""
+
+from __future__ import annotations
+
+import os
+
+import pandas as pd
+
+from analyst_toolkit.mcp_server.input.errors import InputPayloadTooLargeError
+
+_DEFAULT_MAX_INPUT_BYTES = 100 * 1024 * 1024
+_DEFAULT_MAX_INPUT_ROWS = 1_000_000
+_DEFAULT_MAX_INPUT_MEMORY_BYTES = 256 * 1024 * 1024
+_DEFAULT_MAX_GCS_PREFIX_OBJECTS = 32
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        return default
+    return value if value >= 0 else default
+
+
+def max_input_bytes() -> int:
+    return _env_int("ANALYST_MCP_MAX_INPUT_BYTES", _DEFAULT_MAX_INPUT_BYTES)
+
+
+def max_input_rows() -> int:
+    return _env_int("ANALYST_MCP_MAX_INPUT_ROWS", _DEFAULT_MAX_INPUT_ROWS)
+
+
+def max_input_memory_bytes() -> int:
+    return _env_int("ANALYST_MCP_MAX_INPUT_MEMORY_BYTES", _DEFAULT_MAX_INPUT_MEMORY_BYTES)
+
+
+def max_gcs_prefix_objects() -> int:
+    return _env_int("ANALYST_MCP_MAX_GCS_PREFIX_OBJECTS", _DEFAULT_MAX_GCS_PREFIX_OBJECTS)
+
+
+def enforce_input_bytes_limit(size_bytes: int | None, *, reference: str) -> None:
+    if size_bytes is None:
+        return
+    limit = max_input_bytes()
+    if limit and size_bytes > limit:
+        raise InputPayloadTooLargeError(
+            f"Input '{reference}' exceeds ANALYST_MCP_MAX_INPUT_BYTES "
+            f"({size_bytes} bytes > {limit} bytes)."
+        )
+
+
+def enforce_gcs_prefix_object_limit(*, object_count: int, reference: str) -> None:
+    limit = max_gcs_prefix_objects()
+    if limit and object_count > limit:
+        raise InputPayloadTooLargeError(
+            f"GCS prefix '{reference}' exceeds ANALYST_MCP_MAX_GCS_PREFIX_OBJECTS "
+            f"({object_count} objects > {limit})."
+        )
+
+
+def enforce_dataframe_limits(df: pd.DataFrame, *, reference: str) -> None:
+    row_limit = max_input_rows()
+    if row_limit and len(df) > row_limit:
+        raise InputPayloadTooLargeError(
+            f"Input '{reference}' exceeds ANALYST_MCP_MAX_INPUT_ROWS "
+            f"({len(df)} rows > {row_limit})."
+        )
+
+    memory_limit = max_input_memory_bytes()
+    if memory_limit:
+        memory_usage = int(df.memory_usage(index=True, deep=True).sum())
+        if memory_usage > memory_limit:
+            raise InputPayloadTooLargeError(
+                f"Input '{reference}' exceeds ANALYST_MCP_MAX_INPUT_MEMORY_BYTES "
+                f"({memory_usage} bytes > {memory_limit} bytes)."
+            )

--- a/src/analyst_toolkit/mcp_server/input/loaders.py
+++ b/src/analyst_toolkit/mcp_server/input/loaders.py
@@ -7,6 +7,10 @@ from pathlib import Path
 import pandas as pd
 
 from analyst_toolkit.mcp_server.input.errors import InputNotSupportedError
+from analyst_toolkit.mcp_server.input.limits import (
+    enforce_dataframe_limits,
+    enforce_input_bytes_limit,
+)
 from analyst_toolkit.mcp_server.input.models import InputDescriptor
 from analyst_toolkit.mcp_server.io_storage import load_from_gcs
 
@@ -24,10 +28,15 @@ def load_dataframe_from_descriptor(descriptor: InputDescriptor) -> pd.DataFrame:
         )
 
     path = Path(descriptor.resolved_reference).resolve(strict=False)
+    enforce_input_bytes_limit(path.stat().st_size, reference=str(path))
     if path.suffix == ".parquet":
-        return pd.read_parquet(path)
+        df = pd.read_parquet(path)
+        enforce_dataframe_limits(df, reference=str(path))
+        return df
     if path.suffix == ".csv":
-        return pd.read_csv(path, low_memory=False)
+        df = pd.read_csv(path, low_memory=False)
+        enforce_dataframe_limits(df, reference=str(path))
+        return df
     raise InputNotSupportedError(
         f"Unsupported file format: {path.suffix or '<none>'}. Supported formats are .csv and .parquet."
     )

--- a/src/analyst_toolkit/mcp_server/input/loaders.py
+++ b/src/analyst_toolkit/mcp_server/input/loaders.py
@@ -10,9 +10,45 @@ from analyst_toolkit.mcp_server.input.errors import InputNotSupportedError
 from analyst_toolkit.mcp_server.input.limits import (
     enforce_dataframe_limits,
     enforce_input_bytes_limit,
+    enforce_tabular_limits,
+    materialize_chunked_frames,
 )
 from analyst_toolkit.mcp_server.input.models import InputDescriptor
 from analyst_toolkit.mcp_server.io_storage import load_from_gcs
+
+
+def _safe_descriptor_reference(descriptor: InputDescriptor, path: Path) -> str:
+    return descriptor.display_name or descriptor.original_reference or path.name
+
+
+def _read_csv_with_limits(path: Path, *, reference: str) -> pd.DataFrame:
+    return materialize_chunked_frames(
+        pd.read_csv(path, low_memory=False, chunksize=50_000),
+        reference=reference,
+    )
+
+
+def _read_parquet_with_limits(path: Path, *, reference: str) -> pd.DataFrame:
+    try:
+        import pyarrow.parquet as pq
+    except ImportError:
+        df = pd.read_parquet(path)
+        enforce_dataframe_limits(df, reference=reference)
+        return df
+
+    parquet_file = pq.ParquetFile(path)
+    metadata = parquet_file.metadata
+    estimated_bytes = 0
+    for idx in range(metadata.num_row_groups):
+        estimated_bytes += metadata.row_group(idx).total_byte_size
+    enforce_tabular_limits(
+        row_count=metadata.num_rows,
+        memory_usage_bytes=estimated_bytes,
+        reference=reference,
+    )
+    df = pd.read_parquet(path)
+    enforce_dataframe_limits(df, reference=reference)
+    return df
 
 
 def load_dataframe_from_descriptor(descriptor: InputDescriptor) -> pd.DataFrame:
@@ -28,15 +64,12 @@ def load_dataframe_from_descriptor(descriptor: InputDescriptor) -> pd.DataFrame:
         )
 
     path = Path(descriptor.resolved_reference).resolve(strict=False)
-    enforce_input_bytes_limit(path.stat().st_size, reference=str(path))
+    safe_reference = _safe_descriptor_reference(descriptor, path)
+    enforce_input_bytes_limit(path.stat().st_size, reference=safe_reference)
     if path.suffix == ".parquet":
-        df = pd.read_parquet(path)
-        enforce_dataframe_limits(df, reference=str(path))
-        return df
+        return _read_parquet_with_limits(path, reference=safe_reference)
     if path.suffix == ".csv":
-        df = pd.read_csv(path, low_memory=False)
-        enforce_dataframe_limits(df, reference=str(path))
-        return df
+        return _read_csv_with_limits(path, reference=safe_reference)
     raise InputNotSupportedError(
         f"Unsupported file format: {path.suffix or '<none>'}. Supported formats are .csv and .parquet."
     )

--- a/src/analyst_toolkit/mcp_server/io_storage.py
+++ b/src/analyst_toolkit/mcp_server/io_storage.py
@@ -9,10 +9,12 @@ from uuid import uuid4
 
 import pandas as pd
 
+from analyst_toolkit.mcp_server.input.errors import InputNotFoundError
 from analyst_toolkit.mcp_server.input.limits import (
     enforce_dataframe_limits,
     enforce_gcs_prefix_object_limit,
     enforce_input_bytes_limit,
+    materialize_chunked_frames,
 )
 
 logger = logging.getLogger(__name__)
@@ -24,6 +26,38 @@ _CONTENT_TYPES = {
     ".json": "application/json",
     ".png": "image/png",
 }
+
+
+def _read_csv_with_limits(path: Path, *, reference: str) -> pd.DataFrame:
+    return materialize_chunked_frames(
+        pd.read_csv(path, low_memory=False, chunksize=50_000),
+        reference=reference,
+    )
+
+
+def _read_parquet_with_limits(path: Path, *, reference: str) -> pd.DataFrame:
+    try:
+        import pyarrow.parquet as pq
+    except ImportError:
+        df = pd.read_parquet(path)
+        enforce_dataframe_limits(df, reference=reference)
+        return df
+
+    parquet_file = pq.ParquetFile(path)
+    metadata = parquet_file.metadata
+    estimated_bytes = 0
+    for idx in range(metadata.num_row_groups):
+        estimated_bytes += metadata.row_group(idx).total_byte_size
+    from analyst_toolkit.mcp_server.input.limits import enforce_tabular_limits
+
+    enforce_tabular_limits(
+        row_count=metadata.num_rows,
+        memory_usage_bytes=estimated_bytes,
+        reference=reference,
+    )
+    df = pd.read_parquet(path)
+    enforce_dataframe_limits(df, reference=reference)
+    return df
 
 
 def load_from_gcs(gcs_path: str) -> pd.DataFrame:
@@ -38,16 +72,15 @@ def load_from_gcs(gcs_path: str) -> pd.DataFrame:
     if prefix.endswith(".parquet") or prefix.endswith(".csv"):
         blob = bucket.get_blob(prefix)
         if blob is None:
-            raise FileNotFoundError(f"No file found at gs://{bucket_name}/{prefix}")
+            raise InputNotFoundError(f"No file found at gs://{bucket_name}/{prefix}")
         enforce_input_bytes_limit(blob.size, reference=gcs_path)
         with tempfile.TemporaryDirectory() as tmpdir:
             local_path = Path(tmpdir) / Path(prefix).name
             blob.download_to_filename(str(local_path))
             if local_path.suffix == ".parquet":
-                df = pd.read_parquet(local_path)
+                df = _read_parquet_with_limits(local_path, reference=gcs_path)
             else:
-                df = pd.read_csv(local_path, low_memory=False)
-            enforce_dataframe_limits(df, reference=gcs_path)
+                df = _read_csv_with_limits(local_path, reference=gcs_path)
             return df
 
     # Directory path — list and concat all matching files
@@ -70,10 +103,10 @@ def load_from_gcs(gcs_path: str) -> pd.DataFrame:
             local_path = Path(tmpdir) / blob.name.replace("/", "_")
             blob.download_to_filename(str(local_path))
             if local_path.suffix == ".parquet":
-                frames.append(pd.read_parquet(local_path))
+                frames.append(_read_parquet_with_limits(local_path, reference=gcs_path))
             else:
-                frames.append(pd.read_csv(local_path, low_memory=False))
-    result = pd.concat(frames, ignore_index=True) if len(frames) > 1 else frames[0]
+                frames.append(_read_csv_with_limits(local_path, reference=gcs_path))
+    result = materialize_chunked_frames(frames, reference=gcs_path, copy=False)
     enforce_dataframe_limits(result, reference=gcs_path)
     return result
 

--- a/src/analyst_toolkit/mcp_server/io_storage.py
+++ b/src/analyst_toolkit/mcp_server/io_storage.py
@@ -9,6 +9,12 @@ from uuid import uuid4
 
 import pandas as pd
 
+from analyst_toolkit.mcp_server.input.limits import (
+    enforce_dataframe_limits,
+    enforce_gcs_prefix_object_limit,
+    enforce_input_bytes_limit,
+)
+
 logger = logging.getLogger(__name__)
 
 _CONTENT_TYPES = {
@@ -30,16 +36,30 @@ def load_from_gcs(gcs_path: str) -> pd.DataFrame:
 
     # Direct file path — download and read without listing
     if prefix.endswith(".parquet") or prefix.endswith(".csv"):
+        blob = bucket.get_blob(prefix)
+        if blob is None:
+            raise FileNotFoundError(f"No file found at gs://{bucket_name}/{prefix}")
+        enforce_input_bytes_limit(blob.size, reference=gcs_path)
         with tempfile.TemporaryDirectory() as tmpdir:
             local_path = Path(tmpdir) / Path(prefix).name
-            bucket.blob(prefix).download_to_filename(str(local_path))
+            blob.download_to_filename(str(local_path))
             if local_path.suffix == ".parquet":
-                return pd.read_parquet(local_path)
-            return pd.read_csv(local_path, low_memory=False)
+                df = pd.read_parquet(local_path)
+            else:
+                df = pd.read_csv(local_path, low_memory=False)
+            enforce_dataframe_limits(df, reference=gcs_path)
+            return df
 
     # Directory path — list and concat all matching files
-    blobs = list(client.list_blobs(bucket_name, prefix=f"{prefix.rstrip('/')}/"))
-    blobs = [b for b in blobs if b.name.endswith(".parquet") or b.name.endswith(".csv")]
+    blobs = []
+    total_bytes = 0
+    for blob in client.list_blobs(bucket_name, prefix=f"{prefix.rstrip('/')}/"):
+        if not blob.name.endswith(".parquet") and not blob.name.endswith(".csv"):
+            continue
+        blobs.append(blob)
+        total_bytes += int(getattr(blob, "size", 0) or 0)
+        enforce_gcs_prefix_object_limit(object_count=len(blobs), reference=gcs_path)
+        enforce_input_bytes_limit(total_bytes, reference=gcs_path)
 
     if not blobs:
         raise FileNotFoundError(f"No .parquet or .csv files found at gs://{bucket_name}/{prefix}")
@@ -53,7 +73,9 @@ def load_from_gcs(gcs_path: str) -> pd.DataFrame:
                 frames.append(pd.read_parquet(local_path))
             else:
                 frames.append(pd.read_csv(local_path, low_memory=False))
-    return pd.concat(frames, ignore_index=True) if len(frames) > 1 else frames[0]
+    result = pd.concat(frames, ignore_index=True) if len(frames) > 1 else frames[0]
+    enforce_dataframe_limits(result, reference=gcs_path)
+    return result
 
 
 def _collect_export_html_flags(

--- a/src/analyst_toolkit/mcp_server/registry.py
+++ b/src/analyst_toolkit/mcp_server/registry.py
@@ -6,6 +6,7 @@ import inspect
 import logging
 from typing import Any
 
+from analyst_toolkit.mcp_server.input.errors import InputError, client_safe_input_error_code
 from analyst_toolkit.mcp_server.response_utils import (
     attach_trace_id,
     build_error_envelope,
@@ -30,6 +31,33 @@ def register_tool(name: str, fn, description: str, input_schema: dict) -> None:
             if inspect.isawaitable(result):
                 result = await result
             return attach_trace_id(result, trace_id)
+        except InputError as exc:
+            normalized_code = client_safe_input_error_code(exc.code)
+            message = str(exc)
+            logger.warning(
+                "Tool '%s' rejected input at trust boundary (trace_id=%s, code=%s)",
+                name,
+                trace_id,
+                normalized_code,
+            )
+            return {
+                "status": "error",
+                "module": name,
+                "code": normalized_code,
+                "message": message,
+                "error": build_error_envelope(
+                    category="io",
+                    code=normalized_code.lower(),
+                    message=message,
+                    remediation=(
+                        "Reduce input size, narrow the selected prefix, or raise the relevant "
+                        "ANALYST_MCP_MAX_INPUT_* limit if this workload is expected."
+                    ),
+                    retryable=False,
+                    trace_id=trace_id,
+                ),
+                "trace_id": trace_id,
+            }
         except Exception as exc:
             logger.exception("Tool '%s' failed (trace_id=%s)", name, trace_id)
             return {

--- a/src/analyst_toolkit/mcp_server/registry.py
+++ b/src/analyst_toolkit/mcp_server/registry.py
@@ -19,6 +19,28 @@ logger = logging.getLogger("analyst_toolkit.mcp_server.registry")
 TOOL_REGISTRY: dict[str, dict[str, Any]] = {}
 
 
+def _input_error_remediation(code: str) -> str:
+    if code == "INPUT_PAYLOAD_TOO_LARGE":
+        return (
+            "Reduce input size, narrow the selected prefix, or raise the relevant "
+            "ANALYST_MCP_MAX_INPUT_* limit if this workload is expected."
+        )
+    if code == "INPUT_NOT_SUPPORTED":
+        return (
+            "Use a supported source or file format: upload/server-visible .csv/.parquet, or gs://."
+        )
+    if code == "INPUT_PATH_DENIED":
+        return (
+            "Use a server-visible path, update ANALYST_MCP_ALLOWED_INPUT_ROOTS, "
+            "upload the file, or switch to gs://."
+        )
+    if code == "INPUT_CONFLICT":
+        return "Retry with a unique idempotency key or the same canonical source reference."
+    if code == "INPUT_NOT_FOUND" or code == "INPUT_PATH_NOT_FOUND":
+        return "Check the requested input_id or path and retry with an existing resource."
+    return "Verify input arguments and retry."
+
+
 def register_tool(name: str, fn, description: str, input_schema: dict) -> None:
     """
     Register an async callable as an MCP tool.
@@ -49,10 +71,7 @@ def register_tool(name: str, fn, description: str, input_schema: dict) -> None:
                     category="io",
                     code=normalized_code.lower(),
                     message=message,
-                    remediation=(
-                        "Reduce input size, narrow the selected prefix, or raise the relevant "
-                        "ANALYST_MCP_MAX_INPUT_* limit if this workload is expected."
-                    ),
+                    remediation=_input_error_remediation(normalized_code),
                     retryable=False,
                     trace_id=trace_id,
                 ),

--- a/tests/mcp_server/test_input_loaders.py
+++ b/tests/mcp_server/test_input_loaders.py
@@ -40,6 +40,59 @@ def test_load_dataframe_from_descriptor_rejects_dataframe_over_row_limit(monkeyp
         load_dataframe_from_descriptor(_descriptor_for(source))
 
 
+def test_load_dataframe_from_descriptor_rejects_dataframe_over_memory_limit(monkeypatch, tmp_path):
+    source = tmp_path / "memory.csv"
+    pd.DataFrame({"a": ["x" * 64, "y" * 64]}).to_csv(source, index=False)
+    monkeypatch.setenv("ANALYST_MCP_MAX_INPUT_BYTES", "1000000")
+    monkeypatch.setenv("ANALYST_MCP_MAX_INPUT_MEMORY_BYTES", "32")
+
+    with pytest.raises(InputPayloadTooLargeError, match="ANALYST_MCP_MAX_INPUT_MEMORY_BYTES"):
+        load_dataframe_from_descriptor(_descriptor_for(source))
+
+
+def test_load_dataframe_from_descriptor_rejects_gcs_single_blob_over_byte_limit(monkeypatch):
+    class FakeBlob:
+        def __init__(self, name: str, size: int = 8):
+            self.name = name
+            self.size = size
+
+        def download_to_filename(self, filename: str) -> None:
+            Path(filename).write_text("a\n1\n", encoding="utf-8")
+
+    class FakeBucket:
+        def get_blob(self, blob_name: str):
+            assert blob_name == "dataset/file.csv"
+            return FakeBlob(blob_name, size=1024)
+
+    class FakeClient:
+        def bucket(self, _bucket_name: str):
+            return FakeBucket()
+
+    storage_mod = types.ModuleType("google.cloud.storage")
+    storage_mod.Client = FakeClient
+    cloud_mod = types.ModuleType("google.cloud")
+    cloud_mod.storage = storage_mod
+    google_mod = types.ModuleType("google")
+    google_mod.cloud = cloud_mod
+
+    monkeypatch.setitem(sys.modules, "google", google_mod)
+    monkeypatch.setitem(sys.modules, "google.cloud", cloud_mod)
+    monkeypatch.setitem(sys.modules, "google.cloud.storage", storage_mod)
+    monkeypatch.setenv("ANALYST_MCP_MAX_INPUT_BYTES", "16")
+
+    descriptor = InputDescriptor(
+        input_id="input_deadbeefcafebabe",
+        source_type="gcs",
+        original_reference="gs://bucket/dataset/file.csv",
+        resolved_reference="gs://bucket/dataset/file.csv",
+        display_name="dataset/file.csv",
+        media_type="text/csv",
+    )
+
+    with pytest.raises(InputPayloadTooLargeError, match="ANALYST_MCP_MAX_INPUT_BYTES"):
+        load_dataframe_from_descriptor(descriptor)
+
+
 def test_load_dataframe_from_descriptor_rejects_gcs_prefix_over_object_limit(monkeypatch):
     class FakeBlob:
         def __init__(self, name: str, size: int = 8):

--- a/tests/mcp_server/test_input_loaders.py
+++ b/tests/mcp_server/test_input_loaders.py
@@ -1,0 +1,90 @@
+import sys
+import types
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from analyst_toolkit.mcp_server.input.errors import InputPayloadTooLargeError
+from analyst_toolkit.mcp_server.input.loaders import load_dataframe_from_descriptor
+from analyst_toolkit.mcp_server.input.models import InputDescriptor
+
+
+def _descriptor_for(path: Path, *, source_type: str = "server_path") -> InputDescriptor:
+    return InputDescriptor(
+        input_id="input_deadbeefcafebabe",
+        source_type=source_type,
+        original_reference=str(path),
+        resolved_reference=str(path),
+        display_name=path.name,
+        media_type="text/csv",
+    )
+
+
+def test_load_dataframe_from_descriptor_rejects_local_file_over_byte_limit(monkeypatch, tmp_path):
+    source = tmp_path / "wide.csv"
+    source.write_text("a,b\n1,2\n", encoding="utf-8")
+    monkeypatch.setenv("ANALYST_MCP_MAX_INPUT_BYTES", "4")
+
+    with pytest.raises(InputPayloadTooLargeError, match="ANALYST_MCP_MAX_INPUT_BYTES"):
+        load_dataframe_from_descriptor(_descriptor_for(source))
+
+
+def test_load_dataframe_from_descriptor_rejects_dataframe_over_row_limit(monkeypatch, tmp_path):
+    source = tmp_path / "rows.csv"
+    pd.DataFrame({"a": [1, 2]}).to_csv(source, index=False)
+    monkeypatch.setenv("ANALYST_MCP_MAX_INPUT_BYTES", "1000000")
+    monkeypatch.setenv("ANALYST_MCP_MAX_INPUT_ROWS", "1")
+
+    with pytest.raises(InputPayloadTooLargeError, match="ANALYST_MCP_MAX_INPUT_ROWS"):
+        load_dataframe_from_descriptor(_descriptor_for(source))
+
+
+def test_load_dataframe_from_descriptor_rejects_gcs_prefix_over_object_limit(monkeypatch):
+    class FakeBlob:
+        def __init__(self, name: str, size: int = 8):
+            self.name = name
+            self.size = size
+
+        def download_to_filename(self, filename: str) -> None:
+            Path(filename).write_text("a\n1\n", encoding="utf-8")
+
+    class FakeBucket:
+        def get_blob(self, blob_name: str):
+            return None
+
+    class FakeClient:
+        def bucket(self, _bucket_name: str):
+            return FakeBucket()
+
+        def list_blobs(self, _bucket_name: str, prefix: str):
+            assert prefix == "dataset/"
+            return [
+                FakeBlob("dataset/part-000.csv"),
+                FakeBlob("dataset/part-001.csv"),
+            ]
+
+    storage_mod = types.ModuleType("google.cloud.storage")
+    storage_mod.Client = FakeClient
+    cloud_mod = types.ModuleType("google.cloud")
+    cloud_mod.storage = storage_mod
+    google_mod = types.ModuleType("google")
+    google_mod.cloud = cloud_mod
+
+    monkeypatch.setitem(sys.modules, "google", google_mod)
+    monkeypatch.setitem(sys.modules, "google.cloud", cloud_mod)
+    monkeypatch.setitem(sys.modules, "google.cloud.storage", storage_mod)
+    monkeypatch.setenv("ANALYST_MCP_MAX_GCS_PREFIX_OBJECTS", "1")
+    monkeypatch.setenv("ANALYST_MCP_MAX_INPUT_BYTES", "1000000")
+
+    descriptor = InputDescriptor(
+        input_id="input_deadbeefcafebabe",
+        source_type="gcs",
+        original_reference="gs://bucket/dataset/",
+        resolved_reference="gs://bucket/dataset/",
+        display_name="dataset/",
+        media_type="text/csv",
+    )
+
+    with pytest.raises(InputPayloadTooLargeError, match="ANALYST_MCP_MAX_GCS_PREFIX_OBJECTS"):
+        load_dataframe_from_descriptor(descriptor)

--- a/tests/mcp_server/test_rpc_preflight.py
+++ b/tests/mcp_server/test_rpc_preflight.py
@@ -1,3 +1,7 @@
+import analyst_toolkit.mcp_server.tools.diagnostics as diagnostics_tool
+from analyst_toolkit.mcp_server.input.errors import InputPayloadTooLargeError
+
+
 def test_rpc_preflight_config_normalizes_validation_shape(client):
     payload = {
         "jsonrpc": "2.0",
@@ -246,4 +250,28 @@ def test_rpc_tools_call_returns_structured_error_envelope_for_tool_failure(clien
     assert result["error"]["category"] == "internal"
     assert result["error"]["code"] == "tool_execution_failed"
     assert result["error"]["retryable"] is False
+    assert result["error"]["trace_id"] == result["trace_id"]
+
+
+def test_rpc_tools_call_surfaces_stable_input_error_for_capacity_guardrail(client, monkeypatch):
+    def raise_input_limit(*args, **kwargs):
+        raise InputPayloadTooLargeError("Input exceeds ANALYST_MCP_MAX_INPUT_ROWS")
+
+    monkeypatch.setattr(diagnostics_tool, "load_input", raise_input_limit)
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 29,
+        "method": "tools/call",
+        "params": {"name": "diagnostics", "arguments": {"gcs_path": "gs://bucket/data.csv"}},
+    }
+
+    response = client.post("/rpc", json=payload)
+    assert response.status_code == 200
+    result = response.json()["result"]
+    assert result["status"] == "error"
+    assert result["module"] == "diagnostics"
+    assert result["code"] == "INPUT_PAYLOAD_TOO_LARGE"
+    assert isinstance(result.get("trace_id"), str)
+    assert result["trace_id"]
+    assert result["error"]["code"] == "input_payload_too_large"
     assert result["error"]["trace_id"] == result["trace_id"]


### PR DESCRIPTION
## Summary
- add env-driven byte, row, memory, and GCS prefix object limits at the shared MCP input-loading boundary
- normalize `InputError` failures in the tool registry so capacity guardrails surface as stable client-visible codes instead of generic internal errors
- document the new MCP input guardrail env vars and add focused local/GCS/RPC regression coverage

## Validation
- pytest tests/hardening/test_config_and_upload.py tests/mcp_server/test_input_loaders.py tests/mcp_server/test_rpc_preflight.py tests/mcp_server/test_input_ingest.py -q
- ruff check src/ tests/
- ruff format --check src/ tests/
- python -m yamllint .github/workflows .coderabbit.yaml
- mypy src/analyst_toolkit/mcp_server
- pre-commit run --all-files

## CodeRabbit
- attempted local `coderabbit review --plain --no-color --type uncommitted`
- it reached `Reviewing` and then stopped returning findings, so this is documented as a local tooling blocker rather than a clean local review