### PR TITLE
fix: surface session retention policy

### DIFF
--- a/resource_hub/mcp_server_guide.md
+++ b/resource_hub/mcp_server_guide.md
@@ -226,6 +226,8 @@ When diagnosing failures, use `trace_id` from the JSON-RPC error payload and cor
 
 Every tool accepts either a `gcs_path`/file path **or** a `session_id`. When a tool runs, it saves its output to an in-memory `StateStore` and returns a `session_id`. Pass that `session_id` to the next tool to operate on the already-transformed data — no intermediate files needed.
 
+For this release, session persistence is explicitly **in-memory only**. Sessions are bounded by TTL and max-entry eviction, and `manage_session` surfaces the live retention policy plus per-session expiry timestamps.
+
 ```text
 1. diagnostics(gcs_path="gs://bucket/path/file.parquet", run_id="my_run")
      → creates session_id: "sess_abc123", establishes baseline profile
@@ -705,6 +707,8 @@ In your FridAI `remote_manager` config, point to the running server:
 | `ANALYST_MCP_TEMPLATE_IO_TIMEOUT_SEC` | No | `8.0` | Timeout for cockpit template reads (`get_capability_catalog`, `get_golden_templates`) |
 | `ANALYST_MCP_STRUCTURED_LOGS` | No | `false` | Emit JSON-structured request lifecycle logs (`trace_id`, method, tool, duration) |
 | `ANALYST_MCP_JOB_STATE_PATH` | No | `exports/reports/jobs/job_state.json` | Local JSON persistence path for async job state (`get_job_status`, `list_jobs`) |
+| `ANALYST_MCP_SESSION_TTL_SEC` | No | `3600` | Session time-to-live for in-memory `StateStore` entries |
+| `ANALYST_MCP_SESSION_MAX_ENTRIES` | No | `32` | Maximum number of in-memory sessions retained before LRU eviction |
 | `ANALYST_MCP_ALLOW_RUN_ID_OVERRIDE` | No | `false` | Allow a requested `run_id` to differ from the session-bound run id (otherwise run id is coerced) |
 | `ANALYST_MCP_RUN_HISTORY_SUMMARY_ONLY_DEFAULT` | No | `true` | Default compact ledger mode for `get_run_history` when caller omits `summary_only` |
 | `ANALYST_MCP_RUN_HISTORY_DEFAULT_LIMIT` | No | `50` | Default max ledger entries returned in compact mode when caller omits `limit` |
@@ -747,6 +751,11 @@ Boundary guards:
 - local files, single GCS objects, and cumulative GCS prefix loads respect `ANALYST_MCP_MAX_INPUT_BYTES`
 - GCS prefix scans stop once `ANALYST_MCP_MAX_GCS_PREFIX_OBJECTS` is exceeded
 - loaded DataFrames are rejected if they exceed `ANALYST_MCP_MAX_INPUT_ROWS` or `ANALYST_MCP_MAX_INPUT_MEMORY_BYTES`
+
+Session lifecycle notes:
+- `manage_session(action="list")` returns the active retention policy (`backend`, `durable`, `ttl_sec`, `max_entries`) alongside the session summaries
+- `manage_session(action="inspect")` returns `last_accessed_at`, `expires_at`, and `expires_in_sec` for the selected session
+- `manage_session(action="fork")` clones the in-memory DataFrame and optionally the stored inferred configs into a new session with its own run context
 
 > **Note:** Partition-style directory paths must end with `/`. Direct file paths (ending in `.parquet` or `.csv`) are read without listing.
 

--- a/src/analyst_toolkit/mcp_server/state.py
+++ b/src/analyst_toolkit/mcp_server/state.py
@@ -7,6 +7,7 @@ import os
 import threading
 import time
 import uuid
+from datetime import datetime, timezone
 from typing import Dict, Optional
 
 import pandas as pd
@@ -31,6 +32,17 @@ class StateStore:
     _session_run_ids: Dict[str, str] = {}
     _session_start_times: Dict[str, str] = {}
     _session_configs: Dict[str, Dict[str, str]] = {}
+
+    @classmethod
+    def policy(cls) -> dict[str, object]:
+        """Return the current session retention policy."""
+        return {
+            "backend": "memory",
+            "durable": False,
+            "persistence": "in_memory_only",
+            "ttl_sec": SESSION_TTL_SECONDS,
+            "max_entries": SESSION_MAX_ENTRIES,
+        }
 
     @classmethod
     def save(
@@ -84,6 +96,32 @@ class StateStore:
         """Retrieve metadata for a session."""
         with cls._lock:
             return cls._metadata.get(session_id)
+
+    @classmethod
+    def get_last_accessed(cls, session_id: str) -> Optional[float]:
+        """Retrieve the last-access timestamp for a session."""
+        with cls._lock:
+            return cls._last_accessed.get(session_id)
+
+    @classmethod
+    def get_expiry_info(cls, session_id: str) -> dict[str, object]:
+        """Return derived expiry information for a session."""
+        with cls._lock:
+            last_accessed = cls._last_accessed.get(session_id)
+        if last_accessed is None:
+            return {
+                "last_accessed_at": None,
+                "expires_at": None,
+                "expires_in_sec": None,
+            }
+
+        expires_at_ts = last_accessed + SESSION_TTL_SECONDS
+        now = time.time()
+        return {
+            "last_accessed_at": datetime.fromtimestamp(last_accessed, tz=timezone.utc).isoformat(),
+            "expires_at": datetime.fromtimestamp(expires_at_ts, tz=timezone.utc).isoformat(),
+            "expires_in_sec": max(0, int(expires_at_ts - now)),
+        }
 
     @classmethod
     def save_config(cls, session_id: str, module: str, config_yaml: str) -> None:

--- a/src/analyst_toolkit/mcp_server/tools/session.py
+++ b/src/analyst_toolkit/mcp_server/tools/session.py
@@ -10,6 +10,7 @@ from analyst_toolkit.mcp_server.state import StateStore
 def _session_summary(session_id: str) -> dict:
     """Build a compact summary dict for a session."""
     metadata = StateStore.get_metadata(session_id) or {}
+    expiry = StateStore.get_expiry_info(session_id)
     return {
         "session_id": session_id,
         "run_id": StateStore.get_run_id(session_id),
@@ -17,6 +18,9 @@ def _session_summary(session_id: str) -> dict:
         "row_count": metadata.get("row_count"),
         "col_count": metadata.get("col_count"),
         "updated_at": metadata.get("updated_at"),
+        "last_accessed_at": expiry["last_accessed_at"],
+        "expires_at": expiry["expires_at"],
+        "expires_in_sec": expiry["expires_in_sec"],
         "stored_configs": sorted(StateStore.get_configs(session_id).keys()),
     }
 
@@ -46,6 +50,7 @@ async def _toolkit_manage_session(
             "status": "pass",
             "module": "manage_session",
             "action": "list",
+            "session_policy": StateStore.policy(),
             "sessions": summaries,
             "session_count": len(summaries),
         }
@@ -73,6 +78,7 @@ async def _toolkit_manage_session(
                 "status": "pass",
                 "module": "manage_session",
                 "action": "inspect",
+                "session_policy": StateStore.policy(),
                 "session": summary,
             },
             [
@@ -115,6 +121,7 @@ async def _toolkit_manage_session(
                 "status": "pass",
                 "module": "manage_session",
                 "action": "fork",
+                "session_policy": StateStore.policy(),
                 "source_session_id": session_id,
                 "new_session_id": new_session_id,
                 "run_id": run_id,
@@ -166,6 +173,7 @@ async def _toolkit_manage_session(
             "status": "pass",
             "module": "manage_session",
             "action": "rebind",
+            "session_policy": StateStore.policy(),
             "session_id": session_id,
             "previous_run_id": old_run_id,
             "new_run_id": run_id,
@@ -186,6 +194,7 @@ async def _toolkit_manage_session(
                 "status": "pass",
                 "module": "manage_session",
                 "action": "clear",
+                "session_policy": StateStore.policy(),
                 "cleared_session_id": session_id,
             }
         else:
@@ -196,6 +205,7 @@ async def _toolkit_manage_session(
                 "status": "pass",
                 "module": "manage_session",
                 "action": "clear",
+                "session_policy": StateStore.policy(),
                 "cleared_count": count,
                 "message": f"Cleared all {count} sessions.",
             }

--- a/tests/test_mcp_tool_regressions_io.py
+++ b/tests/test_mcp_tool_regressions_io.py
@@ -21,9 +21,12 @@ async def test_manage_session_list():
     result = await session_tool._toolkit_manage_session(action="list")
     assert result["status"] == "pass"
     assert result["session_count"] == 2
+    assert result["session_policy"]["backend"] == "memory"
+    assert result["session_policy"]["durable"] is False
     session_ids = {s["session_id"] for s in result["sessions"]}
     assert sid1 in session_ids
     assert sid2 in session_ids
+    assert all("expires_in_sec" in s for s in result["sessions"])
     StateStore.clear()
 
 
@@ -40,6 +43,9 @@ async def test_manage_session_inspect():
     assert result["session"]["run_id"] == "inspect_run"
     assert result["session"]["row_count"] == 3
     assert "validation" in result["session"]["stored_configs"]
+    assert result["session_policy"]["persistence"] == "in_memory_only"
+    assert result["session"]["last_accessed_at"]
+    assert result["session"]["expires_at"]
     assert "next_actions" in result
     StateStore.clear()
 


### PR DESCRIPTION
## Summary
- expose the current session backend and retention policy directly through `manage_session` responses
- add per-session expiry metadata (`last_accessed_at`, `expires_at`, `expires_in_sec`) so in-memory lifecycle behavior is explicit
- document the release-default session posture as in-memory only and add the session TTL / max-entry env vars to the MCP guide

## Validation
- pytest tests/test_mcp_tool_regressions_io.py tests/hardening/test_state_store.py -q
- ruff check src/ tests/
- ruff format --check src/ tests/
- python -m yamllint .github/workflows .coderabbit.yaml
- mypy src/analyst_toolkit/mcp_server
- pre-commit run --all-files

## CodeRabbit
- attempted local `coderabbit review --plain --no-color --type uncommitted`
- it reached `Reviewing` and then stopped returning findings, so this is documented as a local tooling blocker rather than a clean local review