### PR TITLE
Harden plot runtime cache configuration

### DIFF
--- a/src/analyst_toolkit/m00_utils/plot_runtime.py
+++ b/src/analyst_toolkit/m00_utils/plot_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import getpass
 import os
 import tempfile
 from pathlib import Path
@@ -10,33 +11,59 @@ from pathlib import Path
 def _is_writable_path(path: Path) -> bool:
     candidate = path.expanduser()
     if candidate.exists():
-        return os.access(candidate, os.W_OK | os.X_OK)
+        return candidate.is_dir() and os.access(candidate, os.W_OK | os.X_OK)
 
     parent = candidate.parent
     while not parent.exists() and parent != parent.parent:
         parent = parent.parent
+    if not parent.exists():
+        return False
     return os.access(parent, os.W_OK | os.X_OK)
 
 
 def configure_plot_runtime_env() -> None:
-    """Set writable cache directories for matplotlib/fontconfig when needed."""
+    """Set writable cache directories for matplotlib/fontconfig when needed.
 
-    fallback_root = Path(tempfile.gettempdir()) / "analyst_toolkit_cache"
+    This function may update ``os.environ["XDG_CACHE_HOME"]`` and
+    ``os.environ["MPLCONFIGDIR"]`` when the current values or their default
+    locations are unset or not writable. It only adjusts cache/config paths;
+    it does not alter plot styles, random seeds, timestamps, or other rendering
+    settings that would change deterministic plot output.
+
+    The temp-directory fallback is only used when the standard cache locations
+    (for example ``~/.cache`` or ``~/.matplotlib``) are not writable. Because
+    that fallback is machine-local, callers that need deterministic cache paths
+    across environments should set explicit writable values for
+    ``XDG_CACHE_HOME`` and ``MPLCONFIGDIR`` before importing plotting modules.
+    """
+
+    fallback_root = Path(tempfile.gettempdir()) / f"analyst_toolkit_cache_{getpass.getuser()}"
     fallback_root.mkdir(parents=True, exist_ok=True)
 
     xdg_cache_home = os.environ.get("XDG_CACHE_HOME", "").strip()
     if xdg_cache_home:
         xdg_cache_path = Path(xdg_cache_home).expanduser()
+        if not _is_writable_path(xdg_cache_path):
+            xdg_cache_path = fallback_root
+            os.environ["XDG_CACHE_HOME"] = str(xdg_cache_path)
     else:
         xdg_cache_path = Path.home() / ".cache"
         if not _is_writable_path(xdg_cache_path):
             xdg_cache_path = fallback_root
-            os.environ["XDG_CACHE_HOME"] = str(xdg_cache_path)
+        os.environ["XDG_CACHE_HOME"] = str(xdg_cache_path)
     xdg_cache_path.mkdir(parents=True, exist_ok=True)
 
     mpl_config_dir = os.environ.get("MPLCONFIGDIR", "").strip()
     if mpl_config_dir:
         mpl_config_path = Path(mpl_config_dir).expanduser()
+        if not _is_writable_path(mpl_config_path):
+            default_mpl_path = Path.home() / ".matplotlib"
+            mpl_config_path = (
+                default_mpl_path
+                if _is_writable_path(default_mpl_path)
+                else (xdg_cache_path / "matplotlib")
+            )
+            os.environ["MPLCONFIGDIR"] = str(mpl_config_path)
     else:
         default_mpl_path = Path.home() / ".matplotlib"
         mpl_config_path = (

--- a/src/analyst_toolkit/m05_detect_outliers/plot_outliers.py
+++ b/src/analyst_toolkit/m05_detect_outliers/plot_outliers.py
@@ -14,6 +14,8 @@ from pathlib import Path
 
 from analyst_toolkit.m00_utils.plot_runtime import configure_plot_runtime_env
 
+# Configure writable matplotlib/fontconfig cache paths before pyplot import.
+# This call is idempotent and does not change plot styles or RNG state.
 configure_plot_runtime_env()
 
 import matplotlib.pyplot as plt

--- a/src/analyst_toolkit/m08_visuals/comparison_plots.py
+++ b/src/analyst_toolkit/m08_visuals/comparison_plots.py
@@ -18,6 +18,8 @@ from pathlib import Path
 
 from analyst_toolkit.m00_utils.plot_runtime import configure_plot_runtime_env
 
+# Configure writable matplotlib/fontconfig cache paths before pyplot import.
+# This call is idempotent and does not change plot styles or RNG state.
 configure_plot_runtime_env()
 
 import matplotlib.pyplot as plt

--- a/src/analyst_toolkit/m08_visuals/distributions.py
+++ b/src/analyst_toolkit/m08_visuals/distributions.py
@@ -17,6 +17,8 @@ from pathlib import Path
 
 from analyst_toolkit.m00_utils.plot_runtime import configure_plot_runtime_env
 
+# Configure writable matplotlib/fontconfig cache paths before pyplot import.
+# This call is idempotent and does not change plot styles or RNG state.
 configure_plot_runtime_env()
 
 import matplotlib.pyplot as plt

--- a/src/analyst_toolkit/m08_visuals/summary_plots.py
+++ b/src/analyst_toolkit/m08_visuals/summary_plots.py
@@ -18,6 +18,8 @@ from pathlib import Path
 
 from analyst_toolkit.m00_utils.plot_runtime import configure_plot_runtime_env
 
+# Configure writable matplotlib/fontconfig cache paths before pyplot import.
+# This call is idempotent and does not change plot styles or RNG state.
 configure_plot_runtime_env()
 
 import matplotlib.pyplot as plt

--- a/tests/m00_utils/test_plot_runtime.py
+++ b/tests/m00_utils/test_plot_runtime.py
@@ -47,8 +47,12 @@ def test_configure_plot_runtime_env_uses_existing_xdg_cache_when_mpl_is_unset(
 
     configure_plot_runtime_env()
 
+    expected_mpl_dir = Path.home() / ".matplotlib"
+    if not expected_mpl_dir.is_dir() or not os.access(expected_mpl_dir, os.W_OK | os.X_OK):
+        expected_mpl_dir = xdg_dir / "matplotlib"
+
     assert os.environ["XDG_CACHE_HOME"] == str(xdg_dir)
-    assert os.environ["MPLCONFIGDIR"] == str(xdg_dir / "matplotlib")
+    assert os.environ["MPLCONFIGDIR"] == str(expected_mpl_dir)
     assert Path(os.environ["MPLCONFIGDIR"]).exists()
 
 

--- a/tests/m00_utils/test_plot_runtime.py
+++ b/tests/m00_utils/test_plot_runtime.py
@@ -2,7 +2,10 @@ import os
 import tempfile
 from pathlib import Path
 
-from analyst_toolkit.m00_utils.plot_runtime import configure_plot_runtime_env
+from analyst_toolkit.m00_utils.plot_runtime import (
+    _is_writable_path,
+    configure_plot_runtime_env,
+)
 
 
 def test_configure_plot_runtime_env_uses_writable_tmp_cache(monkeypatch, tmp_path):
@@ -48,7 +51,7 @@ def test_configure_plot_runtime_env_uses_existing_xdg_cache_when_mpl_is_unset(
     configure_plot_runtime_env()
 
     expected_mpl_dir = Path.home() / ".matplotlib"
-    if not expected_mpl_dir.is_dir() or not os.access(expected_mpl_dir, os.W_OK | os.X_OK):
+    if not _is_writable_path(expected_mpl_dir):
         expected_mpl_dir = xdg_dir / "matplotlib"
 
     assert os.environ["XDG_CACHE_HOME"] == str(xdg_dir)

--- a/tests/m00_utils/test_plot_runtime.py
+++ b/tests/m00_utils/test_plot_runtime.py
@@ -9,15 +9,18 @@ def test_configure_plot_runtime_env_uses_writable_tmp_cache(monkeypatch, tmp_pat
     fake_home = tmp_path / "fake_home"
     fake_home.mkdir()
     fake_home.chmod(0o500)
-    monkeypatch.setenv("HOME", str(fake_home))
-    monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
-    monkeypatch.delenv("MPLCONFIGDIR", raising=False)
+    try:
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.delenv("XDG_CACHE_HOME", raising=False)
+        monkeypatch.delenv("MPLCONFIGDIR", raising=False)
 
-    configure_plot_runtime_env()
+        configure_plot_runtime_env()
 
-    assert os.environ["XDG_CACHE_HOME"].startswith(tempfile.gettempdir())
-    assert os.environ["MPLCONFIGDIR"].startswith(os.environ["XDG_CACHE_HOME"])
-    assert Path(os.environ["MPLCONFIGDIR"]).exists()
+        assert os.environ["XDG_CACHE_HOME"].startswith(tempfile.gettempdir())
+        assert os.environ["MPLCONFIGDIR"].startswith(os.environ["XDG_CACHE_HOME"])
+        assert Path(os.environ["MPLCONFIGDIR"]).exists()
+    finally:
+        fake_home.chmod(0o700)
 
 
 def test_configure_plot_runtime_env_respects_existing_settings(monkeypatch, tmp_path):
@@ -32,3 +35,41 @@ def test_configure_plot_runtime_env_respects_existing_settings(monkeypatch, tmp_
 
     assert os.environ["XDG_CACHE_HOME"] == str(xdg_dir)
     assert os.environ["MPLCONFIGDIR"] == str(mpl_dir)
+
+
+def test_configure_plot_runtime_env_uses_existing_xdg_cache_when_mpl_is_unset(
+    monkeypatch, tmp_path
+):
+    xdg_dir = tmp_path / "cache"
+    xdg_dir.mkdir()
+    monkeypatch.setenv("XDG_CACHE_HOME", str(xdg_dir))
+    monkeypatch.delenv("MPLCONFIGDIR", raising=False)
+
+    configure_plot_runtime_env()
+
+    assert os.environ["XDG_CACHE_HOME"] == str(xdg_dir)
+    assert os.environ["MPLCONFIGDIR"] == str(xdg_dir / "matplotlib")
+    assert Path(os.environ["MPLCONFIGDIR"]).exists()
+
+
+def test_configure_plot_runtime_env_falls_back_when_user_paths_are_unwritable(
+    monkeypatch, tmp_path
+):
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir()
+    fake_home.chmod(0o500)
+    bad_cache = fake_home / "missing_cache"
+    bad_mpl = fake_home / "missing_mpl"
+
+    try:
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setenv("XDG_CACHE_HOME", str(bad_cache))
+        monkeypatch.setenv("MPLCONFIGDIR", str(bad_mpl))
+
+        configure_plot_runtime_env()
+
+        assert os.environ["XDG_CACHE_HOME"].startswith(tempfile.gettempdir())
+        assert os.environ["MPLCONFIGDIR"].startswith(os.environ["XDG_CACHE_HOME"])
+        assert Path(os.environ["MPLCONFIGDIR"]).exists()
+    finally:
+        fake_home.chmod(0o700)


### PR DESCRIPTION
## Summary
- harden plot-runtime cache path handling for unwritable or partially configured environments
- document the process-wide environment side effects and deterministic implications of the runtime helper
- annotate the import-time plotting bootstrap so the behavior is explicit in the shared plotting modules

## What changed
- `configure_plot_runtime_env()` now:
  - validates user-provided `XDG_CACHE_HOME` and `MPLCONFIGDIR` for writability
  - falls back to a per-user temp cache root only when the standard or configured paths are not writable
  - documents that it only changes cache/config directories, not plot styling or RNG state
- `_is_writable_path()` now rejects existing non-directory paths and returns `False` if no existing writable ancestor can be found
- added focused tests for:
  - writable-temp fallback when the home cache is not writable
  - respecting existing writable settings
  - partial configuration (`XDG_CACHE_HOME` set, `MPLCONFIGDIR` unset)
  - user-provided unwritable env paths
- added concise comments above the import-time `configure_plot_runtime_env()` calls in the shared plotting modules to explain why they run before pyplot import and that they are idempotent

## Validation
- `pytest tests/m00_utils/test_plot_runtime.py -q`
- `ruff check src/analyst_toolkit/m00_utils/plot_runtime.py tests/m00_utils/test_plot_runtime.py src/analyst_toolkit/m08_visuals/comparison_plots.py src/analyst_toolkit/m08_visuals/summary_plots.py src/analyst_toolkit/m08_visuals/distributions.py src/analyst_toolkit/m05_detect_outliers/plot_outliers.py`
- `ruff format --check src/analyst_toolkit/m00_utils/plot_runtime.py tests/m00_utils/test_plot_runtime.py src/analyst_toolkit/m08_visuals/comparison_plots.py src/analyst_toolkit/m08_visuals/summary_plots.py src/analyst_toolkit/m08_visuals/distributions.py src/analyst_toolkit/m05_detect_outliers/plot_outliers.py`

## Context
This is the final polish slice from the post-QA hardening queue and addresses issue #154.
