### PR TITLE
Harden artifact server occupied-port handling

### DIFF
--- a/resource_hub/mcp_server_guide.md
+++ b/resource_hub/mcp_server_guide.md
@@ -215,7 +215,7 @@ When diagnosing failures, use `trace_id` from the JSON-RPC error payload and cor
 | `get_cockpit_dashboard` | Operator hub HTML artifact — recent-run cards, module dashboard links, artifact rows, data dictionary preview |
 | `get_pipeline_dashboard` | Combined multi-module HTML dashboard for a specific `run_id`; linked from the cockpit hub |
 | `data_dictionary` | Column-level schema report as a standalone HTML artifact; preview surfaced in the cockpit dictionary tab |
-| `ensure_artifact_server` | Start/status the local artifact server — converts artifact file paths into browser-openable localhost URLs and returns `already_running=true` when the target server is already up |
+| `ensure_artifact_server` | Start/status the local artifact server — converts artifact file paths into browser-openable localhost URLs and returns `summary.already_running=true` only when a compatible artifact server is already running on the configured host/port |
 | `manage_session` | Session lifecycle: list active sessions, inspect details, fork a session into a new run context, or rebind a session to a different run_id |
 | `upload_input` | Upload a local file as base64-encoded content through the MCP protocol — use when the file is not server-visible (e.g., server runs in a container) |
 | `read_artifact` | Read a container-local artifact and return its content through MCP — use when localhost artifact URLs are not reachable from the client |
@@ -340,7 +340,7 @@ curl -X POST http://localhost:8001/rpc \
   }'
 ```
 
-The server binds to `127.0.0.1:8765` by default and serves the `exports/` directory. Artifact paths in subsequent tool responses will be replaced with `http://localhost:8765/...` URLs. If a compatible artifact server is already listening on that host/port, `ensure_artifact_server` returns a normal pass response with `summary.already_running=true` instead of failing on the occupied port.
+The server binds to `127.0.0.1:8765` by default and serves the `exports/` directory. Artifact paths in subsequent tool responses will be replaced with `http://localhost:8765/...` URLs. `ensure_artifact_server` performs an active health check against `GET /__health` on the configured host/port and only returns a normal pass response with `summary.already_running=true` when that server reports the same `base_url` and artifact-root path. If the port is occupied and the health check is missing or reports a different root/base URL, the tool returns `status=error` with `error_code=ARTIFACT_SERVER_BIND_CONFLICT` instead of adopting the other process.
 
 | Variable | Default | Description |
 |---|---|---|

--- a/src/analyst_toolkit/mcp_server/local_artifact_server.py
+++ b/src/analyst_toolkit/mcp_server/local_artifact_server.py
@@ -185,10 +185,28 @@ def _read_server_health(base_url: str, timeout_sec: float = 0.25) -> dict[str, A
     try:
         with urllib.request.urlopen(f"{base_url}/__health", timeout=timeout_sec) as response:
             if response.status != 200:
+                logger.debug(
+                    "Artifact server health probe to %s returned non-200 status %s",
+                    base_url,
+                    response.status,
+                )
                 return None
             payload = json.loads(response.read().decode("utf-8"))
-            return payload if isinstance(payload, dict) else None
-    except Exception:
+            if not isinstance(payload, dict):
+                logger.debug(
+                    "Artifact server health probe to %s returned non-dict payload %r",
+                    base_url,
+                    payload,
+                )
+                return None
+            return payload
+    except Exception as exc:
+        logger.debug(
+            "Artifact server health probe to %s failed (timeout=%ss): %s",
+            base_url,
+            timeout_sec,
+            exc,
+        )
         return None
 
 
@@ -253,14 +271,52 @@ def ensure_local_artifact_server() -> dict[str, Any]:
                 if exc.errno == errno.EADDRINUSE:
                     health = _read_server_health(base_url)
                     if health is not None:
+                        health_root = Path(str(health.get("root", ""))).resolve(strict=False)
+                        health_base_url = str(health.get("base_url", ""))
+                        expected_base_url = base_url
+                        if health_root == root and health_base_url == expected_base_url:
+                            return {
+                                "status": "pass",
+                                "enabled": True,
+                                "running": True,
+                                "already_running": True,
+                                "base_url": expected_base_url,
+                                "root": str(root),
+                            }
+                        logger.warning(
+                            "Artifact server port %s is occupied by an incompatible server "
+                            "(expected root=%s, base_url=%s; got root=%s, base_url=%s)",
+                            requested_port,
+                            root,
+                            expected_base_url,
+                            health_root,
+                            health_base_url,
+                        )
                         return {
-                            "status": "pass",
+                            "status": "error",
+                            "error_code": "ARTIFACT_SERVER_BIND_CONFLICT",
                             "enabled": True,
-                            "running": True,
-                            "already_running": True,
-                            "base_url": str(health.get("base_url") or base_url),
-                            "root": str(health.get("root") or root),
+                            "running": False,
+                            "already_running": False,
+                            "base_url": "",
+                            "root": str(root),
+                            "message": (
+                                "Artifact server port is already in use by an incompatible server."
+                            ),
                         }
+                    return {
+                        "status": "error",
+                        "error_code": "ARTIFACT_SERVER_BIND_CONFLICT",
+                        "enabled": True,
+                        "running": False,
+                        "already_running": False,
+                        "base_url": "",
+                        "root": str(root),
+                        "message": (
+                            "Artifact server port is already in use and no compatible health "
+                            "response was found."
+                        ),
+                    }
                 raise
             server.artifact_root = root
             # Advertise 127.0.0.1 in URLs even when bound to 0.0.0.0 —

--- a/tests/mcp_server/test_local_artifact_server.py
+++ b/tests/mcp_server/test_local_artifact_server.py
@@ -100,7 +100,7 @@ def test_translate_path_accepts_reports_prefix(tmp_path):
     assert translated == (root / "reports" / "pipeline" / "run1_dashboard.html")
 
 
-def test_ensure_local_artifact_server_reraises_addrinuse_without_health_match(
+def test_ensure_local_artifact_server_returns_conflict_without_health_match(
     monkeypatch, tmp_path, reset_artifact_server
 ):
     root = tmp_path / "exports"
@@ -121,8 +121,43 @@ def test_ensure_local_artifact_server_reraises_addrinuse_without_health_match(
         lambda *_args, **_kwargs: None,
     )
 
-    try:
-        artifact_server_module.ensure_local_artifact_server()
-        raise AssertionError("expected OSError")
-    except OSError as exc:
-        assert exc.errno == errno.EADDRINUSE
+    result = artifact_server_module.ensure_local_artifact_server()
+
+    assert result["status"] == "error"
+    assert result["error_code"] == "ARTIFACT_SERVER_BIND_CONFLICT"
+    assert result["already_running"] is False
+    assert result["base_url"] == ""
+    assert "no compatible health response" in result["message"]
+
+
+def test_ensure_local_artifact_server_returns_conflict_for_incompatible_health(
+    monkeypatch, tmp_path, reset_artifact_server
+):
+    root = tmp_path / "exports"
+    root.mkdir(parents=True)
+
+    monkeypatch.setenv("ANALYST_MCP_ENABLE_ARTIFACT_SERVER", "true")
+    monkeypatch.setenv("ANALYST_MCP_ARTIFACT_SERVER_HOST", "127.0.0.1")
+    monkeypatch.setenv("ANALYST_MCP_ARTIFACT_SERVER_PORT", "8765")
+    monkeypatch.setenv("ANALYST_MCP_ARTIFACT_SERVER_ROOT", str(root))
+    monkeypatch.setattr(
+        artifact_server_module,
+        "_ArtifactHTTPServer",
+        lambda *args, **kwargs: (_ for _ in ()).throw(OSError(errno.EADDRINUSE, "in use")),
+    )
+    monkeypatch.setattr(
+        artifact_server_module,
+        "_read_server_health",
+        lambda *_args, **_kwargs: {
+            "base_url": "http://127.0.0.1:8765",
+            "root": str((tmp_path / "other_exports").resolve(strict=False)),
+        },
+    )
+
+    result = artifact_server_module.ensure_local_artifact_server()
+
+    assert result["status"] == "error"
+    assert result["error_code"] == "ARTIFACT_SERVER_BIND_CONFLICT"
+    assert result["already_running"] is False
+    assert result["base_url"] == ""
+    assert "incompatible server" in result["message"]


### PR DESCRIPTION
## Summary
- validate occupied-port health responses before treating another process as the active artifact server
- return stable bind-conflict error payloads instead of trusting foreign `base_url` / `root` values or re-raising raw `OSError`
- document the exact compatibility rule for `summary.already_running`

## What changed
- `ensure_local_artifact_server()` now performs an explicit compatibility check when the port is occupied:
  - health probe must succeed
  - reported `root` must match the expected artifact root
  - reported `base_url` must match the expected base URL
- if any of those checks fail, the tool now returns:
  - `status=error`
  - `error_code=ARTIFACT_SERVER_BIND_CONFLICT`
  - `already_running=false`
- `_read_server_health()` now emits debug logs for non-200 responses, malformed payloads, and probe exceptions
- docs now consistently refer to `summary.already_running` and explain what counts as a compatible artifact server

## Validation
- `pytest tests/mcp_server/test_local_artifact_server.py tests/mcp_server/test_rpc_cockpit_guides.py -q`
- `ruff check src/analyst_toolkit/mcp_server/local_artifact_server.py tests/mcp_server/test_local_artifact_server.py`
- `ruff format --check src/analyst_toolkit/mcp_server/local_artifact_server.py tests/mcp_server/test_local_artifact_server.py`

## Context
This is the second polish slice from the post-QA hardening queue and addresses issue #155.
