### PR TITLE
Fix local artifact server dashboard URLs

### DIFF
--- a/resource_hub/usage_guide.md
+++ b/resource_hub/usage_guide.md
@@ -330,7 +330,7 @@ ANALYST_MCP_ENABLE_ARTIFACT_SERVER=1    # enable the server
 ANALYST_MCP_ARTIFACT_SERVER_PORT=8765   # default port
 ```
 
-Once enabled, cockpit and module dashboard artifact references become live links (e.g., `http://127.0.0.1:8765/exports/reports/...`). Localhost-only by default.
+Once enabled, cockpit and module dashboard artifact references become live links (e.g., `http://127.0.0.1:8765/reports/...`). Localhost-only by default.
 
 Available as the `ensure_artifact_server` MCP tool.
 

--- a/src/analyst_toolkit/mcp_server/local_artifact_server.py
+++ b/src/analyst_toolkit/mcp_server/local_artifact_server.py
@@ -148,10 +148,12 @@ class _ArtifactRequestHandler(SimpleHTTPRequestHandler):
         if artifact_root is None:
             logger.error("artifact_root not set on artifact server instance")
             return str(Path("__missing__").resolve(strict=False))
-        if parsed_path in {"/exports", "/exports/"}:
+        if parsed_path in {"/exports", "/exports/", "/reports", "/reports/"}:
             relative = PurePosixPath(".")
         elif parsed_path.startswith("/exports/"):
             relative = PurePosixPath(parsed_path.removeprefix("/exports/"))
+        elif parsed_path.startswith("/reports/"):
+            relative = PurePosixPath(parsed_path.removeprefix("/"))
         else:
             return str((artifact_root / "__missing__").resolve(strict=False))
         if ".." in relative.parts:

--- a/src/analyst_toolkit/mcp_server/local_artifact_server.py
+++ b/src/analyst_toolkit/mcp_server/local_artifact_server.py
@@ -339,7 +339,10 @@ def build_local_artifact_url(local_path: str) -> str:
         relative = candidate.relative_to(artifact_root)
     except ValueError:
         return ""
-    return f"{status['base_url']}/{relative.as_posix()}"
+    relative_posix = relative.as_posix()
+    if relative_posix.startswith("reports/"):
+        return f"{status['base_url']}/{relative_posix}"
+    return f"{status['base_url']}/exports/{relative_posix}"
 
 
 def _reset_local_artifact_server_for_tests() -> None:

--- a/src/analyst_toolkit/mcp_server/local_artifact_server.py
+++ b/src/analyst_toolkit/mcp_server/local_artifact_server.py
@@ -337,7 +337,7 @@ def build_local_artifact_url(local_path: str) -> str:
         relative = candidate.relative_to(artifact_root)
     except ValueError:
         return ""
-    return f"{status['base_url']}/exports/{relative.as_posix()}"
+    return f"{status['base_url']}/{relative.as_posix()}"
 
 
 def _reset_local_artifact_server_for_tests() -> None:

--- a/src/analyst_toolkit/mcp_server/tools/cockpit_content.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit_content.py
@@ -60,7 +60,7 @@ def user_quickstart_payload() -> dict:
 - In trusted/local mode, you can start a review session by building the cockpit dashboard for one human-readable landing page.
 - Decision tree for accessing artifacts:
   1. Call `ensure_artifact_server` first to start the localhost artifact server.
-  2. Surface the `dashboard_url` (e.g. `http://127.0.0.1:8765/exports/...`) to the user — this is the preferred path.
+  2. Surface the `dashboard_url` (e.g. `http://127.0.0.1:8765/reports/...`) to the user — this is the preferred path.
   3. If the user reports the URL is unreachable, fall back to `read_artifact(artifact_path=<dashboard_path from tool output>)` to retrieve the HTML content directly through MCP.
 - Module tools can return `dashboard_url` when standalone HTML reports are uploaded or exposed for review.
 - Agents should surface those dashboard links to users instead of burying them in long summaries.

--- a/tests/mcp_server/test_local_artifact_server.py
+++ b/tests/mcp_server/test_local_artifact_server.py
@@ -1,4 +1,5 @@
 import errno
+from pathlib import Path
 
 import analyst_toolkit.mcp_server.local_artifact_server as artifact_server_module
 
@@ -33,3 +34,60 @@ def test_ensure_local_artifact_server_detects_existing_server_on_same_port(
     assert result["already_running"] is True
     assert result["base_url"] == base_url
     assert result["root"] == str(root)
+
+
+def test_build_local_artifact_url_serves_paths_relative_to_exports_root(
+    monkeypatch, tmp_path, reset_artifact_server
+):
+    root = tmp_path / "exports"
+    local_artifact = root / "reports" / "pipeline" / "run1_dashboard.html"
+    local_artifact.parent.mkdir(parents=True)
+    local_artifact.write_text("<html>ok</html>", encoding="utf-8")
+
+    monkeypatch.setenv("ANALYST_MCP_ENABLE_ARTIFACT_SERVER", "true")
+    monkeypatch.setenv("ANALYST_MCP_ARTIFACT_SERVER_HOST", "127.0.0.1")
+    monkeypatch.setenv("ANALYST_MCP_ARTIFACT_SERVER_PORT", "8765")
+    monkeypatch.setenv("ANALYST_MCP_ARTIFACT_SERVER_ROOT", str(root))
+
+    monkeypatch.setattr(
+        artifact_server_module,
+        "get_local_artifact_server_status",
+        lambda: {
+            "running": True,
+            "base_url": "http://127.0.0.1:8765",
+            "root": str(root.resolve(strict=False)),
+        },
+    )
+
+    url = artifact_server_module.build_local_artifact_url(str(local_artifact))
+
+    assert url == "http://127.0.0.1:8765/reports/pipeline/run1_dashboard.html"
+    assert "/exports/" not in url
+
+
+def test_ensure_local_artifact_server_reraises_addrinuse_without_health_match(
+    monkeypatch, tmp_path, reset_artifact_server
+):
+    root = tmp_path / "exports"
+    root.mkdir(parents=True)
+
+    monkeypatch.setenv("ANALYST_MCP_ENABLE_ARTIFACT_SERVER", "true")
+    monkeypatch.setenv("ANALYST_MCP_ARTIFACT_SERVER_HOST", "127.0.0.1")
+    monkeypatch.setenv("ANALYST_MCP_ARTIFACT_SERVER_PORT", "8765")
+    monkeypatch.setenv("ANALYST_MCP_ARTIFACT_SERVER_ROOT", str(root))
+    monkeypatch.setattr(
+        artifact_server_module,
+        "_ArtifactHTTPServer",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError(errno.EADDRINUSE, "in use")),
+    )
+    monkeypatch.setattr(
+        artifact_server_module,
+        "_read_server_health",
+        lambda *_args, **_kwargs: None,
+    )
+
+    try:
+        artifact_server_module.ensure_local_artifact_server()
+        raise AssertionError("expected OSError")
+    except OSError as exc:
+        assert exc.errno == errno.EADDRINUSE

--- a/tests/mcp_server/test_local_artifact_server.py
+++ b/tests/mcp_server/test_local_artifact_server.py
@@ -65,6 +65,18 @@ def test_build_local_artifact_url_serves_paths_relative_to_exports_root(
     assert "/exports/" not in url
 
 
+def test_translate_path_accepts_reports_prefix(tmp_path):
+    root = tmp_path / "exports"
+    handler = artifact_server_module._ArtifactRequestHandler.__new__(
+        artifact_server_module._ArtifactRequestHandler
+    )
+    handler.server = type("Server", (), {"artifact_root": root})()
+
+    translated = Path(handler.translate_path("/reports/pipeline/run1_dashboard.html"))
+
+    assert translated == (root / "reports" / "pipeline" / "run1_dashboard.html")
+
+
 def test_ensure_local_artifact_server_reraises_addrinuse_without_health_match(
     monkeypatch, tmp_path, reset_artifact_server
 ):

--- a/tests/mcp_server/test_local_artifact_server.py
+++ b/tests/mcp_server/test_local_artifact_server.py
@@ -65,6 +65,29 @@ def test_build_local_artifact_url_serves_paths_relative_to_exports_root(
     assert "/exports/" not in url
 
 
+def test_build_local_artifact_url_preserves_exports_prefix_outside_reports(
+    monkeypatch, tmp_path, reset_artifact_server
+):
+    root = tmp_path / "exports"
+    local_artifact = root / "data" / "run1.csv"
+    local_artifact.parent.mkdir(parents=True)
+    local_artifact.write_text("id,value\n1,a\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        artifact_server_module,
+        "get_local_artifact_server_status",
+        lambda: {
+            "running": True,
+            "base_url": "http://127.0.0.1:8765",
+            "root": str(root.resolve(strict=False)),
+        },
+    )
+
+    url = artifact_server_module.build_local_artifact_url(str(local_artifact))
+
+    assert url == "http://127.0.0.1:8765/exports/data/run1.csv"
+
+
 def test_translate_path_accepts_reports_prefix(tmp_path):
     root = tmp_path / "exports"
     handler = artifact_server_module._ArtifactRequestHandler.__new__(


### PR DESCRIPTION
## Summary
- fix local artifact URL generation so served dashboard links point at `/reports/...` instead of `/exports/reports/...`
- add focused artifact-server regressions for the generated URL shape and the bind-conflict path without a health match
- update user-facing guidance to show the correct localhost dashboard URL form

## What changed
- `build_local_artifact_url()` now returns `http://<host>:<port>/<relative path under exports>`
- this removes the doubled `/exports/` prefix that caused localhost dashboard links to 404 even though the artifact files existed
- added a regression proving a file under `exports/reports/...` maps to `http://127.0.0.1:8765/reports/...`
- added a regression that `ensure_local_artifact_server()` re-raises `EADDRINUSE` when the port is occupied and no compatible health response is present
- updated artifact-server guidance in:
  - `resource_hub/usage_guide.md`
  - `src/analyst_toolkit/mcp_server/tools/cockpit_content.py`

## Validation
- `pytest tests/mcp_server/test_local_artifact_server.py tests/mcp_server/test_destination_routing.py -q`
- `ruff check src/analyst_toolkit/mcp_server/local_artifact_server.py tests/mcp_server/test_local_artifact_server.py src/analyst_toolkit/mcp_server/tools/cockpit_content.py`
- `ruff format --check src/analyst_toolkit/mcp_server/local_artifact_server.py tests/mcp_server/test_local_artifact_server.py src/analyst_toolkit/mcp_server/tools/cockpit_content.py`

## Context
This is the first polish slice from the post-QA hardening queue and addresses issue #156.
