### PR TITLE
fix: fail early on invalid pipeline configs

### DIFF
--- a/src/analyst_toolkit/m00_utils/pipeline_config_validation.py
+++ b/src/analyst_toolkit/m00_utils/pipeline_config_validation.py
@@ -70,6 +70,10 @@ def validate_runner_module_config(
 
     module_name = spec["module_name"]
     root_key = spec["root_key"]
+    if not isinstance(config, dict):
+        raise PipelineConfigValidationError(
+            f"Invalid config for runner module '{runner_module_name}': expected a mapping."
+        )
     coerce_key = "outlier_detection" if runner_module_name == "outlier_detection" else module_name
     coerced = coerce_config(config, coerce_key)
     normalized = normalize_module_config(module_name, coerced)

--- a/src/analyst_toolkit/m00_utils/pipeline_config_validation.py
+++ b/src/analyst_toolkit/m00_utils/pipeline_config_validation.py
@@ -30,6 +30,8 @@ class PipelineRunnerConfig(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
+    # Historical runner behavior allows omitted run_id, but "default_run" is not
+    # appropriate for deterministic reruns because artifact/output names will collide.
     run_id: str = "default_run"
     notebook: bool = False
     pipeline_entry_path: str
@@ -42,7 +44,13 @@ _RUNNER_MODULE_SPECS: dict[str, dict[str, str]] = {
     "validation_gatekeeper": {"module_name": "validation", "root_key": "validation"},
     "normalization": {"module_name": "normalization", "root_key": "normalization"},
     "duplicates": {"module_name": "duplicates", "root_key": "duplicates"},
-    "outlier_detection": {"module_name": "outliers", "root_key": "outlier_detection"},
+    # Historical naming divergence: the public runner key is "outlier_detection"
+    # while the shared MCP/config model name is "outliers".
+    "outlier_detection": {
+        "module_name": "outliers",
+        "root_key": "outlier_detection",
+        "coerce_key": "outlier_detection",
+    },
     "imputation": {"module_name": "imputation", "root_key": "imputation"},
     "final_audit": {"module_name": "final_audit", "root_key": "final_audit"},
 }
@@ -74,7 +82,9 @@ def validate_runner_module_config(
         raise PipelineConfigValidationError(
             f"Invalid config for runner module '{runner_module_name}': expected a mapping."
         )
-    coerce_key = "outlier_detection" if runner_module_name == "outlier_detection" else module_name
+    # "outlier_detection" keeps its historical runner key for coercion even though
+    # the shared model/normalizer is registered under "outliers".
+    coerce_key = spec.get("coerce_key", module_name)
     coerced = coerce_config(config, coerce_key)
     normalized = normalize_module_config(module_name, coerced)
     model = CONFIG_MODELS.get(module_name)
@@ -92,7 +102,7 @@ def validate_runner_module_config(
         ) from exc
 
     effective = normalized
-    canonical = deepcopy(effective)
+    canonical = deepcopy(normalized)
 
     return {
         "runner_module": runner_module_name,

--- a/src/analyst_toolkit/run_toolkit_pipeline.py
+++ b/src/analyst_toolkit/run_toolkit_pipeline.py
@@ -33,6 +33,10 @@ import pandas as pd
 
 from analyst_toolkit.m00_utils.config_loader import load_config
 from analyst_toolkit.m00_utils.load_data import load_csv
+from analyst_toolkit.m00_utils.pipeline_config_validation import (
+    validate_pipeline_runner_config,
+    validate_runner_module_config,
+)
 
 # Import all module runners
 from analyst_toolkit.m01_diagnostics.run_diag_pipeline import run_diag_pipeline
@@ -49,21 +53,23 @@ from analyst_toolkit.m10_final_audit.final_audit_pipeline import run_final_audit
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 
+def _load_validated_module_config(runner_module_name: str, config_path: str) -> dict:
+    raw_config = load_config(config_path)
+    validated = validate_runner_module_config(runner_module_name, raw_config)
+    return validated["canonical_config"]
+
+
 def run_full_pipeline(config_path: str):
     """
     Executes the full data processing pipeline by chaining modules together.
     """
     logging.info(f"--- Loading Master Orchestration Config from {config_path} ---")
-    master_config = load_config(config_path)
+    master_config = validate_pipeline_runner_config(load_config(config_path))
 
     run_id = master_config.get("run_id", "default_run")
     notebook_mode = master_config.get("notebook", False)
     modules_to_run = master_config.get("modules", {})
-
-    # --- ROBUST INITIAL DATA LOAD ---
     entry_path = master_config.get("pipeline_entry_path")
-    if not entry_path:
-        raise ValueError("Master config is missing 'pipeline_entry_path'. Cannot start pipeline.")
 
     logging.info(f"--- 🚚 Loading initial data from {entry_path} ---")
     df: pd.DataFrame = load_csv(entry_path)
@@ -77,7 +83,7 @@ def run_full_pipeline(config_path: str):
     module_info = modules_to_run.get("diagnostics")
     if module_info and module_info.get("run"):
         logging.info("--- 🚀 Starting Module: DIAGNOSTICS ---")
-        module_config = load_config(module_info["config_path"])
+        module_config = _load_validated_module_config("diagnostics", module_info["config_path"])
         # The runner function does not modify the df, so no reassignment needed
         run_diag_pipeline(config=module_config, df=df, notebook=notebook_mode, run_id=run_id)
         logging.info("--- ✅ Finished Module: DIAGNOSTICS ---")
@@ -86,7 +92,7 @@ def run_full_pipeline(config_path: str):
     module_info = modules_to_run.get("validation")
     if module_info and module_info.get("run"):
         logging.info("--- 🚀 Starting Module: VALIDATION ---")
-        module_config = load_config(module_info["config_path"])
+        module_config = _load_validated_module_config("validation", module_info["config_path"])
         df = run_validation_pipeline(
             config=module_config, df=df, notebook=notebook_mode, run_id=run_id
         )
@@ -96,7 +102,7 @@ def run_full_pipeline(config_path: str):
     module_info = modules_to_run.get("normalization")
     if module_info and module_info.get("run"):
         logging.info("--- 🚀 Starting Module: NORMALIZATION ---")
-        module_config = load_config(module_info["config_path"])
+        module_config = _load_validated_module_config("normalization", module_info["config_path"])
         df = run_normalization_pipeline(
             config=module_config, df=df, notebook=notebook_mode, run_id=run_id
         )
@@ -106,7 +112,9 @@ def run_full_pipeline(config_path: str):
     module_info = modules_to_run.get("validation_gatekeeper")
     if module_info and module_info.get("run"):
         logging.info("--- 🚀 Starting Module: VALIDATION_GATEKEEPER ---")
-        module_config = load_config(module_info["config_path"])
+        module_config = _load_validated_module_config(
+            "validation_gatekeeper", module_info["config_path"]
+        )
         df = run_validation_pipeline(
             config=module_config, df=df, notebook=notebook_mode, run_id=run_id
         )
@@ -116,7 +124,7 @@ def run_full_pipeline(config_path: str):
     module_info = modules_to_run.get("duplicates")
     if module_info and module_info.get("run"):
         logging.info("--- 🚀 Starting Module: DUPLICATES ---")
-        module_config = load_config(module_info["config_path"])
+        module_config = _load_validated_module_config("duplicates", module_info["config_path"])
         df = run_duplicates_pipeline(
             config=module_config, df=df, notebook=notebook_mode, run_id=run_id
         )
@@ -126,7 +134,9 @@ def run_full_pipeline(config_path: str):
     module_info = modules_to_run.get("outlier_detection")
     if module_info and module_info.get("run"):
         logging.info("--- 🚀 Starting Module: OUTLIER_DETECTION ---")
-        module_config = load_config(module_info["config_path"])
+        module_config = _load_validated_module_config(
+            "outlier_detection", module_info["config_path"]
+        )
         df, detection_results = run_outlier_detection_pipeline(
             config=module_config, df=df, notebook=notebook_mode, run_id=run_id
         )
@@ -154,7 +164,7 @@ def run_full_pipeline(config_path: str):
     module_info = modules_to_run.get("imputation")
     if module_info and module_info.get("run"):
         logging.info("--- 🚀 Starting Module: IMPUTATION ---")
-        module_config = load_config(module_info["config_path"])
+        module_config = _load_validated_module_config("imputation", module_info["config_path"])
         df = run_imputation_pipeline(
             config=module_config, df=df, notebook=notebook_mode, run_id=run_id
         )
@@ -164,7 +174,7 @@ def run_full_pipeline(config_path: str):
     module_info = modules_to_run.get("final_audit")
     if module_info and module_info.get("run"):
         logging.info("--- 🚀 Starting Module: FINAL_AUDIT ---")
-        module_config = load_config(module_info["config_path"])
+        module_config = _load_validated_module_config("final_audit", module_info["config_path"])
         df = run_final_audit_pipeline(
             config=module_config, df=df, run_id=run_id, notebook=notebook_mode
         )

--- a/tests/test_pipeline_config_validation.py
+++ b/tests/test_pipeline_config_validation.py
@@ -11,7 +11,7 @@ from analyst_toolkit.m00_utils.pipeline_config_validation import (
 
 
 def _load_yaml(path: str) -> dict:
-    resolved = (Path(__file__).resolve().parent.parent / path).resolve()
+    resolved = Path(__file__).resolve().parent.parent / path
     with resolved.open("r", encoding="utf-8") as handle:
         loaded = yaml.safe_load(handle)
     assert isinstance(loaded, dict)

--- a/tests/test_run_toolkit_pipeline.py
+++ b/tests/test_run_toolkit_pipeline.py
@@ -5,6 +5,18 @@ import analyst_toolkit.run_toolkit_pipeline as pipeline_module
 from analyst_toolkit.m00_utils.pipeline_config_validation import PipelineConfigValidationError
 
 
+@pytest.fixture
+def mock_load_config(mocker):
+    def _configure(config_map):
+        mocker.patch.object(
+            pipeline_module,
+            "load_config",
+            side_effect=lambda path: config_map[path],
+        )
+
+    return _configure
+
+
 def test_run_full_pipeline_rejects_invalid_master_config(mocker):
     mocker.patch.object(
         pipeline_module,
@@ -23,7 +35,7 @@ def test_run_full_pipeline_rejects_invalid_master_config(mocker):
     load_csv.assert_not_called()
 
 
-def test_run_full_pipeline_rejects_invalid_module_config_before_runner(mocker):
+def test_run_full_pipeline_rejects_invalid_module_config_before_runner(mocker, mock_load_config):
     config_map = {
         "config/run_toolkit_config.yaml": {
             "run_id": "cli_run",
@@ -39,10 +51,7 @@ def test_run_full_pipeline_rejects_invalid_module_config_before_runner(mocker):
         "config/validation_config_template.yaml": [],
     }
 
-    def fake_load_config(path):
-        return config_map[path]
-
-    mocker.patch.object(pipeline_module, "load_config", side_effect=fake_load_config)
+    mock_load_config(config_map)
     mocker.patch.object(
         pipeline_module,
         "load_csv",
@@ -59,7 +68,7 @@ def test_run_full_pipeline_rejects_invalid_module_config_before_runner(mocker):
     run_validation.assert_not_called()
 
 
-def test_run_full_pipeline_passes_validated_canonical_config_to_runner(mocker):
+def test_run_full_pipeline_passes_validated_canonical_config_to_runner(mocker, mock_load_config):
     config_map = {
         "config/run_toolkit_config.yaml": {
             "run_id": "cli_run",
@@ -83,10 +92,7 @@ def test_run_full_pipeline_passes_validated_canonical_config_to_runner(mocker):
         },
     }
 
-    def fake_load_config(path):
-        return config_map[path]
-
-    mocker.patch.object(pipeline_module, "load_config", side_effect=fake_load_config)
+    mock_load_config(config_map)
     mocker.patch.object(
         pipeline_module,
         "load_csv",

--- a/tests/test_run_toolkit_pipeline.py
+++ b/tests/test_run_toolkit_pipeline.py
@@ -1,0 +1,114 @@
+import pandas as pd
+import pytest
+
+import analyst_toolkit.run_toolkit_pipeline as pipeline_module
+from analyst_toolkit.m00_utils.pipeline_config_validation import PipelineConfigValidationError
+
+
+def test_run_full_pipeline_rejects_invalid_master_config(mocker):
+    mocker.patch.object(
+        pipeline_module,
+        "load_config",
+        return_value={
+            "run_id": "broken",
+            "notebook": False,
+            "modules": {},
+        },
+    )
+    load_csv = mocker.patch.object(pipeline_module, "load_csv")
+
+    with pytest.raises(PipelineConfigValidationError, match="pipeline_entry_path"):
+        pipeline_module.run_full_pipeline("config/run_toolkit_config.yaml")
+
+    load_csv.assert_not_called()
+
+
+def test_run_full_pipeline_rejects_invalid_module_config_before_runner(mocker):
+    config_map = {
+        "config/run_toolkit_config.yaml": {
+            "run_id": "cli_run",
+            "notebook": False,
+            "pipeline_entry_path": "data/raw/example.csv",
+            "modules": {
+                "validation": {
+                    "run": True,
+                    "config_path": "config/validation_config_template.yaml",
+                }
+            },
+        },
+        "config/validation_config_template.yaml": [],
+    }
+
+    def fake_load_config(path):
+        return config_map[path]
+
+    mocker.patch.object(pipeline_module, "load_config", side_effect=fake_load_config)
+    mocker.patch.object(
+        pipeline_module,
+        "load_csv",
+        return_value=pd.DataFrame({"col": [1, 2]}),
+    )
+    run_validation = mocker.patch.object(pipeline_module, "run_validation_pipeline")
+
+    with pytest.raises(
+        PipelineConfigValidationError,
+        match="Invalid config for runner module 'validation': expected a mapping",
+    ):
+        pipeline_module.run_full_pipeline("config/run_toolkit_config.yaml")
+
+    run_validation.assert_not_called()
+
+
+def test_run_full_pipeline_passes_validated_canonical_config_to_runner(mocker):
+    config_map = {
+        "config/run_toolkit_config.yaml": {
+            "run_id": "cli_run",
+            "notebook": False,
+            "pipeline_entry_path": "data/raw/example.csv",
+            "modules": {
+                "validation": {
+                    "run": True,
+                    "config_path": "config/validation_config_template.yaml",
+                }
+            },
+        },
+        "config/validation_config_template.yaml": {
+            "validation": {
+                "schema_validation": {
+                    "run": True,
+                    "fail_on_error": True,
+                    "rules": {"expected_columns": ["col"]},
+                }
+            }
+        },
+    }
+
+    def fake_load_config(path):
+        return config_map[path]
+
+    mocker.patch.object(pipeline_module, "load_config", side_effect=fake_load_config)
+    mocker.patch.object(
+        pipeline_module,
+        "load_csv",
+        return_value=pd.DataFrame({"col": [1, 2]}),
+    )
+    run_validation = mocker.patch.object(
+        pipeline_module,
+        "run_validation_pipeline",
+        side_effect=lambda config, df, notebook, run_id: df,
+    )
+
+    result = pipeline_module.run_full_pipeline("config/run_toolkit_config.yaml")
+
+    assert list(result["col"]) == [1, 2]
+    run_validation.assert_called_once()
+    kwargs = run_validation.call_args.kwargs
+    assert kwargs["config"] == {
+        "validation": {
+            "schema_validation": {
+                "run": True,
+                "fail_on_error": True,
+                "rules": {"expected_columns": ["col"]},
+            }
+        }
+    }


### PR DESCRIPTION
## Summary
- wire the master pipeline runner to the shared pipeline config validation helpers before module execution starts
- fail early on invalid master runner config or obviously broken module config files instead of failing later inside module runners
- add focused runner tests proving master config failures block startup and invalid module config files fail before the runner is called

## Validation
- pytest tests/test_run_toolkit_pipeline.py tests/test_pipeline_config_validation.py tests/test_template_contracts.py tests/test_golden_template_execution.py -q
- ruff check src/ tests/
- ruff format --check src/ tests/
- python -m yamllint .github/workflows .coderabbit.yaml
- mypy src/analyst_toolkit/mcp_server
- pre-commit run --all-files

## CodeRabbit
- attempted local `coderabbit review --plain --no-color --type uncommitted`
- it reached `Analyzing` and then stopped returning findings, so this is documented as a local tooling blocker rather than a clean local review