### PR TITLE
chore: normalize config and CLI surface text

### DIFF
--- a/config/certification_config_template.yaml
+++ b/config/certification_config_template.yaml
@@ -1,29 +1,29 @@
 # ------------------------------------------------------------------------------
-# 📄 Config File: run_certification_config.yaml
-# 🧩 Module: Validation (M02 - Certification Mode)
-# 📌 Purpose: Performs strict schema and content validation as a quality gate.
+# Config File: run_certification_config.yaml
+# Module: Validation (M02 - Certification Mode)
+# Purpose: Performs strict schema and content validation as a quality gate.
 # ------------------------------------------------------------------------------
 # This configuration is used as the final checkpoint before certifying the data.
 # It enforces a strict fail policy (`fail_on_error: true`) to stop the pipeline
 # if any schema or value rules are violated.
 # ------------------------------------------------------------------------------
 
-# 📥 Execution context
+# Execution context
 notebook: true
 run_id: "0002_QA"
 logging: "auto"              # Options: 'on', 'off', or 'auto'
 
-# 🧪 Validation settings
+# Validation settings
 validation:
   input_path: "data/raw/synthetic_penguins_v3.5.csv"
 
-  # ✅ Schema and content validation rules
+  # Schema and content validation rules
   schema_validation:
     run: true
     fail_on_error: true  # Hard stop if validation fails (certification mode)
 
     rules:
-      # 📐 Required column schema
+      # Required column schema
       expected_columns: 
         - "tag_id"
         - "species"
@@ -41,7 +41,7 @@ validation:
         - "clutch_completion"
         - "date_egg"
 
-      # 🔢 Expected data types (post-normalization)
+      # Expected data types (post-normalization)
       expected_types:
         tag_id: "object"
         species: "object"
@@ -59,7 +59,7 @@ validation:
         clutch_completion: "object"
         date_egg: "datetime64[ns]"
 
-      # 🧬 Valid categorical values (strict)
+      # Valid categorical values (strict)
       categorical_values:
         species: ["Adelie", "Chinstrap", "Gentoo"]
         island: ["Dream", "Biscoe", "Torgersen", "Cormorant", "Shortcut", "UNKNOWN"]
@@ -70,7 +70,7 @@ validation:
         health_status: ["Healthy", "Critical", "Underweight", "Sick", "Overweight", "UNKNOWN"]
         study_name: ["PAPRI2019", "PAPRI2020", "PAPRI2021", "PAPRI2022", "PAPRI2023", "PAPRI2024", "UNKNOWN"]
 
-      # 📏 Numeric range validation
+      # Numeric range validation
       numeric_ranges:
         bill length (mm):
           min: 30.0
@@ -85,7 +85,7 @@ validation:
           min: 2300.0
           max: 7500.0
 
-  # 📤 Output and reporting
+  # Output and reporting
   settings:
     checkpoint: true
     checkpoint_path: "exports/joblib/{run_id}/{run_id}_m02_certified.joblib"

--- a/config/diag_config_template.yaml
+++ b/config/diag_config_template.yaml
@@ -1,12 +1,12 @@
 # ------------------------------------------------------------------------------
-# 📄 Config File: run_diagnostics_config.yaml
-# 🧩 Module: Diagnostics (M01)
-# 📌 Purpose: Generates a high-level statistical and structural profile of a DataFrame.
+# Config File: run_diagnostics_config.yaml
+# Module: Diagnostics (M01)
+# Purpose: Generates a high-level statistical and structural profile of a DataFrame.
 # ------------------------------------------------------------------------------
 # This module is non-destructive. It produces reports and plots without modifying data.
 # ------------------------------------------------------------------------------
 
-# 📥 Execution context
+# Execution context
 notebook: true               # Show inline output in notebooks
 run_id: "0002_QA"            # Identifier for tagging output files
 logging: "auto"                # Options: 'on', 'off', or 'auto' (auto = on in notebook mode)
@@ -19,7 +19,7 @@ diagnostics:
     run: true                # Master toggle to run the profile step
 
     settings:
-      # 📤 Output controls
+      # Output controls
       export: true
       export_html: true
       export_html_path: "exports/reports/diagnostics/{run_id}_diagnostics_report.html"
@@ -28,7 +28,7 @@ diagnostics:
       checkpoint: false
       checkpoint_path: "exports/joblib/{run_id}/{run_id}_m02_diag_checkpoint.joblib"
 
-      # 📊 Display + analysis controls
+      # Display + analysis controls
       show_inline: true
       include_samples: true
       include_metadata: true
@@ -36,7 +36,7 @@ diagnostics:
       max_rows: 5
       high_cardinality_threshold: 15
 
-      # ✅ Quality checks
+      # Quality checks
       quality_checks:
         skew_threshold: 2.0
         expected_dtypes:

--- a/config/handling_config_template.yaml
+++ b/config/handling_config_template.yaml
@@ -1,26 +1,26 @@
 # ------------------------------------------------------------------------------
-# 📄 Config File: run_outlier_handling_config.yaml
-# 🧩 Module: Outlier Handling (M06)
-# 📌 Purpose: Applies corrective strategies to flagged outlier values.
+# Config File: run_outlier_handling_config.yaml
+# Module: Outlier Handling (M06)
+# Purpose: Applies corrective strategies to flagged outlier values.
 # ------------------------------------------------------------------------------
 # This module takes in the results of the detection step and modifies values
 # based on per-column or global handling strategies.
 # ------------------------------------------------------------------------------
 
-# 📥 Execution context
+# Execution context
 notebook: true
 run_id: "0002_QA"
 logging: "auto"               # Options: 'on', 'off', or 'auto'
 
-# 🛠️ Outlier handling configuration
+# Outlier handling configuration
 outlier_handling:
   run: true
 
-  # 📂 Input paths
+  # Input paths
   input_path: "exports/joblib/{run_id}_m05_outliers_flagged.joblib"
   detection_results_path: "exports/joblib/{run_id}_m05_detection_results.joblib"
 
-  # ⚙️ Handling strategies
+  # Handling strategies
   handling_specs:
     __global__:
       strategy: 'none'         # Explicitly specify no handling unless overridden
@@ -38,7 +38,7 @@ outlier_handling:
     __default__:
       strategy: 'clip'         # Fallback if column-specific rule not defined
 
-  # ⚙️ Settings for export, checkpointing, and display
+  # Settings for export, checkpointing, and display
   settings:
     show_inline: true
 

--- a/config/nightly_silver_qa_config.yaml
+++ b/config/nightly_silver_qa_config.yaml
@@ -1,6 +1,6 @@
 # ------------------------------------------------------------------------------
-# 📄 Config File: nightly_silver_qa_config.yaml
-# 📌 Purpose: Pre-authored base config for the FridAI nightly silver QA spec.
+# Config File: nightly_silver_qa_config.yaml
+# Purpose: Pre-authored base config for the FridAI nightly silver QA spec.
 #
 # Used by the autonomous daily_silver_qa spec. The SLM passes relevant blocks
 # from this file as the `config` argument when calling toolkit MCP tools.
@@ -14,14 +14,14 @@
 # Data is loaded via GCS path — gcs_path is passed at runtime by the spec.
 # ------------------------------------------------------------------------------
 
-# 📥 Execution context
+# Execution context
 notebook: false
 run_id: "nightly_silver_qa"   # Overridden at runtime by FridAI spec with dated run_id
 logging: "on"
 
 
 # ==============================================================================
-# 🔍 DIAGNOSTICS
+# DIAGNOSTICS
 # Structural profile — types, nulls, cardinality, skew. Non-destructive.
 # ==============================================================================
 diagnostics:
@@ -91,7 +91,7 @@ diagnostics:
 
 
 # ==============================================================================
-# 🚨 OUTLIER DETECTION
+# OUTLIER DETECTION
 # Column-specific thresholds calibrated to ecom enriched silver distributions.
 # ==============================================================================
 outlier_detection:

--- a/config/outlier_config_template.yaml
+++ b/config/outlier_config_template.yaml
@@ -1,25 +1,25 @@
 # ------------------------------------------------------------------------------
-# 📄 Config File: run_outlier_detection_config.yaml
-# 🧩 Module: Outlier Detection (M05)
-# 📌 Purpose: Identifies numeric outliers using IQR or Z-score methods.
+# Config File: run_outlier_detection_config.yaml
+# Module: Outlier Detection (M05)
+# Purpose: Identifies numeric outliers using IQR or Z-score methods.
 # ------------------------------------------------------------------------------
 # This module flags outliers in numeric columns and supports visualization,
 # column-specific thresholds, and export of flagged results.
 # ------------------------------------------------------------------------------
 
-# 📥 Execution context
+# Execution context
 notebook: true
 run_id: "0002_QA"
 logging: "auto"               # Options: 'on', 'off', or 'auto'
 
-# 🚨 Outlier detection configuration
+# Outlier detection configuration
 outlier_detection:
   run: true
 
-  # 📂 Input data path
+  # Input data path
   input_path: "data/processed/df_validated.csv"
 
-  # ⚙️ Detection rules
+  # Detection rules
   detection_specs:
     # Per-column overrides
     bill_length_mm:
@@ -35,13 +35,13 @@ outlier_detection:
       method: 'iqr'
       iqr_multiplier: 2.0
 
-  # 🚫 Columns to exclude from analysis
+  # Columns to exclude from analysis
   exclude_columns: ['id', 'tag_id']
 
-  # 🏷️ Append boolean flags (e.g., 'bill_length_mm_outlier') to output
+  # Append boolean flags (e.g., 'bill_length_mm_outlier') to output
   append_flags: true
 
-  # 📊 Plotting settings
+  # Plotting settings
   plotting:
     run: true
     plot_save_dir: "exports/plots/outliers/{run_id}"
@@ -49,7 +49,7 @@ outlier_detection:
     show_plots_inline: true                    # Enables PlotViewer in notebook
     hue: "species"                             # Optional grouping variable for plots
 
-  # 📤 Export reports
+  # Export reports
   export:
     run: true
     export_dir: "exports/reports/outliers/detection/"
@@ -57,7 +57,7 @@ outlier_detection:
     export_html: true
     export_html_path: "exports/reports/outliers/detection/{run_id}_outlier_report.html"
 
-  # 💾 Checkpoint results
+  # Checkpoint results
   checkpoint:
     run: true
     checkpoint_path: "exports/joblib/{run_id}/{run_id}_m05_outliers_flagged.joblib"

--- a/config/validation_config_template.yaml
+++ b/config/validation_config_template.yaml
@@ -1,7 +1,7 @@
 validation:
   input_path: "data/raw/example.csv"
 
-  # ✅ Schema and content validation rules
+  # Schema and content validation rules
   schema_validation:
     run: true
     fail_on_error: false   # Set to false in audit mode to detect all issues

--- a/src/analyst_toolkit/m00_utils/export_utils.py
+++ b/src/analyst_toolkit/m00_utils/export_utils.py
@@ -1,5 +1,5 @@
 """
-📦 export_utils.py
+export_utils.py
 
 Standardized export utilities for Analyst Toolkit pipeline modules.
 """
@@ -56,7 +56,7 @@ def export_dataframes(
                 filename = f"{base_stem}_{name}.csv"
                 df.to_csv(base_dir / filename, index=False, encoding=encoding)
         if logging_mode != "off":
-            logging.info(f"📊 Exported {len(data_dict)} CSV files to directory {base_dir}")
+            logging.info("Exported %s CSV files to directory %s", len(data_dict), base_dir)
 
     # Accept both 'excel' and 'xlsx' as valid identifiers for an Excel file.
     elif normalized_format in ["excel", "xlsx"]:
@@ -75,11 +75,12 @@ def export_dataframes(
                         df.columns = ["__".join(map(str, col)).strip() for col in df.columns.values]
                         if logging_mode != "off":
                             logging.info(
-                                f"⚠️ Flattened MultiIndex columns in sheet '{name}' for Excel compatibility."
+                                "Flattened MultiIndex columns in sheet '%s' for Excel compatibility.",
+                                name,
                             )
                     df.to_excel(writer, sheet_name=name[:31], index=False)
         if logging_mode != "off":
-            logging.info(f"📊 Exported {len(data_dict)} sheets to {path_with_run_id}")
+            logging.info("Exported %s sheets to %s", len(data_dict), path_with_run_id)
     else:
         raise ValueError(f"Unsupported file format: {file_format}")
 
@@ -126,7 +127,7 @@ def export_html_report(
         )
 
     path.write_text(html, encoding="utf-8")
-    logging.info(f"📄 HTML report written to {path.resolve()}")
+    logging.info("HTML report written to %s", path.resolve())
     return str(path.resolve())
 
 
@@ -237,7 +238,7 @@ def save_joblib(obj, path: str):
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
     dump(obj, path)
-    logging.info(f"💾 Checkpoint saved to {path}")
+    logging.info("Checkpoint saved to %s", path)
 
 
 def export_duplicates_report(report: dict, config: dict, run_id: str):

--- a/src/analyst_toolkit/m00_utils/load_data.py
+++ b/src/analyst_toolkit/m00_utils/load_data.py
@@ -1,5 +1,5 @@
 """
-📦 Module: load_data.py
+Module: load_data.py
 
 Utility functions for loading tabular data into pandas DataFrames.
 

--- a/src/analyst_toolkit/m01_diagnostics/run_diag_pipeline.py
+++ b/src/analyst_toolkit/m01_diagnostics/run_diag_pipeline.py
@@ -1,5 +1,5 @@
 """
-🚀 Module: run_diag_pipeline.py
+Module: run_diag_pipeline.py
 
 Runner script for the M01 Diagnostics module of the Analyst Toolkit.
 

--- a/src/analyst_toolkit/m02_validation/run_validation_pipeline.py
+++ b/src/analyst_toolkit/m02_validation/run_validation_pipeline.py
@@ -1,5 +1,5 @@
 """
-🚀 Module: run_validation_pipeline.py
+Module: run_validation_pipeline.py
 
 Runner script for the M02 Validation module of the Analyst Toolkit.
 
@@ -102,7 +102,7 @@ def run_validation_pipeline(
                 logging.error(error_message)
                 raise ValueError(error_message)
             else:
-                logging.info("✅ Validation Gatekeeper PASSED. All checks are clean.")
+                logging.info("Validation Gatekeeper passed. All checks are clean.")
 
         settings = module_cfg.get("settings", {})
         if settings.get("export", True):

--- a/src/analyst_toolkit/m02_validation/run_validation_pipeline.py
+++ b/src/analyst_toolkit/m02_validation/run_validation_pipeline.py
@@ -96,7 +96,7 @@ def run_validation_pipeline(
             ]
             if failed_checks:
                 error_message = (
-                    "Validation Gatekeeper FAILED. The following checks did not pass:\n- "
+                    "Validation Gatekeeper failed. The following checks did not pass:\n- "
                     + "\n- ".join(failed_checks)
                 )
                 logging.error(error_message)

--- a/src/analyst_toolkit/m03_normalization/run_normalization_pipeline.py
+++ b/src/analyst_toolkit/m03_normalization/run_normalization_pipeline.py
@@ -1,5 +1,5 @@
 """
-🚀 Module: run_normalization_pipeline.py
+Module: run_normalization_pipeline.py
 
 Runner script for the M03 Normalization module of the Analyst Toolkit.
 

--- a/src/analyst_toolkit/m04_duplicates/run_dupes_pipeline.py
+++ b/src/analyst_toolkit/m04_duplicates/run_dupes_pipeline.py
@@ -1,5 +1,5 @@
 """
-🚀 Module: run_dupes_pipeline.py
+Module: run_dupes_pipeline.py
 
 This module serves as the primary runner for the M04 Duplicates pipeline.
 It orchestrates the detection and handling of duplicate rows in a DataFrame,

--- a/src/analyst_toolkit/m05_detect_outliers/run_detection_pipeline.py
+++ b/src/analyst_toolkit/m05_detect_outliers/run_detection_pipeline.py
@@ -1,5 +1,5 @@
 """
-🚀 Module: run_detection_pipeline.py
+Module: run_detection_pipeline.py
 
 Runner script for the M05 Outlier Detection module in the Analyst Toolkit.
 
@@ -119,6 +119,6 @@ def run_outlier_detection_pipeline(
         if not checkpoint_path:
             raise ValueError("Checkpoint enabled but 'checkpoint_path' is missing.")
         save_joblib(df_out, path=checkpoint_path)
-        logging.info(f"✅ Outlier-flagged DataFrame checkpoint saved to {checkpoint_path}")
+        logging.info("Outlier-flagged DataFrame checkpoint saved to %s", checkpoint_path)
 
     return df_out, detection_results

--- a/src/analyst_toolkit/m06_outlier_handling/run_handling_pipeline.py
+++ b/src/analyst_toolkit/m06_outlier_handling/run_handling_pipeline.py
@@ -1,5 +1,5 @@
 """
-🚀 Module: run_handling_pipeline.py
+Module: run_handling_pipeline.py
 
 Runner script for the M06 Outlier Handling module in the Analyst Toolkit.
 

--- a/src/analyst_toolkit/m07_imputation/run_imputation_pipeline.py
+++ b/src/analyst_toolkit/m07_imputation/run_imputation_pipeline.py
@@ -1,5 +1,5 @@
 """
-🧩 Module: run_imputation_pipeline.py
+Module: run_imputation_pipeline.py
 
 Runner script for the M07 Imputation module in the Analyst Toolkit.
 
@@ -23,7 +23,7 @@ Example:
 """
 
 import logging
-from pathlib import Path  # <-- CORRECTED: Added missing import
+from pathlib import Path
 
 import pandas as pd
 

--- a/src/analyst_toolkit/m10_final_audit/final_audit_pipeline.py
+++ b/src/analyst_toolkit/m10_final_audit/final_audit_pipeline.py
@@ -1,5 +1,5 @@
 """
-✅ Module: final_audit_pipeline.py
+Module: final_audit_pipeline.py
 
 This is the main runner script for the M10 Final Audit & Certification module.
 
@@ -156,6 +156,6 @@ def run_final_audit_pipeline(
                 "report_html", "exports/reports/final_audit/{run_id}_final_audit_report.html"
             ).format(run_id=run_id)
             export_html_report(final_report, html_path, "Final Audit", run_id)
-        logging.info("✅ Final artifacts exported successfully.")
+        logging.info("Final artifacts exported successfully.")
 
     return df_certified

--- a/src/analyst_toolkit/run_toolkit_pipeline.py
+++ b/src/analyst_toolkit/run_toolkit_pipeline.py
@@ -1,6 +1,6 @@
 """
-🚀 run_toolkit_pipeline.py
-✅ Module: Master Pipeline Orchestrator
+run_toolkit_pipeline.py
+Module: Master Pipeline Orchestrator
 This is the main entry point for running the entire Analyst Toolkit pipeline from start to finish.
 
 Responsibilities:
@@ -71,7 +71,10 @@ def run_full_pipeline(config_path: str):
     modules_to_run = master_config.get("modules", {})
     entry_path = master_config.get("pipeline_entry_path")
 
-    logging.info(f"--- 🚚 Loading initial data from {entry_path} ---")
+    if not entry_path:
+        raise ValueError("Master config is missing 'pipeline_entry_path'. Cannot start pipeline.")
+
+    logging.info("--- Loading initial data from %s ---", entry_path)
     df: pd.DataFrame = load_csv(entry_path)
 
     # Initialize artifact placeholder for outlier detection
@@ -82,65 +85,65 @@ def run_full_pipeline(config_path: str):
     # M01: Diagnostics
     module_info = modules_to_run.get("diagnostics")
     if module_info and module_info.get("run"):
-        logging.info("--- 🚀 Starting Module: DIAGNOSTICS ---")
+        logging.info("--- Starting Module: DIAGNOSTICS ---")
         module_config = _load_validated_module_config("diagnostics", module_info["config_path"])
         # The runner function does not modify the df, so no reassignment needed
         run_diag_pipeline(config=module_config, df=df, notebook=notebook_mode, run_id=run_id)
-        logging.info("--- ✅ Finished Module: DIAGNOSTICS ---")
+        logging.info("--- Finished Module: DIAGNOSTICS ---")
 
     # M02: Initial Validation
     module_info = modules_to_run.get("validation")
     if module_info and module_info.get("run"):
-        logging.info("--- 🚀 Starting Module: VALIDATION ---")
+        logging.info("--- Starting Module: VALIDATION ---")
         module_config = _load_validated_module_config("validation", module_info["config_path"])
         df = run_validation_pipeline(
             config=module_config, df=df, notebook=notebook_mode, run_id=run_id
         )
-        logging.info("--- ✅ Finished Module: VALIDATION ---")
+        logging.info("--- Finished Module: VALIDATION ---")
 
     # M03: Normalization
     module_info = modules_to_run.get("normalization")
     if module_info and module_info.get("run"):
-        logging.info("--- 🚀 Starting Module: NORMALIZATION ---")
+        logging.info("--- Starting Module: NORMALIZATION ---")
         module_config = _load_validated_module_config("normalization", module_info["config_path"])
         df = run_normalization_pipeline(
             config=module_config, df=df, notebook=notebook_mode, run_id=run_id
         )
-        logging.info("--- ✅ Finished Module: NORMALIZATION ---")
+        logging.info("--- Finished Module: NORMALIZATION ---")
 
     # M04: Validation Gatekeeper
     module_info = modules_to_run.get("validation_gatekeeper")
     if module_info and module_info.get("run"):
-        logging.info("--- 🚀 Starting Module: VALIDATION_GATEKEEPER ---")
+        logging.info("--- Starting Module: VALIDATION_GATEKEEPER ---")
         module_config = _load_validated_module_config(
             "validation_gatekeeper", module_info["config_path"]
         )
         df = run_validation_pipeline(
             config=module_config, df=df, notebook=notebook_mode, run_id=run_id
         )
-        logging.info("--- ✅ Finished Module: VALIDATION_GATEKEEPER ---")
+        logging.info("--- Finished Module: VALIDATION_GATEKEEPER ---")
 
     # M05: Duplicates Handling
     module_info = modules_to_run.get("duplicates")
     if module_info and module_info.get("run"):
-        logging.info("--- 🚀 Starting Module: DUPLICATES ---")
+        logging.info("--- Starting Module: DUPLICATES ---")
         module_config = _load_validated_module_config("duplicates", module_info["config_path"])
         df = run_duplicates_pipeline(
             config=module_config, df=df, notebook=notebook_mode, run_id=run_id
         )
-        logging.info("--- ✅ Finished Module: DUPLICATES ---")
+        logging.info("--- Finished Module: DUPLICATES ---")
 
     # M06: Outlier Detection
     module_info = modules_to_run.get("outlier_detection")
     if module_info and module_info.get("run"):
-        logging.info("--- 🚀 Starting Module: OUTLIER_DETECTION ---")
+        logging.info("--- Starting Module: OUTLIER_DETECTION ---")
         module_config = _load_validated_module_config(
             "outlier_detection", module_info["config_path"]
         )
         df, detection_results = run_outlier_detection_pipeline(
             config=module_config, df=df, notebook=notebook_mode, run_id=run_id
         )
-        logging.info("--- ✅ Finished Module: OUTLIER_DETECTION ---")
+        logging.info("--- Finished Module: OUTLIER_DETECTION ---")
 
     # M07: Outlier Handling
     module_info = modules_to_run.get("outlier_handling")
@@ -149,7 +152,7 @@ def run_full_pipeline(config_path: str):
             raise RuntimeError(
                 "M07 Outlier Handling cannot run because M06 Outlier Detection did not return results."
             )
-        logging.info("--- 🚀 Starting Module: OUTLIER_HANDLING ---")
+        logging.info("--- Starting Module: OUTLIER_HANDLING ---")
         module_config = load_config(module_info["config_path"])
         df = run_outlier_handling_pipeline(
             config=module_config,
@@ -158,29 +161,29 @@ def run_full_pipeline(config_path: str):
             notebook=notebook_mode,
             run_id=run_id,
         )
-        logging.info("--- ✅ Finished Module: OUTLIER_HANDLING ---")
+        logging.info("--- Finished Module: OUTLIER_HANDLING ---")
 
     # M08: Imputation
     module_info = modules_to_run.get("imputation")
     if module_info and module_info.get("run"):
-        logging.info("--- 🚀 Starting Module: IMPUTATION ---")
+        logging.info("--- Starting Module: IMPUTATION ---")
         module_config = _load_validated_module_config("imputation", module_info["config_path"])
         df = run_imputation_pipeline(
             config=module_config, df=df, notebook=notebook_mode, run_id=run_id
         )
-        logging.info("--- ✅ Finished Module: IMPUTATION ---")
+        logging.info("--- Finished Module: IMPUTATION ---")
 
     # M10: Final Audit
     module_info = modules_to_run.get("final_audit")
     if module_info and module_info.get("run"):
-        logging.info("--- 🚀 Starting Module: FINAL_AUDIT ---")
+        logging.info("--- Starting Module: FINAL_AUDIT ---")
         module_config = _load_validated_module_config("final_audit", module_info["config_path"])
         df = run_final_audit_pipeline(
             config=module_config, df=df, run_id=run_id, notebook=notebook_mode
         )
-        logging.info("--- ✅ Finished Module: FINAL_AUDIT ---")
+        logging.info("--- Finished Module: FINAL_AUDIT ---")
 
-    logging.info("--- 🎉 Full Pipeline Execution Complete ---")
+    logging.info("--- Full Pipeline Execution Complete ---")
     return df
 
 


### PR DESCRIPTION
## Summary
- remove emoji-heavy language from YAML config comments and template headings
- normalize runner/logging text in the notebook and CLI execution layer to plain, grep-friendly messages
- leave HTML dashboard/report presentation strings unchanged so notebook/export visuals keep their current look

## Validation
- pytest tests/test_pipeline_config_validation.py tests/test_template_contracts.py tests/test_golden_template_execution.py -q
- ruff check src/ tests/
- ruff format --check src/ tests/
- python -m yamllint .github/workflows .coderabbit.yaml
- mypy src/analyst_toolkit/mcp_server
- pre-commit run --all-files

## CodeRabbit
- local CodeRabbit review was intentionally skipped for this slice because the user is running it directly