### PR TITLE
fix: polish artifact server and plotting runtime

### DIFF
--- a/resource_hub/mcp_server_guide.md
+++ b/resource_hub/mcp_server_guide.md
@@ -215,7 +215,7 @@ When diagnosing failures, use `trace_id` from the JSON-RPC error payload and cor
 | `get_cockpit_dashboard` | Operator hub HTML artifact — recent-run cards, module dashboard links, artifact rows, data dictionary preview |
 | `get_pipeline_dashboard` | Combined multi-module HTML dashboard for a specific `run_id`; linked from the cockpit hub |
 | `data_dictionary` | Column-level schema report as a standalone HTML artifact; preview surfaced in the cockpit dictionary tab |
-| `ensure_artifact_server` | Start/status the local artifact server — converts artifact file paths into browser-openable localhost URLs |
+| `ensure_artifact_server` | Start/status the local artifact server — converts artifact file paths into browser-openable localhost URLs and returns `already_running=true` when the target server is already up |
 | `manage_session` | Session lifecycle: list active sessions, inspect details, fork a session into a new run context, or rebind a session to a different run_id |
 | `upload_input` | Upload a local file as base64-encoded content through the MCP protocol — use when the file is not server-visible (e.g., server runs in a container) |
 | `read_artifact` | Read a container-local artifact and return its content through MCP — use when localhost artifact URLs are not reachable from the client |
@@ -340,7 +340,7 @@ curl -X POST http://localhost:8001/rpc \
   }'
 ```
 
-The server binds to `127.0.0.1:8765` by default and serves the `exports/` directory. Artifact paths in subsequent tool responses will be replaced with `http://localhost:8765/...` URLs.
+The server binds to `127.0.0.1:8765` by default and serves the `exports/` directory. Artifact paths in subsequent tool responses will be replaced with `http://localhost:8765/...` URLs. If a compatible artifact server is already listening on that host/port, `ensure_artifact_server` returns a normal pass response with `summary.already_running=true` instead of failing on the occupied port.
 
 | Variable | Default | Description |
 |---|---|---|

--- a/src/analyst_toolkit/m00_utils/plot_runtime.py
+++ b/src/analyst_toolkit/m00_utils/plot_runtime.py
@@ -1,0 +1,48 @@
+"""Runtime helpers for local plotting cache configuration."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def _is_writable_path(path: Path) -> bool:
+    candidate = path.expanduser()
+    if candidate.exists():
+        return os.access(candidate, os.W_OK | os.X_OK)
+
+    parent = candidate.parent
+    while not parent.exists() and parent != parent.parent:
+        parent = parent.parent
+    return os.access(parent, os.W_OK | os.X_OK)
+
+
+def configure_plot_runtime_env() -> None:
+    """Set writable cache directories for matplotlib/fontconfig when needed."""
+
+    fallback_root = Path(tempfile.gettempdir()) / "analyst_toolkit_cache"
+    fallback_root.mkdir(parents=True, exist_ok=True)
+
+    xdg_cache_home = os.environ.get("XDG_CACHE_HOME", "").strip()
+    if xdg_cache_home:
+        xdg_cache_path = Path(xdg_cache_home).expanduser()
+    else:
+        xdg_cache_path = Path.home() / ".cache"
+        if not _is_writable_path(xdg_cache_path):
+            xdg_cache_path = fallback_root
+            os.environ["XDG_CACHE_HOME"] = str(xdg_cache_path)
+    xdg_cache_path.mkdir(parents=True, exist_ok=True)
+
+    mpl_config_dir = os.environ.get("MPLCONFIGDIR", "").strip()
+    if mpl_config_dir:
+        mpl_config_path = Path(mpl_config_dir).expanduser()
+    else:
+        default_mpl_path = Path.home() / ".matplotlib"
+        mpl_config_path = (
+            default_mpl_path
+            if _is_writable_path(default_mpl_path)
+            else (xdg_cache_path / "matplotlib")
+        )
+        os.environ["MPLCONFIGDIR"] = str(mpl_config_path)
+    mpl_config_path.mkdir(parents=True, exist_ok=True)

--- a/src/analyst_toolkit/m05_detect_outliers/plot_outliers.py
+++ b/src/analyst_toolkit/m05_detect_outliers/plot_outliers.py
@@ -12,6 +12,10 @@ returned for optional widget-based viewing or HTML inclusion.
 import logging
 from pathlib import Path
 
+from analyst_toolkit.m00_utils.plot_runtime import configure_plot_runtime_env
+
+configure_plot_runtime_env()
+
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns

--- a/src/analyst_toolkit/m08_visuals/comparison_plots.py
+++ b/src/analyst_toolkit/m08_visuals/comparison_plots.py
@@ -16,6 +16,10 @@ widget-based reviewers.
 import logging
 from pathlib import Path
 
+from analyst_toolkit.m00_utils.plot_runtime import configure_plot_runtime_env
+
+configure_plot_runtime_env()
+
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns

--- a/src/analyst_toolkit/m08_visuals/distributions.py
+++ b/src/analyst_toolkit/m08_visuals/distributions.py
@@ -15,6 +15,10 @@ All plots are saved to disk with run-aware filenames for audit traceability.
 import logging
 from pathlib import Path
 
+from analyst_toolkit.m00_utils.plot_runtime import configure_plot_runtime_env
+
+configure_plot_runtime_env()
+
 import matplotlib.pyplot as plt
 import pandas as pd
 

--- a/src/analyst_toolkit/m08_visuals/summary_plots.py
+++ b/src/analyst_toolkit/m08_visuals/summary_plots.py
@@ -16,6 +16,10 @@ Designed for use in diagnostic modules and notebook inline displays.
 import logging
 from pathlib import Path
 
+from analyst_toolkit.m00_utils.plot_runtime import configure_plot_runtime_env
+
+configure_plot_runtime_env()
+
 import matplotlib.pyplot as plt
 import pandas as pd
 import seaborn as sns

--- a/src/analyst_toolkit/mcp_server/local_artifact_server.py
+++ b/src/analyst_toolkit/mcp_server/local_artifact_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import ipaddress
 import json
 import logging
@@ -178,6 +179,17 @@ def _probe_server(base_url: str, timeout_sec: float = 0.25) -> bool:
         return False
 
 
+def _read_server_health(base_url: str, timeout_sec: float = 0.25) -> dict[str, Any] | None:
+    try:
+        with urllib.request.urlopen(f"{base_url}/__health", timeout=timeout_sec) as response:
+            if response.status != 200:
+                return None
+            payload = json.loads(response.read().decode("utf-8"))
+            return payload if isinstance(payload, dict) else None
+    except Exception:
+        return None
+
+
 def get_local_artifact_server_status() -> dict[str, Any]:
     with _SERVER_GUARD:
         running = bool(
@@ -231,11 +243,26 @@ def ensure_local_artifact_server() -> dict[str, Any]:
             root.mkdir(parents=True, exist_ok=True)
             host = _artifact_server_host()
             requested_port = _artifact_server_port()
-            server = _ArtifactHTTPServer((host, requested_port), _ArtifactRequestHandler)
+            advertised_host = "127.0.0.1" if host == "0.0.0.0" else host
+            base_url = f"http://{advertised_host}:{requested_port}"
+            try:
+                server = _ArtifactHTTPServer((host, requested_port), _ArtifactRequestHandler)
+            except OSError as exc:
+                if exc.errno == errno.EADDRINUSE:
+                    health = _read_server_health(base_url)
+                    if health is not None:
+                        return {
+                            "status": "pass",
+                            "enabled": True,
+                            "running": True,
+                            "already_running": True,
+                            "base_url": str(health.get("base_url") or base_url),
+                            "root": str(health.get("root") or root),
+                        }
+                raise
             server.artifact_root = root
             # Advertise 127.0.0.1 in URLs even when bound to 0.0.0.0 —
             # 0.0.0.0 is not a valid browsable address.
-            advertised_host = "127.0.0.1" if host == "0.0.0.0" else host
             server.base_url = f"http://{advertised_host}:{server.server_address[1]}"
             thread = threading.Thread(
                 target=server.serve_forever,

--- a/tests/m00_utils/test_plot_runtime.py
+++ b/tests/m00_utils/test_plot_runtime.py
@@ -1,0 +1,34 @@
+import os
+import tempfile
+from pathlib import Path
+
+from analyst_toolkit.m00_utils.plot_runtime import configure_plot_runtime_env
+
+
+def test_configure_plot_runtime_env_uses_writable_tmp_cache(monkeypatch, tmp_path):
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir()
+    fake_home.chmod(0o500)
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+    monkeypatch.delenv("MPLCONFIGDIR", raising=False)
+
+    configure_plot_runtime_env()
+
+    assert os.environ["XDG_CACHE_HOME"].startswith(tempfile.gettempdir())
+    assert os.environ["MPLCONFIGDIR"].startswith(os.environ["XDG_CACHE_HOME"])
+    assert Path(os.environ["MPLCONFIGDIR"]).exists()
+
+
+def test_configure_plot_runtime_env_respects_existing_settings(monkeypatch, tmp_path):
+    xdg_dir = tmp_path / "cache"
+    mpl_dir = tmp_path / "mpl"
+    xdg_dir.mkdir()
+    mpl_dir.mkdir()
+    monkeypatch.setenv("XDG_CACHE_HOME", str(xdg_dir))
+    monkeypatch.setenv("MPLCONFIGDIR", str(mpl_dir))
+
+    configure_plot_runtime_env()
+
+    assert os.environ["XDG_CACHE_HOME"] == str(xdg_dir)
+    assert os.environ["MPLCONFIGDIR"] == str(mpl_dir)

--- a/tests/mcp_server/test_local_artifact_server.py
+++ b/tests/mcp_server/test_local_artifact_server.py
@@ -1,0 +1,35 @@
+import errno
+
+import analyst_toolkit.mcp_server.local_artifact_server as artifact_server_module
+
+
+def test_ensure_local_artifact_server_detects_existing_server_on_same_port(
+    monkeypatch, tmp_path, reset_artifact_server
+):
+    root = tmp_path / "exports"
+    root.mkdir(parents=True)
+    port = 8765
+    base_url = f"http://127.0.0.1:{port}"
+
+    monkeypatch.setenv("ANALYST_MCP_ENABLE_ARTIFACT_SERVER", "true")
+    monkeypatch.setenv("ANALYST_MCP_ARTIFACT_SERVER_HOST", "127.0.0.1")
+    monkeypatch.setenv("ANALYST_MCP_ARTIFACT_SERVER_PORT", str(port))
+    monkeypatch.setenv("ANALYST_MCP_ARTIFACT_SERVER_ROOT", str(root))
+    monkeypatch.setattr(
+        artifact_server_module,
+        "_ArtifactHTTPServer",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError(errno.EADDRINUSE, "in use")),
+    )
+    monkeypatch.setattr(
+        artifact_server_module,
+        "_read_server_health",
+        lambda *_args, **_kwargs: {"base_url": base_url, "root": str(root)},
+    )
+
+    result = artifact_server_module.ensure_local_artifact_server()
+
+    assert result["status"] == "pass"
+    assert result["running"] is True
+    assert result["already_running"] is True
+    assert result["base_url"] == base_url
+    assert result["root"] == str(root)


### PR DESCRIPTION
## Summary
- treat an occupied artifact-server port as a normal pass when a compatible toolkit artifact server is already listening there
- configure writable plotting cache directories before matplotlib/seaborn imports so local CLI and notebook runs avoid cache-dir warning noise
- document the  already-running behavior and add focused regressions for both changes

## Validation
- pytest tests/m00_utils/test_plot_runtime.py tests/mcp_server/test_local_artifact_server.py tests/mcp_server/test_rpc_cockpit_guides.py -q
- ruff check src/analyst_toolkit/m00_utils/plot_runtime.py src/analyst_toolkit/m08_visuals/distributions.py src/analyst_toolkit/m08_visuals/summary_plots.py src/analyst_toolkit/m08_visuals/comparison_plots.py src/analyst_toolkit/m05_detect_outliers/plot_outliers.py src/analyst_toolkit/mcp_server/local_artifact_server.py tests/m00_utils/test_plot_runtime.py tests/mcp_server/test_local_artifact_server.py
- ruff format --check src/analyst_toolkit/m00_utils/plot_runtime.py src/analyst_toolkit/m08_visuals/distributions.py src/analyst_toolkit/m08_visuals/summary_plots.py src/analyst_toolkit/m08_visuals/comparison_plots.py src/analyst_toolkit/m05_detect_outliers/plot_outliers.py src/analyst_toolkit/mcp_server/local_artifact_server.py tests/m00_utils/test_plot_runtime.py tests/mcp_server/test_local_artifact_server.py
- mypy src/analyst_toolkit/mcp_server
- real CLI smoke rerun via python -m analyst_toolkit.run_toolkit_pipeline --config /tmp/qa_run_toolkit_config_polish.yaml

## Notes
- I left the unrelated local notebook edit uncommitted and out of this branch.
- Per your instruction, I did not run local CodeRabbit for this slice.