### PR TITLE
feat: add sqlite session backend

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -99,7 +99,8 @@ export ANALYST_MCP_TEMPLATE_IO_TIMEOUT_SEC=8
 # export ANALYST_MCP_SESSION_BACKEND=memory
 
 # SQLite database path when ANALYST_MCP_SESSION_BACKEND=sqlite.
-# export ANALYST_MCP_SESSION_DB_PATH=exports/reports/state/session_store.db
+# Leave unset to use a private user-local state dir; paths under ./exports are rejected.
+# export ANALYST_MCP_SESSION_DB_PATH=$HOME/.local/state/analyst_toolkit/session_store.db
 
 # Maximum number of retained sessions before LRU eviction.
 # export ANALYST_MCP_SESSION_MAX_ENTRIES=32

--- a/.envrc.example
+++ b/.envrc.example
@@ -95,7 +95,13 @@ export ANALYST_MCP_TEMPLATE_IO_TIMEOUT_SEC=8
 # export ANALYST_MCP_ALLOW_EMPTY_CERT_RULES=false
 
 # --- MCP Session Store ---
-# Maximum number of sessions to keep in memory (LRU eviction when exceeded).
+# Session backend. Default memory keeps sessions process-local; sqlite persists them on disk.
+# export ANALYST_MCP_SESSION_BACKEND=memory
+
+# SQLite database path when ANALYST_MCP_SESSION_BACKEND=sqlite.
+# export ANALYST_MCP_SESSION_DB_PATH=exports/reports/state/session_store.db
+
+# Maximum number of retained sessions before LRU eviction.
 # export ANALYST_MCP_SESSION_MAX_ENTRIES=32
 
 # TTL (seconds) for sessions before eviction. Default 1 hour.

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Tools accept a `gcs_path` (GCS URI, local `.parquet`, or local `.csv`) and an op
 | `ANALYST_MCP_STRUCTURED_LOGS=true` | Structured request lifecycle logging |
 | `ANALYST_MCP_AUTH_TOKEN` | Bearer token auth for networked deployments |
 | `ANALYST_MCP_RESOURCE_TIMEOUT_SEC` | Tune template/resource read timeouts |
+| `ANALYST_MCP_SESSION_BACKEND` | Keep session state in memory by default or opt into durable local SQLite persistence |
 
 ### Deployment Profiles
 
@@ -197,6 +198,7 @@ Notes:
 - Default HTTP posture is localhost-first. Do not treat `docker-compose` port publishing as a reason to skip auth.
 - If you set a non-loopback host, set `ANALYST_MCP_AUTH_TOKEN` as an operator policy. Current runtime behavior warns when the token is unset; it does not hard-fail startup.
 - The artifact server is also localhost-first by default and should only be widened deliberately.
+- `ANALYST_MCP_SESSION_BACKEND=sqlite` writes durable session state to the local filesystem. Treat that as an explicit trust-boundary expansion: keep filesystem permissions narrow and prefer the default memory backend unless operators intentionally want restart-persistent sessions.
 
 > See [📡 MCP Server Guide](resource_hub/mcp_server_guide.md) for full setup, tool reference, FridAI integration, Claude Desktop wiring, and environment variable reference.
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Notes:
 - Default HTTP posture is localhost-first. Do not treat `docker-compose` port publishing as a reason to skip auth.
 - If you set a non-loopback host, set `ANALYST_MCP_AUTH_TOKEN` as an operator policy. Current runtime behavior warns when the token is unset; it does not hard-fail startup.
 - The artifact server is also localhost-first by default and should only be widened deliberately.
-- `ANALYST_MCP_SESSION_BACKEND=sqlite` writes durable session state to the local filesystem. Treat that as an explicit trust-boundary expansion: keep filesystem permissions narrow and prefer the default memory backend unless operators intentionally want restart-persistent sessions.
+- `ANALYST_MCP_SESSION_BACKEND=sqlite` writes durable session state to the local filesystem. By default the database lives in a private user-local state directory, not under `exports/`. Treat that as an explicit trust-boundary expansion: keep filesystem permissions narrow and prefer the default memory backend unless operators intentionally want restart-persistent sessions.
 
 > See [📡 MCP Server Guide](resource_hub/mcp_server_guide.md) for full setup, tool reference, FridAI integration, Claude Desktop wiring, and environment variable reference.
 

--- a/resource_hub/mcp_server_guide.md
+++ b/resource_hub/mcp_server_guide.md
@@ -122,7 +122,7 @@ Release note:
 - The toolkit is production-oriented, but production claims should only be made for the deployment profile that matches the actual tested posture.
 - Current runtime behavior is localhost-first and logs when `ANALYST_MCP_AUTH_TOKEN` is unset on non-loopback binds. It does not currently hard-fail startup in that posture.
 - Treat HTTP access to local files and local artifact paths as privileged. If you intentionally expose non-loopback HTTP, pair it with token auth and normal network controls.
-- Enabling `ANALYST_MCP_SESSION_BACKEND=sqlite` writes durable session state to the local filesystem at `ANALYST_MCP_SESSION_DB_PATH`. That is an explicit trust-boundary expansion: keep filesystem permissions narrow, prefer localhost binding, and do not persist long-lived sensitive session payloads unless the operator intentionally accepts that posture.
+- Enabling `ANALYST_MCP_SESSION_BACKEND=sqlite` writes durable session state to the local filesystem at `ANALYST_MCP_SESSION_DB_PATH` or, if unset, to a private user-local state directory. That is an explicit trust-boundary expansion: keep filesystem permissions narrow, prefer localhost binding, and do not persist long-lived sensitive session payloads unless the operator intentionally accepts that posture.
 
 ## Operability Endpoints
 
@@ -711,7 +711,7 @@ In your FridAI `remote_manager` config, point to the running server:
 | `ANALYST_MCP_STRUCTURED_LOGS` | No | `false` | Emit JSON-structured request lifecycle logs (`trace_id`, method, tool, duration) |
 | `ANALYST_MCP_JOB_STATE_PATH` | No | `exports/reports/jobs/job_state.json` | Local JSON persistence path for async job state (`get_job_status`, `list_jobs`) |
 | `ANALYST_MCP_SESSION_BACKEND` | No | `memory` | Session backend: `memory` or `sqlite` |
-| `ANALYST_MCP_SESSION_DB_PATH` | No | `exports/reports/state/session_store.db` | SQLite database path when `ANALYST_MCP_SESSION_BACKEND=sqlite` |
+| `ANALYST_MCP_SESSION_DB_PATH` | No | XDG/user-local state dir (`.../analyst_toolkit/session_store.db`) | SQLite database path when `ANALYST_MCP_SESSION_BACKEND=sqlite`; blank values fall back to the private default and paths under `./exports` are rejected |
 | `ANALYST_MCP_SESSION_TTL_SEC` | No | `3600` | Session time-to-live for both backends; SQLite cleanup is applied lazily on session reads/writes and explicit cleanup/list activity |
 | `ANALYST_MCP_SESSION_MAX_ENTRIES` | No | `32` | Maximum number of retained sessions for both backends before LRU eviction |
 | `ANALYST_MCP_ALLOW_RUN_ID_OVERRIDE` | No | `false` | Allow a requested `run_id` to differ from the session-bound run id (otherwise run id is coerced) |

--- a/resource_hub/mcp_server_guide.md
+++ b/resource_hub/mcp_server_guide.md
@@ -116,11 +116,13 @@ Recommended environment posture:
 | `ANALYST_MCP_AUTH_TOKEN` | optional | strongly recommended | strongly recommended |
 | `ANALYST_MCP_ENABLE_ARTIFACT_SERVER` | optional | optional | only if intentionally exposed |
 | `ANALYST_MCP_ARTIFACT_SERVER_HOST` | loopback | loopback unless justified | loopback unless explicitly reviewed |
+| `ANALYST_MCP_SESSION_BACKEND` | `memory` or explicit `sqlite` | prefer `memory` unless operators accept durable local state | prefer `memory` unless durable local state is explicitly reviewed |
 
 Release note:
 - The toolkit is production-oriented, but production claims should only be made for the deployment profile that matches the actual tested posture.
 - Current runtime behavior is localhost-first and logs when `ANALYST_MCP_AUTH_TOKEN` is unset on non-loopback binds. It does not currently hard-fail startup in that posture.
 - Treat HTTP access to local files and local artifact paths as privileged. If you intentionally expose non-loopback HTTP, pair it with token auth and normal network controls.
+- Enabling `ANALYST_MCP_SESSION_BACKEND=sqlite` writes durable session state to the local filesystem at `ANALYST_MCP_SESSION_DB_PATH`. That is an explicit trust-boundary expansion: keep filesystem permissions narrow, prefer localhost binding, and do not persist long-lived sensitive session payloads unless the operator intentionally accepts that posture.
 
 ## Operability Endpoints
 
@@ -226,7 +228,7 @@ When diagnosing failures, use `trace_id` from the JSON-RPC error payload and cor
 
 Every tool accepts either a `gcs_path`/file path **or** a `session_id`. When a tool runs, it saves its output to an in-memory `StateStore` and returns a `session_id`. Pass that `session_id` to the next tool to operate on the already-transformed data — no intermediate files needed.
 
-For this release, session persistence defaults to **in-memory only**, but a durable SQLite-backed session store is available via `ANALYST_MCP_SESSION_BACKEND=sqlite`. In both modes, sessions are bounded by TTL and max-entry eviction, and `manage_session` surfaces the live retention policy plus per-session expiry timestamps.
+For this release, session persistence defaults to **in-memory only**, but a durable SQLite-backed session store is available via `ANALYST_MCP_SESSION_BACKEND=sqlite`. In both modes, sessions are still bounded by `ANALYST_MCP_SESSION_TTL_SEC` and `ANALYST_MCP_SESSION_MAX_ENTRIES`: cleanup is enforced lazily on session reads, writes, and explicit `manage_session` / `cleanup` activity, so SQLite sessions can survive process restarts while still expiring or being evicted once the server touches the store again. `manage_session` surfaces the live retention policy plus per-session expiry timestamps.
 Use `manage_session(action="inspect", include_configs=true)` when you need the stored inferred config payloads; the default inspect/list responses stay compact and only include config names/counts.
 
 ```text
@@ -710,8 +712,8 @@ In your FridAI `remote_manager` config, point to the running server:
 | `ANALYST_MCP_JOB_STATE_PATH` | No | `exports/reports/jobs/job_state.json` | Local JSON persistence path for async job state (`get_job_status`, `list_jobs`) |
 | `ANALYST_MCP_SESSION_BACKEND` | No | `memory` | Session backend: `memory` or `sqlite` |
 | `ANALYST_MCP_SESSION_DB_PATH` | No | `exports/reports/state/session_store.db` | SQLite database path when `ANALYST_MCP_SESSION_BACKEND=sqlite` |
-| `ANALYST_MCP_SESSION_TTL_SEC` | No | `3600` | Session time-to-live for in-memory `StateStore` entries |
-| `ANALYST_MCP_SESSION_MAX_ENTRIES` | No | `32` | Maximum number of in-memory sessions retained before LRU eviction |
+| `ANALYST_MCP_SESSION_TTL_SEC` | No | `3600` | Session time-to-live for both backends; SQLite cleanup is applied lazily on session reads/writes and explicit cleanup/list activity |
+| `ANALYST_MCP_SESSION_MAX_ENTRIES` | No | `32` | Maximum number of retained sessions for both backends before LRU eviction |
 | `ANALYST_MCP_ALLOW_RUN_ID_OVERRIDE` | No | `false` | Allow a requested `run_id` to differ from the session-bound run id (otherwise run id is coerced) |
 | `ANALYST_MCP_RUN_HISTORY_SUMMARY_ONLY_DEFAULT` | No | `true` | Default compact ledger mode for `get_run_history` when caller omits `summary_only` |
 | `ANALYST_MCP_RUN_HISTORY_DEFAULT_LIMIT` | No | `50` | Default max ledger entries returned in compact mode when caller omits `limit` |
@@ -756,7 +758,7 @@ Boundary guards:
 - loaded DataFrames are rejected if they exceed `ANALYST_MCP_MAX_INPUT_ROWS` or `ANALYST_MCP_MAX_INPUT_MEMORY_BYTES`
 
 Session lifecycle notes:
-- `manage_session(action="list")` returns the active retention policy (`backend`, `durable`, `ttl_sec`, `max_entries`, and `db_path` for SQLite) alongside the session summaries
+- `manage_session(action="list")` returns the active retention policy (`backend`, `durable`, `ttl_sec`, `max_entries`) alongside the session summaries
 - `manage_session(action="inspect")` returns `last_accessed_at`, `expires_at`, and `expires_in_sec` for the selected session
 - `manage_session(action="inspect", include_configs=true)` retrieves the stored inferred config YAML payloads on demand
 - `manage_session(action="fork")` clones the in-memory DataFrame and optionally the stored inferred configs into a new session with its own run context

--- a/resource_hub/mcp_server_guide.md
+++ b/resource_hub/mcp_server_guide.md
@@ -226,7 +226,7 @@ When diagnosing failures, use `trace_id` from the JSON-RPC error payload and cor
 
 Every tool accepts either a `gcs_path`/file path **or** a `session_id`. When a tool runs, it saves its output to an in-memory `StateStore` and returns a `session_id`. Pass that `session_id` to the next tool to operate on the already-transformed data — no intermediate files needed.
 
-For this release, session persistence is explicitly **in-memory only**. Sessions are bounded by TTL and max-entry eviction, and `manage_session` surfaces the live retention policy plus per-session expiry timestamps.
+For this release, session persistence defaults to **in-memory only**, but a durable SQLite-backed session store is available via `ANALYST_MCP_SESSION_BACKEND=sqlite`. In both modes, sessions are bounded by TTL and max-entry eviction, and `manage_session` surfaces the live retention policy plus per-session expiry timestamps.
 Use `manage_session(action="inspect", include_configs=true)` when you need the stored inferred config payloads; the default inspect/list responses stay compact and only include config names/counts.
 
 ```text
@@ -708,6 +708,8 @@ In your FridAI `remote_manager` config, point to the running server:
 | `ANALYST_MCP_TEMPLATE_IO_TIMEOUT_SEC` | No | `8.0` | Timeout for cockpit template reads (`get_capability_catalog`, `get_golden_templates`) |
 | `ANALYST_MCP_STRUCTURED_LOGS` | No | `false` | Emit JSON-structured request lifecycle logs (`trace_id`, method, tool, duration) |
 | `ANALYST_MCP_JOB_STATE_PATH` | No | `exports/reports/jobs/job_state.json` | Local JSON persistence path for async job state (`get_job_status`, `list_jobs`) |
+| `ANALYST_MCP_SESSION_BACKEND` | No | `memory` | Session backend: `memory` or `sqlite` |
+| `ANALYST_MCP_SESSION_DB_PATH` | No | `exports/reports/state/session_store.db` | SQLite database path when `ANALYST_MCP_SESSION_BACKEND=sqlite` |
 | `ANALYST_MCP_SESSION_TTL_SEC` | No | `3600` | Session time-to-live for in-memory `StateStore` entries |
 | `ANALYST_MCP_SESSION_MAX_ENTRIES` | No | `32` | Maximum number of in-memory sessions retained before LRU eviction |
 | `ANALYST_MCP_ALLOW_RUN_ID_OVERRIDE` | No | `false` | Allow a requested `run_id` to differ from the session-bound run id (otherwise run id is coerced) |
@@ -754,7 +756,7 @@ Boundary guards:
 - loaded DataFrames are rejected if they exceed `ANALYST_MCP_MAX_INPUT_ROWS` or `ANALYST_MCP_MAX_INPUT_MEMORY_BYTES`
 
 Session lifecycle notes:
-- `manage_session(action="list")` returns the active retention policy (`backend`, `durable`, `ttl_sec`, `max_entries`) alongside the session summaries
+- `manage_session(action="list")` returns the active retention policy (`backend`, `durable`, `ttl_sec`, `max_entries`, and `db_path` for SQLite) alongside the session summaries
 - `manage_session(action="inspect")` returns `last_accessed_at`, `expires_at`, and `expires_in_sec` for the selected session
 - `manage_session(action="inspect", include_configs=true)` retrieves the stored inferred config YAML payloads on demand
 - `manage_session(action="fork")` clones the in-memory DataFrame and optionally the stored inferred configs into a new session with its own run context

--- a/src/analyst_toolkit/mcp_server/state.py
+++ b/src/analyst_toolkit/mcp_server/state.py
@@ -27,7 +27,8 @@ def _session_backend() -> str:
 
 
 def _sqlite_state_path() -> Path:
-    return Path(os.environ.get("ANALYST_MCP_SESSION_DB_PATH", SESSION_SQLITE_PATH_DEFAULT))
+    raw_path = os.environ.get("ANALYST_MCP_SESSION_DB_PATH", SESSION_SQLITE_PATH_DEFAULT).strip()
+    return Path(raw_path).expanduser().resolve(strict=False)
 
 
 class StateStore:
@@ -53,7 +54,11 @@ class StateStore:
     def _sqlite_connect_unsafe(cls) -> sqlite3.Connection:
         path = _sqlite_state_path()
         path.parent.mkdir(parents=True, exist_ok=True)
-        conn = sqlite3.connect(path)
+        conn = sqlite3.connect(path, timeout=10.0)
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            logger.debug("Could not tighten SQLite session store permissions for %s", path)
         conn.execute(
             """
             CREATE TABLE IF NOT EXISTS sessions (
@@ -99,6 +104,7 @@ class StateStore:
 
     @classmethod
     def _sqlite_df_from_row(cls, row) -> pd.DataFrame:
+        # SQLite session blobs come only from this process's own StateStore writes.
         return pickle.loads(row[5])
 
     @classmethod
@@ -134,7 +140,6 @@ class StateStore:
             "persistence": "sqlite" if backend == "sqlite" else "in_memory_only",
             "ttl_sec": SESSION_TTL_SECONDS,
             "max_entries": SESSION_MAX_ENTRIES,
-            **({"db_path": str(_sqlite_state_path())} if backend == "sqlite" else {}),
         }
 
     @classmethod
@@ -197,6 +202,7 @@ class StateStore:
                             json.dumps(configs),
                         ),
                     )
+                    conn.commit()
                     cls._sqlite_cleanup_unsafe(conn)
                 finally:
                     conn.close()
@@ -310,7 +316,16 @@ class StateStore:
     def get_expiry_info(cls, session_id: str) -> dict[str, object]:
         """Return derived expiry information for a session."""
         with cls._lock:
-            last_accessed = cls._last_accessed.get(session_id)
+            if cls._using_sqlite():
+                conn = cls._sqlite_connect_unsafe()
+                try:
+                    cls._sqlite_cleanup_unsafe(conn)
+                    row = cls._sqlite_fetch_row_unsafe(conn, session_id)
+                    last_accessed = float(row[4]) if row is not None else None
+                finally:
+                    conn.close()
+            else:
+                last_accessed = cls._last_accessed.get(session_id)
         if last_accessed is None:
             return {
                 "last_accessed_at": None,
@@ -436,6 +451,7 @@ class StateStore:
                             json.dumps(configs),
                         ),
                     )
+                    conn.commit()
                     cls._sqlite_cleanup_unsafe(conn)
                     logger.info(
                         "Forked sqlite session %s → %s (run_id: %s, copy_configs: %s)",
@@ -601,3 +617,21 @@ class StateStore:
                 cls._session_run_ids.clear()
                 cls._session_start_times.clear()
                 cls._session_configs.clear()
+
+    @classmethod
+    def backdate_session_for_test(cls, session_id: str, timestamp: float) -> None:
+        """Test helper: set last_accessed to a known timestamp for TTL assertions."""
+        with cls._lock:
+            if cls._using_sqlite():
+                conn = cls._sqlite_connect_unsafe()
+                try:
+                    conn.execute(
+                        "UPDATE sessions SET last_accessed = ? WHERE session_id = ?",
+                        (timestamp, session_id),
+                    )
+                    conn.commit()
+                finally:
+                    conn.close()
+                return
+            if session_id in cls._last_accessed:
+                cls._last_accessed[session_id] = timestamp

--- a/src/analyst_toolkit/mcp_server/state.py
+++ b/src/analyst_toolkit/mcp_server/state.py
@@ -1,13 +1,15 @@
-"""
-state.py — In-memory state management for MCP tool pipelines.
-"""
+"""state.py — Session state management for MCP tool pipelines."""
 
+import json
 import logging
 import os
+import pickle
+import sqlite3
 import threading
 import time
 import uuid
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Dict, Optional
 
 import pandas as pd
@@ -16,6 +18,16 @@ logger = logging.getLogger(__name__)
 
 SESSION_TTL_SECONDS = int(os.environ.get("ANALYST_MCP_SESSION_TTL_SEC", 3600))
 SESSION_MAX_ENTRIES = int(os.environ.get("ANALYST_MCP_SESSION_MAX_ENTRIES", 32))
+SESSION_SQLITE_PATH_DEFAULT = "exports/reports/state/session_store.db"
+
+
+def _session_backend() -> str:
+    backend = os.environ.get("ANALYST_MCP_SESSION_BACKEND", "memory").strip().lower()
+    return backend if backend in {"memory", "sqlite"} else "memory"
+
+
+def _sqlite_state_path() -> Path:
+    return Path(os.environ.get("ANALYST_MCP_SESSION_DB_PATH", SESSION_SQLITE_PATH_DEFAULT))
 
 
 class StateStore:
@@ -34,14 +46,95 @@ class StateStore:
     _session_configs: Dict[str, Dict[str, str]] = {}
 
     @classmethod
+    def _using_sqlite(cls) -> bool:
+        return _session_backend() == "sqlite"
+
+    @classmethod
+    def _sqlite_connect_unsafe(cls) -> sqlite3.Connection:
+        path = _sqlite_state_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(path)
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS sessions (
+                session_id TEXT PRIMARY KEY,
+                run_id TEXT,
+                started_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                last_accessed REAL NOT NULL,
+                dataframe_blob BLOB NOT NULL,
+                metadata_json TEXT NOT NULL,
+                configs_json TEXT NOT NULL
+            )
+            """
+        )
+        return conn
+
+    @classmethod
+    def _sqlite_fetch_row_unsafe(cls, conn: sqlite3.Connection, session_id: str):
+        cursor = conn.execute(
+            """
+            SELECT session_id, run_id, started_at, updated_at, last_accessed, dataframe_blob,
+                   metadata_json, configs_json
+            FROM sessions
+            WHERE session_id = ?
+            """,
+            (session_id,),
+        )
+        return cursor.fetchone()
+
+    @classmethod
+    def _sqlite_configs_from_row(cls, row) -> Dict[str, str]:
+        if row is None or not row[7]:
+            return {}
+        loaded = json.loads(row[7])
+        return loaded if isinstance(loaded, dict) else {}
+
+    @classmethod
+    def _sqlite_metadata_from_row(cls, row) -> dict:
+        if row is None or not row[6]:
+            return {}
+        loaded = json.loads(row[6])
+        return loaded if isinstance(loaded, dict) else {}
+
+    @classmethod
+    def _sqlite_df_from_row(cls, row) -> pd.DataFrame:
+        return pickle.loads(row[5])
+
+    @classmethod
+    def _sqlite_evict_session_unsafe(cls, conn: sqlite3.Connection, sid: str, reason: str) -> None:
+        conn.execute("DELETE FROM sessions WHERE session_id = ?", (sid,))
+        logger.info("Evicted session %s (%s)", sid, reason)
+
+    @classmethod
+    def _sqlite_cleanup_unsafe(cls, conn: sqlite3.Connection) -> None:
+        now = time.time()
+        expiry_cutoff = now - SESSION_TTL_SECONDS
+        expired_rows = conn.execute(
+            "SELECT session_id FROM sessions WHERE last_accessed < ?",
+            (expiry_cutoff,),
+        ).fetchall()
+        for (sid,) in expired_rows:
+            cls._sqlite_evict_session_unsafe(conn, sid, "TTL reached")
+
+        rows = conn.execute("SELECT session_id FROM sessions ORDER BY last_accessed ASC").fetchall()
+        overflow = len(rows) - SESSION_MAX_ENTRIES
+        if overflow > 0:
+            for (sid,) in rows[:overflow]:
+                cls._sqlite_evict_session_unsafe(conn, sid, "LRU capacity limit")
+        conn.commit()
+
+    @classmethod
     def policy(cls) -> dict[str, object]:
         """Return the current session retention policy."""
+        backend = _session_backend()
         return {
-            "backend": "memory",
-            "durable": False,
-            "persistence": "in_memory_only",
+            "backend": backend,
+            "durable": backend == "sqlite",
+            "persistence": "sqlite" if backend == "sqlite" else "in_memory_only",
             "ttl_sec": SESSION_TTL_SECONDS,
             "max_entries": SESSION_MAX_ENTRIES,
+            **({"db_path": str(_sqlite_state_path())} if backend == "sqlite" else {}),
         }
 
     @classmethod
@@ -50,6 +143,68 @@ class StateStore:
     ) -> str:
         """Save a DataFrame to the store. Generates a new session_id if not provided."""
         with cls._lock:
+            if cls._using_sqlite():
+                conn = cls._sqlite_connect_unsafe()
+                try:
+                    cls._sqlite_cleanup_unsafe(conn)
+                    existing_row = (
+                        cls._sqlite_fetch_row_unsafe(conn, session_id) if session_id else None
+                    )
+                    now_ts = pd.Timestamp.now()
+                    now_iso = now_ts.isoformat()
+                    if session_id is None:
+                        session_id = f"sess_{uuid.uuid4().hex[:8]}"
+                    started_at = (
+                        existing_row[2]
+                        if existing_row is not None
+                        else now_ts.strftime("%Y%m%d_%H%M%S")
+                    )
+                    effective_run_id = (
+                        run_id
+                        if run_id is not None
+                        else (existing_row[1] if existing_row is not None else None)
+                    )
+                    configs = cls._sqlite_configs_from_row(existing_row)
+                    metadata = {
+                        "row_count": len(df),
+                        "col_count": len(df.columns),
+                        "updated_at": now_iso,
+                    }
+                    conn.execute(
+                        """
+                        INSERT INTO sessions (
+                            session_id, run_id, started_at, updated_at, last_accessed,
+                            dataframe_blob, metadata_json, configs_json
+                        )
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                        ON CONFLICT(session_id) DO UPDATE SET
+                            run_id = excluded.run_id,
+                            started_at = excluded.started_at,
+                            updated_at = excluded.updated_at,
+                            last_accessed = excluded.last_accessed,
+                            dataframe_blob = excluded.dataframe_blob,
+                            metadata_json = excluded.metadata_json,
+                            configs_json = excluded.configs_json
+                        """,
+                        (
+                            session_id,
+                            effective_run_id,
+                            started_at,
+                            now_iso,
+                            time.time(),
+                            sqlite3.Binary(pickle.dumps(df, protocol=pickle.HIGHEST_PROTOCOL)),
+                            json.dumps(metadata),
+                            json.dumps(configs),
+                        ),
+                    )
+                    cls._sqlite_cleanup_unsafe(conn)
+                finally:
+                    conn.close()
+                logger.info(
+                    "Saved sqlite session %s (run_id: %s, shape: %s)", session_id, run_id, df.shape
+                )
+                return session_id
+
             cls._cleanup_unsafe()
 
             if session_id is None:
@@ -74,6 +229,22 @@ class StateStore:
     def get(cls, session_id: str) -> Optional[pd.DataFrame]:
         """Retrieve a DataFrame from the store by session_id."""
         with cls._lock:
+            if cls._using_sqlite():
+                conn = cls._sqlite_connect_unsafe()
+                try:
+                    cls._sqlite_cleanup_unsafe(conn)
+                    row = cls._sqlite_fetch_row_unsafe(conn, session_id)
+                    if row is None:
+                        return None
+                    now_ts = time.time()
+                    conn.execute(
+                        "UPDATE sessions SET last_accessed = ? WHERE session_id = ?",
+                        (now_ts, session_id),
+                    )
+                    conn.commit()
+                    return cls._sqlite_df_from_row(row)
+                finally:
+                    conn.close()
             if session_id in cls._sessions:
                 cls._last_accessed[session_id] = time.time()
                 return cls._sessions[session_id]
@@ -83,24 +254,56 @@ class StateStore:
     def get_run_id(cls, session_id: str) -> Optional[str]:
         """Retrieve the run_id associated with a session."""
         with cls._lock:
+            if cls._using_sqlite():
+                conn = cls._sqlite_connect_unsafe()
+                try:
+                    cls._sqlite_cleanup_unsafe(conn)
+                    row = cls._sqlite_fetch_row_unsafe(conn, session_id)
+                    return row[1] if row is not None else None
+                finally:
+                    conn.close()
             return cls._session_run_ids.get(session_id)
 
     @classmethod
     def get_session_start(cls, session_id: str) -> Optional[str]:
         """Retrieve the start time associated with a session."""
         with cls._lock:
+            if cls._using_sqlite():
+                conn = cls._sqlite_connect_unsafe()
+                try:
+                    cls._sqlite_cleanup_unsafe(conn)
+                    row = cls._sqlite_fetch_row_unsafe(conn, session_id)
+                    return row[2] if row is not None else None
+                finally:
+                    conn.close()
             return cls._session_start_times.get(session_id)
 
     @classmethod
     def get_metadata(cls, session_id: str) -> Optional[dict]:
         """Retrieve metadata for a session."""
         with cls._lock:
+            if cls._using_sqlite():
+                conn = cls._sqlite_connect_unsafe()
+                try:
+                    cls._sqlite_cleanup_unsafe(conn)
+                    row = cls._sqlite_fetch_row_unsafe(conn, session_id)
+                    return cls._sqlite_metadata_from_row(row) if row is not None else None
+                finally:
+                    conn.close()
             return cls._metadata.get(session_id)
 
     @classmethod
     def get_last_accessed(cls, session_id: str) -> Optional[float]:
         """Retrieve the last-access timestamp for a session."""
         with cls._lock:
+            if cls._using_sqlite():
+                conn = cls._sqlite_connect_unsafe()
+                try:
+                    cls._sqlite_cleanup_unsafe(conn)
+                    row = cls._sqlite_fetch_row_unsafe(conn, session_id)
+                    return float(row[4]) if row is not None else None
+                finally:
+                    conn.close()
             return cls._last_accessed.get(session_id)
 
     @classmethod
@@ -127,6 +330,27 @@ class StateStore:
     def save_config(cls, session_id: str, module: str, config_yaml: str) -> None:
         """Store an inferred config YAML string for a module in session scope."""
         with cls._lock:
+            if cls._using_sqlite():
+                conn = cls._sqlite_connect_unsafe()
+                try:
+                    cls._sqlite_cleanup_unsafe(conn)
+                    row = cls._sqlite_fetch_row_unsafe(conn, session_id)
+                    if row is None:
+                        return
+                    configs = cls._sqlite_configs_from_row(row)
+                    configs[module] = config_yaml
+                    conn.execute(
+                        "UPDATE sessions SET configs_json = ?, updated_at = ? WHERE session_id = ?",
+                        (
+                            json.dumps(configs),
+                            pd.Timestamp.now().isoformat(),
+                            session_id,
+                        ),
+                    )
+                    conn.commit()
+                    return
+                finally:
+                    conn.close()
             if session_id not in cls._session_configs:
                 cls._session_configs[session_id] = {}
             cls._session_configs[session_id][module] = config_yaml
@@ -135,12 +359,30 @@ class StateStore:
     def get_config(cls, session_id: str, module: str) -> Optional[str]:
         """Retrieve a previously stored inferred config for a module."""
         with cls._lock:
+            if cls._using_sqlite():
+                conn = cls._sqlite_connect_unsafe()
+                try:
+                    cls._sqlite_cleanup_unsafe(conn)
+                    row = cls._sqlite_fetch_row_unsafe(conn, session_id)
+                    return (
+                        cls._sqlite_configs_from_row(row).get(module) if row is not None else None
+                    )
+                finally:
+                    conn.close()
             return cls._session_configs.get(session_id, {}).get(module)
 
     @classmethod
     def get_configs(cls, session_id: str) -> Dict[str, str]:
         """Retrieve all stored inferred configs for a session."""
         with cls._lock:
+            if cls._using_sqlite():
+                conn = cls._sqlite_connect_unsafe()
+                try:
+                    cls._sqlite_cleanup_unsafe(conn)
+                    row = cls._sqlite_fetch_row_unsafe(conn, session_id)
+                    return cls._sqlite_configs_from_row(row) if row is not None else {}
+                finally:
+                    conn.close()
             return dict(cls._session_configs.get(session_id, {}))
 
     @classmethod
@@ -156,6 +398,55 @@ class StateStore:
         Returns the new session_id, or None if the source session does not exist.
         """
         with cls._lock:
+            if cls._using_sqlite():
+                conn = cls._sqlite_connect_unsafe()
+                try:
+                    cls._sqlite_cleanup_unsafe(conn)
+                    row = cls._sqlite_fetch_row_unsafe(conn, source_session_id)
+                    if row is None:
+                        return None
+                    df = cls._sqlite_df_from_row(row)
+                    new_session_id = f"sess_{uuid.uuid4().hex[:8]}"
+                    now_ts = pd.Timestamp.now()
+                    now_iso = now_ts.isoformat()
+                    configs = cls._sqlite_configs_from_row(row) if copy_configs else {}
+                    metadata = {
+                        "row_count": len(df),
+                        "col_count": len(df.columns),
+                        "updated_at": now_iso,
+                    }
+                    conn.execute(
+                        """
+                        INSERT INTO sessions (
+                            session_id, run_id, started_at, updated_at, last_accessed,
+                            dataframe_blob, metadata_json, configs_json
+                        )
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                        """,
+                        (
+                            new_session_id,
+                            run_id,
+                            now_ts.strftime("%Y%m%d_%H%M%S"),
+                            now_iso,
+                            time.time(),
+                            sqlite3.Binary(
+                                pickle.dumps(df.copy(), protocol=pickle.HIGHEST_PROTOCOL)
+                            ),
+                            json.dumps(metadata),
+                            json.dumps(configs),
+                        ),
+                    )
+                    cls._sqlite_cleanup_unsafe(conn)
+                    logger.info(
+                        "Forked sqlite session %s → %s (run_id: %s, copy_configs: %s)",
+                        source_session_id,
+                        new_session_id,
+                        run_id,
+                        copy_configs,
+                    )
+                    return new_session_id
+                finally:
+                    conn.close()
             cls._cleanup_unsafe()
             df = cls._sessions.get(source_session_id)
             if df is None:
@@ -191,6 +482,21 @@ class StateStore:
     def rebind_run_id(cls, session_id: str, run_id: str) -> bool:
         """Rebind a session to a new run_id. Returns False if session does not exist."""
         with cls._lock:
+            if cls._using_sqlite():
+                conn = cls._sqlite_connect_unsafe()
+                try:
+                    cls._sqlite_cleanup_unsafe(conn)
+                    cursor = conn.execute(
+                        "UPDATE sessions SET run_id = ?, updated_at = ? WHERE session_id = ?",
+                        (run_id, pd.Timestamp.now().isoformat(), session_id),
+                    )
+                    conn.commit()
+                    ok = cursor.rowcount > 0
+                finally:
+                    conn.close()
+                if ok:
+                    logger.info("Rebound sqlite session %s to run_id %s", session_id, run_id)
+                return ok
             cls._cleanup_unsafe()
             if session_id not in cls._sessions:
                 return False
@@ -202,6 +508,19 @@ class StateStore:
     def list_sessions(cls) -> Dict[str, dict]:
         """List available sessions and their metadata."""
         with cls._lock:
+            if cls._using_sqlite():
+                conn = cls._sqlite_connect_unsafe()
+                try:
+                    cls._sqlite_cleanup_unsafe(conn)
+                    rows = conn.execute(
+                        "SELECT session_id, metadata_json FROM sessions ORDER BY last_accessed DESC"
+                    ).fetchall()
+                    return {
+                        sid: (json.loads(metadata_json) if metadata_json else {})
+                        for sid, metadata_json in rows
+                    }
+                finally:
+                    conn.close()
             cls._cleanup_unsafe()
             return {k: cls._metadata.get(k, {}) for k in cls._sessions.keys()}
 
@@ -237,12 +556,37 @@ class StateStore:
     def cleanup(cls):
         """Remove sessions that have exceeded the TTL."""
         with cls._lock:
+            if cls._using_sqlite():
+                conn = cls._sqlite_connect_unsafe()
+                try:
+                    cls._sqlite_cleanup_unsafe(conn)
+                finally:
+                    conn.close()
+                return
             cls._cleanup_unsafe()
 
     @classmethod
     def clear(cls, session_id: Optional[str] = None):
         """Clear one or all sessions."""
         with cls._lock:
+            if cls._using_sqlite():
+                conn = cls._sqlite_connect_unsafe()
+                try:
+                    if session_id:
+                        conn.execute("DELETE FROM sessions WHERE session_id = ?", (session_id,))
+                    else:
+                        conn.execute("DELETE FROM sessions")
+                    conn.commit()
+                finally:
+                    conn.close()
+                # Also clear in-memory state so backend switches in tests stay deterministic.
+                cls._sessions.clear()
+                cls._metadata.clear()
+                cls._last_accessed.clear()
+                cls._session_run_ids.clear()
+                cls._session_start_times.clear()
+                cls._session_configs.clear()
+                return
             if session_id:
                 cls._sessions.pop(session_id, None)
                 cls._metadata.pop(session_id, None)

--- a/src/analyst_toolkit/mcp_server/state.py
+++ b/src/analyst_toolkit/mcp_server/state.py
@@ -18,7 +18,14 @@ logger = logging.getLogger(__name__)
 
 SESSION_TTL_SECONDS = int(os.environ.get("ANALYST_MCP_SESSION_TTL_SEC", 3600))
 SESSION_MAX_ENTRIES = int(os.environ.get("ANALYST_MCP_SESSION_MAX_ENTRIES", 32))
-SESSION_SQLITE_PATH_DEFAULT = "exports/reports/state/session_store.db"
+SESSION_SQLITE_PATH_DEFAULT = "analyst_toolkit/session_store.db"
+
+
+def _session_state_home() -> Path:
+    xdg_state_home = os.environ.get("XDG_STATE_HOME", "").strip()
+    if xdg_state_home:
+        return Path(xdg_state_home).expanduser().resolve(strict=False)
+    return (Path.home() / ".local" / "state").resolve(strict=False)
 
 
 def _session_backend() -> str:
@@ -27,8 +34,20 @@ def _session_backend() -> str:
 
 
 def _sqlite_state_path() -> Path:
-    raw_path = os.environ.get("ANALYST_MCP_SESSION_DB_PATH", SESSION_SQLITE_PATH_DEFAULT).strip()
-    return Path(raw_path).expanduser().resolve(strict=False)
+    raw_path = os.environ.get("ANALYST_MCP_SESSION_DB_PATH", "").strip()
+    if raw_path:
+        path = Path(raw_path).expanduser().resolve(strict=False)
+    else:
+        path = (_session_state_home() / SESSION_SQLITE_PATH_DEFAULT).resolve(strict=False)
+
+    exports_root = (Path.cwd() / "exports").resolve(strict=False)
+    path_parents = {path, *path.parents}
+    if exports_root in path_parents:
+        raise ValueError(
+            "SQLite session persistence cannot use a path under ./exports; "
+            "choose a private state path outside public artifact roots."
+        )
+    return path
 
 
 class StateStore:

--- a/tests/hardening/test_state_store.py
+++ b/tests/hardening/test_state_store.py
@@ -1,5 +1,6 @@
 import threading
 import time
+from pathlib import Path
 
 from analyst_toolkit.mcp_server.state import StateStore
 
@@ -114,3 +115,71 @@ def test_non_expired_session_survives_cleanup(sample_df, monkeypatch):
     sid = StateStore.save(sample_df)
     StateStore.cleanup()
     assert StateStore.get(sid) is not None
+
+
+def test_sqlite_backend_save_and_get(sample_df, tmp_path, monkeypatch):
+    monkeypatch.setenv("ANALYST_MCP_SESSION_BACKEND", "sqlite")
+    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", str(tmp_path / "session_store.db"))
+
+    sid = StateStore.save(sample_df, run_id="sqlite_run")
+
+    assert StateStore.policy()["backend"] == "sqlite"
+    assert StateStore.policy()["durable"] is True
+    assert Path(StateStore.policy()["db_path"]).name == "session_store.db"
+    result = StateStore.get(sid)
+
+    import pandas as pd
+
+    pd.testing.assert_frame_equal(result, sample_df)
+    assert StateStore.get_run_id(sid) == "sqlite_run"
+
+
+def test_sqlite_backend_persists_configs_and_fork(sample_df, tmp_path, monkeypatch):
+    monkeypatch.setenv("ANALYST_MCP_SESSION_BACKEND", "sqlite")
+    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", str(tmp_path / "session_store.db"))
+
+    sid = StateStore.save(sample_df, run_id="sqlite_run")
+    StateStore.save_config(sid, "validation", "validation:\n  run: true\n")
+
+    forked = StateStore.fork(sid, run_id="forked_sqlite_run", copy_configs=True)
+
+    assert forked is not None
+    assert StateStore.get_run_id(forked) == "forked_sqlite_run"
+    assert StateStore.get_config(forked, "validation") is not None
+
+
+def test_sqlite_backend_rebind_and_clear(sample_df, tmp_path, monkeypatch):
+    monkeypatch.setenv("ANALYST_MCP_SESSION_BACKEND", "sqlite")
+    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", str(tmp_path / "session_store.db"))
+
+    sid = StateStore.save(sample_df, run_id="sqlite_run")
+
+    assert StateStore.rebind_run_id(sid, "sqlite_rebound") is True
+    assert StateStore.get_run_id(sid) == "sqlite_rebound"
+
+    StateStore.clear(sid)
+    assert StateStore.get(sid) is None
+
+
+def test_sqlite_backend_ttl_cleanup(sample_df, tmp_path, monkeypatch):
+    import analyst_toolkit.mcp_server.state as state_module
+
+    monkeypatch.setenv("ANALYST_MCP_SESSION_BACKEND", "sqlite")
+    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", str(tmp_path / "session_store.db"))
+    monkeypatch.setattr(state_module, "SESSION_TTL_SECONDS", 1)
+
+    sid = StateStore.save(sample_df, run_id="sqlite_run")
+
+    with StateStore._lock:
+        conn = StateStore._sqlite_connect_unsafe()
+        try:
+            conn.execute(
+                "UPDATE sessions SET last_accessed = ? WHERE session_id = ?",
+                (time.time() - 2, sid),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    StateStore.cleanup()
+    assert StateStore.get(sid) is None

--- a/tests/hardening/test_state_store.py
+++ b/tests/hardening/test_state_store.py
@@ -1,6 +1,5 @@
 import threading
 import time
-from pathlib import Path
 
 from analyst_toolkit.mcp_server.state import StateStore
 
@@ -98,8 +97,7 @@ def test_ttl_eviction_removes_expired_sessions(sample_df, monkeypatch):
     sid = StateStore.save(sample_df)
     assert StateStore.get(sid) is not None
 
-    with StateStore._lock:
-        StateStore._last_accessed[sid] = time.time() - 2
+    StateStore.backdate_session_for_test(sid, time.time() - 2)
 
     StateStore.save(sample_df)
 
@@ -125,7 +123,6 @@ def test_sqlite_backend_save_and_get(sample_df, tmp_path, monkeypatch):
 
     assert StateStore.policy()["backend"] == "sqlite"
     assert StateStore.policy()["durable"] is True
-    assert Path(StateStore.policy()["db_path"]).name == "session_store.db"
     result = StateStore.get(sid)
 
     import pandas as pd
@@ -145,7 +142,7 @@ def test_sqlite_backend_persists_configs_and_fork(sample_df, tmp_path, monkeypat
 
     assert forked is not None
     assert StateStore.get_run_id(forked) == "forked_sqlite_run"
-    assert StateStore.get_config(forked, "validation") is not None
+    assert StateStore.get_config(forked, "validation") == StateStore.get_config(sid, "validation")
 
 
 def test_sqlite_backend_rebind_and_clear(sample_df, tmp_path, monkeypatch):
@@ -169,17 +166,61 @@ def test_sqlite_backend_ttl_cleanup(sample_df, tmp_path, monkeypatch):
     monkeypatch.setattr(state_module, "SESSION_TTL_SECONDS", 1)
 
     sid = StateStore.save(sample_df, run_id="sqlite_run")
-
-    with StateStore._lock:
-        conn = StateStore._sqlite_connect_unsafe()
-        try:
-            conn.execute(
-                "UPDATE sessions SET last_accessed = ? WHERE session_id = ?",
-                (time.time() - 2, sid),
-            )
-            conn.commit()
-        finally:
-            conn.close()
+    StateStore.backdate_session_for_test(sid, time.time() - 2)
 
     StateStore.cleanup()
     assert StateStore.get(sid) is None
+
+
+def test_sqlite_concurrent_saves_are_thread_safe(tmp_path, monkeypatch):
+    monkeypatch.setenv("ANALYST_MCP_SESSION_BACKEND", "sqlite")
+    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", str(tmp_path / "session_store.db"))
+    ids = []
+    errors = []
+    lock = threading.Lock()
+
+    def worker(i):
+        try:
+            import pandas as pd
+
+            df = pd.DataFrame({"col": [i]})
+            sid = StateStore.save(df, run_id=f"run_{i}")
+            with lock:
+                ids.append(sid)
+        except Exception as e:
+            with lock:
+                errors.append(e)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(20)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors, f"Errors during concurrent sqlite saves: {errors}"
+    assert len(ids) == 20
+    for sid in ids:
+        assert StateStore.get(sid) is not None
+
+
+def test_sqlite_concurrent_reads_are_safe(sample_df, tmp_path, monkeypatch):
+    monkeypatch.setenv("ANALYST_MCP_SESSION_BACKEND", "sqlite")
+    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", str(tmp_path / "session_store.db"))
+    sid = StateStore.save(sample_df, run_id="sqlite_run")
+    errors = []
+    lock = threading.Lock()
+
+    def reader():
+        try:
+            StateStore.get(sid)
+        except Exception as e:
+            with lock:
+                errors.append(e)
+
+    threads = [threading.Thread(target=reader) for _ in range(20)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not errors

--- a/tests/hardening/test_state_store.py
+++ b/tests/hardening/test_state_store.py
@@ -1,6 +1,8 @@
 import threading
 import time
 
+import pytest
+
 from analyst_toolkit.mcp_server.state import StateStore
 
 
@@ -224,3 +226,34 @@ def test_sqlite_concurrent_reads_are_safe(sample_df, tmp_path, monkeypatch):
         thread.join()
 
     assert not errors
+
+
+def test_sqlite_state_path_defaults_to_private_state_dir(monkeypatch, tmp_path):
+    import analyst_toolkit.mcp_server.state as state_module
+
+    monkeypatch.delenv("ANALYST_MCP_SESSION_DB_PATH", raising=False)
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state_home"))
+
+    path = state_module._sqlite_state_path()
+
+    assert path == (tmp_path / "state_home" / "analyst_toolkit" / "session_store.db").resolve()
+
+
+def test_sqlite_state_path_treats_blank_env_as_unset(monkeypatch, tmp_path):
+    import analyst_toolkit.mcp_server.state as state_module
+
+    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", "   ")
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state_home"))
+
+    path = state_module._sqlite_state_path()
+
+    assert path == (tmp_path / "state_home" / "analyst_toolkit" / "session_store.db").resolve()
+
+
+def test_sqlite_state_path_rejects_exports_root(monkeypatch):
+    import analyst_toolkit.mcp_server.state as state_module
+
+    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", "exports/reports/state/session_store.db")
+
+    with pytest.raises(ValueError, match="cannot use a path under ./exports"):
+        state_module._sqlite_state_path()

--- a/tests/test_mcp_tool_regressions_io.py
+++ b/tests/test_mcp_tool_regressions_io.py
@@ -31,6 +31,22 @@ async def test_manage_session_list():
 
 
 @pytest.mark.asyncio
+async def test_manage_session_list_reports_sqlite_policy(monkeypatch, tmp_path):
+    monkeypatch.setenv("ANALYST_MCP_SESSION_BACKEND", "sqlite")
+    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", str(tmp_path / "session_store.db"))
+    StateStore.clear()
+    df = pd.DataFrame({"a": [1, 2]})
+    StateStore.save(df, run_id="sqlite_run")
+
+    result = await session_tool._toolkit_manage_session(action="list")
+    assert result["status"] == "pass"
+    assert result["session_policy"]["backend"] == "sqlite"
+    assert result["session_policy"]["durable"] is True
+    assert result["session_policy"]["db_path"].endswith("session_store.db")
+    StateStore.clear()
+
+
+@pytest.mark.asyncio
 async def test_manage_session_inspect():
     StateStore.clear()
     df = pd.DataFrame({"x": [1, 2, 3]})

--- a/tests/test_mcp_tool_regressions_io.py
+++ b/tests/test_mcp_tool_regressions_io.py
@@ -42,7 +42,6 @@ async def test_manage_session_list_reports_sqlite_policy(monkeypatch, tmp_path):
     assert result["status"] == "pass"
     assert result["session_policy"]["backend"] == "sqlite"
     assert result["session_policy"]["durable"] is True
-    assert result["session_policy"]["db_path"].endswith("session_store.db")
     StateStore.clear()
 
 
@@ -82,6 +81,22 @@ async def test_manage_session_inspect_can_include_configs():
     assert result["status"] == "pass"
     assert result["session"]["configs"] == {"validation": config_yaml}
     assert result["session"]["config_bytes"] == len(config_yaml.encode("utf-8"))
+    StateStore.clear()
+
+
+@pytest.mark.asyncio
+async def test_manage_session_inspect_reports_sqlite_expiry(monkeypatch, tmp_path):
+    monkeypatch.setenv("ANALYST_MCP_SESSION_BACKEND", "sqlite")
+    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", str(tmp_path / "session_store.db"))
+    StateStore.clear()
+    sid = StateStore.save(pd.DataFrame({"x": [1, 2, 3]}), run_id="inspect_run")
+
+    result = await session_tool._toolkit_manage_session(action="inspect", session_id=sid)
+    assert result["status"] == "pass"
+    assert result["session_policy"]["backend"] == "sqlite"
+    assert result["session"]["last_accessed_at"]
+    assert result["session"]["expires_at"]
+    assert result["session"]["expires_in_sec"] is not None
     StateStore.clear()
 
 


### PR DESCRIPTION
## Summary
- add an opt-in SQLite-backed `StateStore` backend behind `ANALYST_MCP_SESSION_BACKEND=sqlite`
- persist session DataFrames, metadata, run bindings, inferred configs, TTL cleanup, and LRU-style capacity eviction in SQLite while keeping the existing caller API stable
- surface SQLite configuration in session policy and document `ANALYST_MCP_SESSION_BACKEND` / `ANALYST_MCP_SESSION_DB_PATH` in the MCP guide

## Validation
- pytest tests/hardening/test_state_store.py tests/test_mcp_tool_regressions_io.py -q
- ruff check src/ tests/
- ruff format --check src/ tests/
- python -m yamllint .github/workflows .coderabbit.yaml
- mypy src/analyst_toolkit/mcp_server
- pre-commit run --all-files

## CodeRabbit
- attempted local `coderabbit review --plain --no-color --type uncommitted`
- it reached `Reviewing` and then stopped returning findings, so this is documented as a local tooling blocker rather than a clean local review