### PR TITLE
refactor: add shared pipeline config validation helpers

### DIFF
--- a/src/analyst_toolkit/m00_utils/pipeline_config_validation.py
+++ b/src/analyst_toolkit/m00_utils/pipeline_config_validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
@@ -72,20 +73,27 @@ def validate_runner_module_config(
     coerce_key = "outlier_detection" if runner_module_name == "outlier_detection" else module_name
     coerced = coerce_config(config, coerce_key)
     normalized = normalize_module_config(module_name, coerced)
+    model = CONFIG_MODELS.get(module_name)
+    if model is None:
+        raise PipelineConfigValidationError(
+            f"No shared config model is registered for runner module '{runner_module_name}' "
+            f"(resolved module '{module_name}')."
+        )
 
     try:
-        CONFIG_MODELS[module_name].model_validate(normalized)
+        model.model_validate(normalized)
     except ValidationError as exc:
         raise PipelineConfigValidationError(
             f"Invalid config for runner module '{runner_module_name}': {exc}"
         ) from exc
 
     effective = normalized
+    canonical = deepcopy(effective)
 
     return {
         "runner_module": runner_module_name,
         "module_name": module_name,
         "root_key": root_key,
         "effective_config": effective,
-        "canonical_config": {root_key: effective},
+        "canonical_config": {root_key: canonical},
     }

--- a/src/analyst_toolkit/m00_utils/pipeline_config_validation.py
+++ b/src/analyst_toolkit/m00_utils/pipeline_config_validation.py
@@ -1,0 +1,91 @@
+"""Shared pipeline/notebook/CLI config validation helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from analyst_toolkit.mcp_server.config_models import CONFIG_MODELS
+from analyst_toolkit.mcp_server.config_normalizers import normalize_module_config
+from analyst_toolkit.mcp_server.io import coerce_config
+
+
+class PipelineConfigValidationError(ValueError):
+    """Raised when runner-facing pipeline config validation fails."""
+
+
+class PipelineModuleSelection(BaseModel):
+    """Master runner module toggle + config path."""
+
+    model_config = ConfigDict(extra="allow")
+
+    run: bool = False
+    config_path: str
+
+
+class PipelineRunnerConfig(BaseModel):
+    """Validated master runner config for the CLI/notebook pipeline entrypoint."""
+
+    model_config = ConfigDict(extra="allow")
+
+    run_id: str = "default_run"
+    notebook: bool = False
+    pipeline_entry_path: str
+    modules: dict[str, PipelineModuleSelection] = Field(default_factory=dict)
+
+
+_RUNNER_MODULE_SPECS: dict[str, dict[str, str]] = {
+    "diagnostics": {"module_name": "diagnostics", "root_key": "diagnostics"},
+    "validation": {"module_name": "validation", "root_key": "validation"},
+    "validation_gatekeeper": {"module_name": "validation", "root_key": "validation"},
+    "normalization": {"module_name": "normalization", "root_key": "normalization"},
+    "duplicates": {"module_name": "duplicates", "root_key": "duplicates"},
+    "outlier_detection": {"module_name": "outliers", "root_key": "outlier_detection"},
+    "imputation": {"module_name": "imputation", "root_key": "imputation"},
+    "final_audit": {"module_name": "final_audit", "root_key": "final_audit"},
+}
+
+
+def validate_pipeline_runner_config(config: dict[str, Any]) -> dict[str, Any]:
+    """Validate and normalize the master pipeline runner config shape."""
+
+    try:
+        return PipelineRunnerConfig.model_validate(config).model_dump()
+    except ValidationError as exc:
+        raise PipelineConfigValidationError(f"Invalid master pipeline config: {exc}") from exc
+
+
+def validate_runner_module_config(
+    runner_module_name: str, config: dict[str, Any]
+) -> dict[str, Any]:
+    """Validate a runner-facing module config against the shared MCP models."""
+
+    spec = _RUNNER_MODULE_SPECS.get(runner_module_name)
+    if spec is None:
+        raise PipelineConfigValidationError(
+            f"Unsupported runner module for shared validation: {runner_module_name}"
+        )
+
+    module_name = spec["module_name"]
+    root_key = spec["root_key"]
+    coerce_key = "outlier_detection" if runner_module_name == "outlier_detection" else module_name
+    coerced = coerce_config(config, coerce_key)
+    normalized = normalize_module_config(module_name, coerced)
+
+    try:
+        CONFIG_MODELS[module_name].model_validate(normalized)
+    except ValidationError as exc:
+        raise PipelineConfigValidationError(
+            f"Invalid config for runner module '{runner_module_name}': {exc}"
+        ) from exc
+
+    effective = normalized
+
+    return {
+        "runner_module": runner_module_name,
+        "module_name": module_name,
+        "root_key": root_key,
+        "effective_config": effective,
+        "canonical_config": {root_key: effective},
+    }

--- a/tests/test_pipeline_config_validation.py
+++ b/tests/test_pipeline_config_validation.py
@@ -1,0 +1,58 @@
+import pytest
+import yaml
+
+from analyst_toolkit.m00_utils.pipeline_config_validation import (
+    PipelineConfigValidationError,
+    validate_pipeline_runner_config,
+    validate_runner_module_config,
+)
+
+
+def _load_yaml(path: str) -> dict:
+    with open(path, "r", encoding="utf-8") as handle:
+        loaded = yaml.safe_load(handle)
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def test_validate_pipeline_runner_config_accepts_master_template():
+    config = _load_yaml("config/run_toolkit_config.yaml")
+
+    validated = validate_pipeline_runner_config(config)
+
+    assert validated["run_id"] == "CLI_2_QA"
+    assert validated["pipeline_entry_path"] == "data/raw/synthetic_penguins_v3.5.csv"
+    assert validated["modules"]["diagnostics"]["config_path"] == "config/diag_config_template.yaml"
+
+
+def test_validate_pipeline_runner_config_requires_pipeline_entry_path():
+    with pytest.raises(PipelineConfigValidationError, match="pipeline_entry_path"):
+        validate_pipeline_runner_config({"run_id": "x", "modules": {}})
+
+
+def test_validate_runner_module_config_normalizes_validation_gatekeeper_template():
+    config = _load_yaml("config/certification_config_template.yaml")
+
+    validated = validate_runner_module_config("validation_gatekeeper", config)
+
+    assert validated["module_name"] == "validation"
+    assert validated["root_key"] == "validation"
+    assert validated["effective_config"]["schema_validation"]["fail_on_error"] is True
+    assert "expected_columns" in validated["effective_config"]["schema_validation"]["rules"]
+
+
+def test_validate_runner_module_config_normalizes_outlier_detection_template():
+    config = _load_yaml("config/outlier_config_template.yaml")
+
+    validated = validate_runner_module_config("outlier_detection", config)
+
+    assert validated["module_name"] == "outliers"
+    assert validated["root_key"] == "outlier_detection"
+    assert validated["effective_config"]["run"] is True
+    assert validated["effective_config"]["detection_specs"]["__default__"]["method"] == "iqr"
+    assert "outlier_detection" in validated["canonical_config"]
+
+
+def test_validate_runner_module_config_rejects_unsupported_runner_module():
+    with pytest.raises(PipelineConfigValidationError, match="Unsupported runner module"):
+        validate_runner_module_config("outlier_handling", {})

--- a/tests/test_pipeline_config_validation.py
+++ b/tests/test_pipeline_config_validation.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 import yaml
 
@@ -9,7 +11,8 @@ from analyst_toolkit.m00_utils.pipeline_config_validation import (
 
 
 def _load_yaml(path: str) -> dict:
-    with open(path, "r", encoding="utf-8") as handle:
+    resolved = (Path(__file__).resolve().parent.parent / path).resolve()
+    with resolved.open("r", encoding="utf-8") as handle:
         loaded = yaml.safe_load(handle)
     assert isinstance(loaded, dict)
     return loaded


### PR DESCRIPTION
## Summary
- add a shared pipeline/notebook/CLI validation helper for master runner configs and runner-facing module configs
- reuse the existing MCP config coercion and normalization path instead of inventing a second config-shaping system
- add focused regression coverage for master runner validation, validation-gatekeeper normalization, and outlier-detection normalization

## Validation
- pytest tests/test_pipeline_config_validation.py tests/test_template_contracts.py tests/test_golden_template_execution.py -q
- ruff check src/ tests/
- ruff format --check src/ tests/
- python -m yamllint .github/workflows .coderabbit.yaml
- mypy src/analyst_toolkit/mcp_server
- pre-commit run --all-files

## CodeRabbit
- attempted local `coderabbit review --plain --no-color --type uncommitted`
- it reached `Reviewing` and then stopped returning findings, so this is documented as a local tooling blocker rather than a clean local review