### PR TITLE
fix: add on-demand session config retrieval

### DIFF
--- a/resource_hub/mcp_server_guide.md
+++ b/resource_hub/mcp_server_guide.md
@@ -227,6 +227,7 @@ When diagnosing failures, use `trace_id` from the JSON-RPC error payload and cor
 Every tool accepts either a `gcs_path`/file path **or** a `session_id`. When a tool runs, it saves its output to an in-memory `StateStore` and returns a `session_id`. Pass that `session_id` to the next tool to operate on the already-transformed data — no intermediate files needed.
 
 For this release, session persistence is explicitly **in-memory only**. Sessions are bounded by TTL and max-entry eviction, and `manage_session` surfaces the live retention policy plus per-session expiry timestamps.
+Use `manage_session(action="inspect", include_configs=true)` when you need the stored inferred config payloads; the default inspect/list responses stay compact and only include config names/counts.
 
 ```text
 1. diagnostics(gcs_path="gs://bucket/path/file.parquet", run_id="my_run")
@@ -755,6 +756,7 @@ Boundary guards:
 Session lifecycle notes:
 - `manage_session(action="list")` returns the active retention policy (`backend`, `durable`, `ttl_sec`, `max_entries`) alongside the session summaries
 - `manage_session(action="inspect")` returns `last_accessed_at`, `expires_at`, and `expires_in_sec` for the selected session
+- `manage_session(action="inspect", include_configs=true)` retrieves the stored inferred config YAML payloads on demand
 - `manage_session(action="fork")` clones the in-memory DataFrame and optionally the stored inferred configs into a new session with its own run context
 
 > **Note:** Partition-style directory paths must end with `/`. Direct file paths (ending in `.parquet` or `.csv`) are read without listing.

--- a/src/analyst_toolkit/mcp_server/tools/session.py
+++ b/src/analyst_toolkit/mcp_server/tools/session.py
@@ -27,7 +27,7 @@ def _session_summary(session_id: str, *, include_configs: bool = False) -> dict:
         "config_count": len(config_names),
         **(
             {
-                "configs": dict(configs),
+                "configs": configs,
                 "config_bytes": sum(len(value.encode("utf-8")) for value in configs.values()),
             }
             if include_configs
@@ -85,20 +85,17 @@ async def _toolkit_manage_session(
                 "error_code": "SESSION_NOT_FOUND",
             }
         summary = _session_summary(session_id, include_configs=include_configs)
-        return with_next_actions(
-            {
-                "status": "pass",
-                "module": "manage_session",
-                "action": "inspect",
-                "session_policy": StateStore.policy(),
-                "session": summary,
-            },
-            [
+        actions = []
+        if not include_configs:
+            actions.append(
                 next_action(
                     "manage_session",
                     "Retrieve stored configs for this session.",
                     {"action": "inspect", "session_id": session_id, "include_configs": True},
-                ),
+                )
+            )
+        actions.extend(
+            [
                 next_action(
                     "manage_session",
                     "Fork this session to start a new run.",
@@ -109,7 +106,17 @@ async def _toolkit_manage_session(
                     "Inspect the run history associated with this session.",
                     {"run_id": summary["run_id"]},
                 ),
-            ],
+            ]
+        )
+        return with_next_actions(
+            {
+                "status": "pass",
+                "module": "manage_session",
+                "action": "inspect",
+                "session_policy": StateStore.policy(),
+                "session": summary,
+            },
+            actions,
         )
 
     if action == "fork":

--- a/src/analyst_toolkit/mcp_server/tools/session.py
+++ b/src/analyst_toolkit/mcp_server/tools/session.py
@@ -7,10 +7,12 @@ from analyst_toolkit.mcp_server.response_utils import next_action, with_next_act
 from analyst_toolkit.mcp_server.state import StateStore
 
 
-def _session_summary(session_id: str) -> dict:
+def _session_summary(session_id: str, *, include_configs: bool = False) -> dict:
     """Build a compact summary dict for a session."""
     metadata = StateStore.get_metadata(session_id) or {}
     expiry = StateStore.get_expiry_info(session_id)
+    configs = StateStore.get_configs(session_id)
+    config_names = sorted(configs.keys())
     return {
         "session_id": session_id,
         "run_id": StateStore.get_run_id(session_id),
@@ -21,7 +23,16 @@ def _session_summary(session_id: str) -> dict:
         "last_accessed_at": expiry["last_accessed_at"],
         "expires_at": expiry["expires_at"],
         "expires_in_sec": expiry["expires_in_sec"],
-        "stored_configs": sorted(StateStore.get_configs(session_id).keys()),
+        "stored_configs": config_names,
+        "config_count": len(config_names),
+        **(
+            {
+                "configs": dict(configs),
+                "config_bytes": sum(len(value.encode("utf-8")) for value in configs.values()),
+            }
+            if include_configs
+            else {}
+        ),
     }
 
 
@@ -30,6 +41,7 @@ async def _toolkit_manage_session(
     session_id: str | None = None,
     run_id: str | None = None,
     copy_configs: bool = True,
+    include_configs: bool = False,
 ) -> dict:
     """
     Manage session lifecycle: list, inspect, fork, rebind, or clear.
@@ -72,7 +84,7 @@ async def _toolkit_manage_session(
                 "error": f"Session '{session_id}' not found or expired.",
                 "error_code": "SESSION_NOT_FOUND",
             }
-        summary = _session_summary(session_id)
+        summary = _session_summary(session_id, include_configs=include_configs)
         return with_next_actions(
             {
                 "status": "pass",
@@ -84,8 +96,18 @@ async def _toolkit_manage_session(
             [
                 next_action(
                     "manage_session",
+                    "Retrieve stored configs for this session.",
+                    {"action": "inspect", "session_id": session_id, "include_configs": True},
+                ),
+                next_action(
+                    "manage_session",
                     "Fork this session to start a new run.",
                     {"action": "fork", "session_id": session_id},
+                ),
+                next_action(
+                    "get_run_history",
+                    "Inspect the run history associated with this session.",
+                    {"run_id": summary["run_id"]},
                 ),
             ],
         )
@@ -248,6 +270,14 @@ _INPUT_SCHEMA = {
             "type": "boolean",
             "description": "Whether to copy inferred configs when forking. Defaults to true.",
             "default": True,
+        },
+        "include_configs": {
+            "type": "boolean",
+            "description": (
+                "When action=inspect, include the stored inferred config YAML payloads in the response. "
+                "Defaults to false to keep responses compact."
+            ),
+            "default": False,
         },
     },
     "required": ["action"],

--- a/tests/test_mcp_tool_regressions_io.py
+++ b/tests/test_mcp_tool_regressions_io.py
@@ -43,10 +43,29 @@ async def test_manage_session_inspect():
     assert result["session"]["run_id"] == "inspect_run"
     assert result["session"]["row_count"] == 3
     assert "validation" in result["session"]["stored_configs"]
+    assert result["session"]["config_count"] == 1
+    assert "configs" not in result["session"]
     assert result["session_policy"]["persistence"] == "in_memory_only"
     assert result["session"]["last_accessed_at"]
     assert result["session"]["expires_at"]
     assert "next_actions" in result
+    StateStore.clear()
+
+
+@pytest.mark.asyncio
+async def test_manage_session_inspect_can_include_configs():
+    StateStore.clear()
+    df = pd.DataFrame({"x": [1, 2, 3]})
+    sid = StateStore.save(df, run_id="inspect_run")
+    config_yaml = "validation:\n  run: true\n"
+    StateStore.save_config(sid, "validation", config_yaml)
+
+    result = await session_tool._toolkit_manage_session(
+        action="inspect", session_id=sid, include_configs=True
+    )
+    assert result["status"] == "pass"
+    assert result["session"]["configs"] == {"validation": config_yaml}
+    assert result["session"]["config_bytes"] == len(config_yaml.encode("utf-8"))
     StateStore.clear()
 
 


### PR DESCRIPTION
## Summary
- add `include_configs` to `manage_session(action="inspect")` so stored inferred config YAML can be retrieved on demand
- keep default `manage_session` responses compact by returning config names/counts inline and full config payloads only when explicitly requested
- document the retrieval path in the MCP guide and add regression coverage for both compact and expanded inspect responses

## Validation
- pytest tests/test_mcp_tool_regressions_io.py tests/hardening/test_state_store.py -q
- ruff check src/ tests/
- ruff format --check src/ tests/
- python -m yamllint .github/workflows .coderabbit.yaml
- mypy src/analyst_toolkit/mcp_server
- pre-commit run --all-files

## CodeRabbit
- attempted local `coderabbit review --plain --no-color --type uncommitted`
- it reached `Reviewing` and then stopped returning findings, so this is documented as a local tooling blocker rather than a clean local review

## Workflow note
- caught a local branch-discipline slip before push and isolated the commit onto this scoped branch before opening the PR