### PR TITLE
Harden MCP retry idempotency

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,8 +199,15 @@ Notes:
 - If you set a non-loopback host, set `ANALYST_MCP_AUTH_TOKEN` as an operator policy. Current runtime behavior warns when the token is unset; it does not hard-fail startup.
 - The artifact server is also localhost-first by default and should only be widened deliberately.
 - `ANALYST_MCP_SESSION_BACKEND=sqlite` writes durable session state to the local filesystem. By default the database lives in a private user-local state directory, not under `exports/`. Treat that as an explicit trust-boundary expansion: keep filesystem permissions narrow and prefer the default memory backend unless operators intentionally want restart-persistent sessions.
+- In stdio/local mode, run one `analyst_toolkit` MCP server instance per client. Repeated reconnects can orphan extra stdio workers, which can make session visibility and input bindings look inconsistent during QA. If behavior looks split-brain, restart the client and terminate stale `python -m analyst_toolkit.mcp_server.server --stdio` processes before retesting.
 
 > See [📡 MCP Server Guide](resource_hub/mcp_server_guide.md) for full setup, tool reference, FridAI integration, Claude Desktop wiring, and environment variable reference.
+
+### MCP Retry Semantics
+
+- `register_input` and `upload_input` are input-idempotent when you provide a stable `idempotency_key`.
+- If `load_into_session=true` and you do not provide an explicit `session_id`, anonymous retries now reuse the existing live bound session for that canonical input instead of minting a new session each time.
+- Repeating the same-run module and dashboard calls now reuses the primary remote artifact object when it already exists. Versioned fallback object names are reserved for true first-write collisions or permission failures, not normal retries.
 
 ---
 

--- a/resource_hub/mcp_server_guide.md
+++ b/resource_hub/mcp_server_guide.md
@@ -231,6 +231,11 @@ Every tool accepts either a `gcs_path`/file path **or** a `session_id`. When a t
 For this release, session persistence defaults to **in-memory only**, but a durable SQLite-backed session store is available via `ANALYST_MCP_SESSION_BACKEND=sqlite`. In both modes, sessions are still bounded by `ANALYST_MCP_SESSION_TTL_SEC` and `ANALYST_MCP_SESSION_MAX_ENTRIES`: cleanup is enforced lazily on session reads, writes, and explicit `manage_session` / `cleanup` activity, so SQLite sessions can survive process restarts while still expiring or being evicted once the server touches the store again. `manage_session` surfaces the live retention policy plus per-session expiry timestamps.
 Use `manage_session(action="inspect", include_configs=true)` when you need the stored inferred config payloads; the default inspect/list responses stay compact and only include config names/counts.
 
+Retry contract:
+- `register_input` and `upload_input` are input-idempotent when you provide a stable `idempotency_key`.
+- If `load_into_session=true` and no explicit `session_id` is supplied, anonymous retries reuse the existing live bound session for that canonical `input_id` instead of allocating a fresh session on every retry.
+- Repeating the same-run module or dashboard call now reuses the primary remote artifact object when it already exists. UUID-suffixed fallback objects are reserved for true first-write collisions or permission failures, not normal retries.
+
 ```text
 1. diagnostics(gcs_path="gs://bucket/path/file.parquet", run_id="my_run")
      → creates session_id: "sess_abc123", establishes baseline profile
@@ -661,6 +666,9 @@ Add to `~/.config/claude/claude_desktop_config.json` (Mac: `~/Library/Applicatio
   }
 }
 ```
+
+Operational note:
+- In stdio/local mode, keep one `analyst_toolkit` MCP server instance per client. Repeated reconnects can orphan extra `python -m analyst_toolkit.mcp_server.server --stdio` workers, which can make session visibility and input bindings look inconsistent because some MCP state is still process-local. If behavior looks split-brain during QA, terminate stale stdio workers and relaunch one clean instance before debugging tool behavior.
 
 ### FridAI (HTTP Transport)
 

--- a/src/analyst_toolkit/mcp_server/input/ingest.py
+++ b/src/analyst_toolkit/mcp_server/input/ingest.py
@@ -10,7 +10,7 @@ from pathlib import Path
 import pandas as pd
 
 from analyst_toolkit.mcp_server.input.adapters import resolve_source_reference
-from analyst_toolkit.mcp_server.input.errors import InputNotFoundError
+from analyst_toolkit.mcp_server.input.errors import InputConflictError, InputNotFoundError
 from analyst_toolkit.mcp_server.input.loaders import load_dataframe_from_descriptor
 from analyst_toolkit.mcp_server.input.models import (
     INPUT_ID_HEX_LENGTH,
@@ -68,6 +68,16 @@ def _reuse_live_bound_session_id(
     return existing_descriptor.session_id
 
 
+def _ensure_descriptor_compatible(descriptor: InputDescriptor) -> None:
+    """Abort idempotent retries before mutating session state on descriptor mismatch."""
+    existing_descriptor = get_descriptor(descriptor.input_id)
+    if existing_descriptor is None:
+        return
+    if existing_descriptor.same_canonical_input(descriptor):
+        return
+    raise InputConflictError(f"Conflicting descriptor for input_id '{descriptor.input_id}'.")
+
+
 def ingest_uploaded_bytes(
     *,
     filename: str,
@@ -98,6 +108,7 @@ def ingest_uploaded_bytes(
         session_id=session_id,
         run_id=run_id,
     )
+    _ensure_descriptor_compatible(descriptor)
     df: pd.DataFrame | None = None
     effective_session_id = session_id
     if load_into_session:
@@ -150,6 +161,7 @@ def register_input_source(
         session_id=session_id,
         run_id=run_id,
     )
+    _ensure_descriptor_compatible(descriptor)
     df: pd.DataFrame | None = None
     effective_session_id = session_id
     if load_into_session:

--- a/src/analyst_toolkit/mcp_server/input/ingest.py
+++ b/src/analyst_toolkit/mcp_server/input/ingest.py
@@ -45,6 +45,25 @@ def get_input_descriptor(input_id: str) -> InputDescriptor | None:
     return get_descriptor(input_id)
 
 
+def _reuse_live_bound_session_id(
+    *,
+    input_id: str,
+    requested_session_id: str | None,
+) -> str | None:
+    """Reuse an existing bound session for anonymous idempotent retries."""
+    if requested_session_id is not None:
+        return requested_session_id
+
+    existing_descriptor = get_descriptor(input_id)
+    if existing_descriptor is None or existing_descriptor.session_id is None:
+        return None
+
+    if StateStore.get_metadata(existing_descriptor.session_id) is None:
+        return None
+
+    return existing_descriptor.session_id
+
+
 def ingest_uploaded_bytes(
     *,
     filename: str,
@@ -62,8 +81,9 @@ def ingest_uploaded_bytes(
     Full run/session idempotency still requires callers to provide stable session_id/run_id.
     """
     staged_path, digest, size = stage_uploaded_file(filename=filename, payload=payload)
+    input_id = _new_input_id(idempotency_key or f"upload:{Path(filename).name}:{digest}")
     descriptor = InputDescriptor(
-        input_id=_new_input_id(idempotency_key or f"upload:{Path(filename).name}:{digest}"),
+        input_id=input_id,
         source_type="upload",
         original_reference=filename,
         resolved_reference=str(staged_path),
@@ -77,8 +97,16 @@ def ingest_uploaded_bytes(
     df: pd.DataFrame | None = None
     effective_session_id = session_id
     if load_into_session:
+        effective_session_id = _reuse_live_bound_session_id(
+            input_id=input_id,
+            requested_session_id=session_id,
+        )
         df = load_dataframe_from_descriptor(descriptor)
-        effective_session_id = StateStore.save(df, session_id=session_id, run_id=run_id)
+        effective_session_id = StateStore.save(
+            df,
+            session_id=effective_session_id,
+            run_id=run_id,
+        )
         descriptor = descriptor.with_runtime_binding(
             session_id=effective_session_id,
             run_id=run_id,
@@ -107,8 +135,9 @@ def register_input_source(
     resolved_type, resolved_reference, display_name = resolve_source_reference(
         reference, source_type
     )
+    input_id = _new_input_id(idempotency_key or f"source:{resolved_reference}")
     descriptor = InputDescriptor(
-        input_id=_new_input_id(idempotency_key or f"source:{resolved_reference}"),
+        input_id=input_id,
         source_type=resolved_type,
         original_reference=reference,
         resolved_reference=resolved_reference,
@@ -120,8 +149,16 @@ def register_input_source(
     df: pd.DataFrame | None = None
     effective_session_id = session_id
     if load_into_session:
+        effective_session_id = _reuse_live_bound_session_id(
+            input_id=input_id,
+            requested_session_id=session_id,
+        )
         df = load_dataframe_from_descriptor(descriptor)
-        effective_session_id = StateStore.save(df, session_id=session_id, run_id=run_id)
+        effective_session_id = StateStore.save(
+            df,
+            session_id=effective_session_id,
+            run_id=run_id,
+        )
         descriptor = descriptor.with_runtime_binding(
             session_id=effective_session_id,
             run_id=run_id,

--- a/src/analyst_toolkit/mcp_server/input/ingest.py
+++ b/src/analyst_toolkit/mcp_server/input/ingest.py
@@ -58,6 +58,10 @@ def _reuse_live_bound_session_id(
     if existing_descriptor is None or existing_descriptor.session_id is None:
         return None
 
+    bound_input_id = get_session_input_id(existing_descriptor.session_id)
+    if bound_input_id != input_id:
+        return None
+
     if StateStore.get_metadata(existing_descriptor.session_id) is None:
         return None
 

--- a/src/analyst_toolkit/mcp_server/io_storage.py
+++ b/src/analyst_toolkit/mcp_server/io_storage.py
@@ -39,23 +39,14 @@ def _gcs_uri(bucket_name: str, blob_path: str) -> str:
 def _blob_exists(bucket: object, blob_path: str) -> bool:
     get_blob = getattr(bucket, "get_blob", None)
     if callable(get_blob):
-        try:
-            return get_blob(blob_path) is not None
-        except Exception:
-            return False
+        return get_blob(blob_path) is not None
 
     blob_factory = getattr(bucket, "blob", None)
     if callable(blob_factory):
-        try:
-            blob = blob_factory(blob_path)
-        except Exception:
-            return False
+        blob = blob_factory(blob_path)
         exists = getattr(blob, "exists", None)
         if callable(exists):
-            try:
-                return bool(exists())
-            except Exception:
-                return False
+            return bool(exists())
     return False
 
 

--- a/src/analyst_toolkit/mcp_server/io_storage.py
+++ b/src/analyst_toolkit/mcp_server/io_storage.py
@@ -256,8 +256,6 @@ def save_output(df: pd.DataFrame, path: str) -> str:
 
                 client = storage.Client()
                 bucket = client.bucket(bucket_name)
-                if _blob_exists(bucket, blob_path):
-                    return _gcs_uri(bucket_name, blob_path)
                 blob = bucket.blob(blob_path)
                 try:
                     blob.upload_from_filename(tmp_path, content_type=content_type)
@@ -338,8 +336,6 @@ def upload_artifact(
         blob.upload_from_filename(str(p), content_type=content_type)
         return _gcs_url(bucket_name, path)
 
-    if _blob_exists(bucket, blob_path):
-        return _gcs_url(bucket_name, blob_path)
     try:
         return _upload(blob_path)
     except Exception as first_exc:

--- a/src/analyst_toolkit/mcp_server/io_storage.py
+++ b/src/analyst_toolkit/mcp_server/io_storage.py
@@ -28,6 +28,37 @@ _CONTENT_TYPES = {
 }
 
 
+def _gcs_url(bucket_name: str, blob_path: str) -> str:
+    return f"https://storage.googleapis.com/{bucket_name}/{blob_path}"
+
+
+def _gcs_uri(bucket_name: str, blob_path: str) -> str:
+    return f"gs://{bucket_name}/{blob_path}"
+
+
+def _blob_exists(bucket: object, blob_path: str) -> bool:
+    get_blob = getattr(bucket, "get_blob", None)
+    if callable(get_blob):
+        try:
+            return get_blob(blob_path) is not None
+        except Exception:
+            return False
+
+    blob_factory = getattr(bucket, "blob", None)
+    if callable(blob_factory):
+        try:
+            blob = blob_factory(blob_path)
+        except Exception:
+            return False
+        exists = getattr(blob, "exists", None)
+        if callable(exists):
+            try:
+                return bool(exists())
+            except Exception:
+                return False
+    return False
+
+
 def _read_csv_with_limits(path: Path, *, reference: str) -> pd.DataFrame:
     return materialize_chunked_frames(
         pd.read_csv(path, low_memory=False, chunksize=50_000),
@@ -225,10 +256,14 @@ def save_output(df: pd.DataFrame, path: str) -> str:
 
                 client = storage.Client()
                 bucket = client.bucket(bucket_name)
+                if _blob_exists(bucket, blob_path):
+                    return _gcs_uri(bucket_name, blob_path)
                 blob = bucket.blob(blob_path)
                 try:
                     blob.upload_from_filename(tmp_path, content_type=content_type)
                 except Exception as first_exc:
+                    if _blob_exists(bucket, blob_path):
+                        return _gcs_uri(bucket_name, blob_path)
                     alt_blob_path = _versioned_blob_path(blob_path)
                     alt_blob = bucket.blob(alt_blob_path)
                     try:
@@ -301,11 +336,15 @@ def upload_artifact(
     def _upload(path: str) -> str:
         blob = bucket.blob(path)
         blob.upload_from_filename(str(p), content_type=content_type)
-        return f"https://storage.googleapis.com/{bucket_name}/{path}"
+        return _gcs_url(bucket_name, path)
 
+    if _blob_exists(bucket, blob_path):
+        return _gcs_url(bucket_name, blob_path)
     try:
         return _upload(blob_path)
     except Exception as first_exc:
+        if _blob_exists(bucket, blob_path):
+            return _gcs_url(bucket_name, blob_path)
         # Fallback for idempotent reruns where same-key overwrite/delete permissions vary.
         alt_name = f"{p.stem}_{uuid4().hex[:8]}{p.suffix}"
         alt_path = f"{prefix}/{path_root}/{module}/{alt_name}"

--- a/tests/hardening/test_config_and_upload.py
+++ b/tests/hardening/test_config_and_upload.py
@@ -1,6 +1,8 @@
 import sys
 import types
 
+import pytest
+
 from analyst_toolkit.mcp_server.io import (
     check_upload,
     coerce_config,
@@ -9,7 +11,7 @@ from analyst_toolkit.mcp_server.io import (
     save_output,
     upload_artifact,
 )
-from analyst_toolkit.mcp_server.io_storage import should_export_html
+from analyst_toolkit.mcp_server.io_storage import _blob_exists, should_export_html
 from analyst_toolkit.mcp_server.state import StateStore
 
 
@@ -106,7 +108,7 @@ def test_should_export_html_honors_nested_module_config(monkeypatch):
     assert should_export_html({"normalization": {"settings": {"export_html": ["true"]}}}) is False
 
 
-def _install_fake_google_storage(monkeypatch, calls: list):
+def _install_fake_google_storage(monkeypatch, calls: list, *, fail_on_existing: bool = False):
     existing_blobs: set[str] = set()
 
     class FakeBlob:
@@ -115,6 +117,8 @@ def _install_fake_google_storage(monkeypatch, calls: list):
 
         def upload_from_filename(self, filename: str, content_type: str | None = None):
             calls.append(("upload", self.name, content_type, filename))
+            if fail_on_existing and self.name in existing_blobs:
+                raise FileExistsError(f"blob already exists: {self.name}")
             existing_blobs.add(self.name)
 
         def exists(self):
@@ -170,7 +174,7 @@ def test_save_output_gcs_uses_storage_upload(sample_df, monkeypatch):
 
 def test_save_output_gcs_is_idempotent_for_same_path(sample_df, monkeypatch):
     calls: list = []
-    _install_fake_google_storage(monkeypatch, calls)
+    _install_fake_google_storage(monkeypatch, calls, fail_on_existing=True)
 
     path = "gs://example-bucket/runs/shared_run/imputation_output.csv"
     out_one = save_output(sample_df, path)
@@ -182,6 +186,7 @@ def test_save_output_gcs_is_idempotent_for_same_path(sample_df, monkeypatch):
     assert len(uploads) == 2
     assert uploads[0][1] == "runs/shared_run/imputation_output.csv"
     assert uploads[1][1] == "runs/shared_run/imputation_output.csv"
+    assert not any(call[1].startswith("runs/shared_run/imputation_output_") for call in uploads)
 
 
 def test_save_output_gcs_falls_back_to_versioned_key_on_primary_failure(sample_df, monkeypatch):
@@ -316,6 +321,8 @@ def test_upload_artifact_reuses_existing_remote_object_for_same_path(monkeypatch
 
         def upload_from_filename(self, filename: str, content_type: str | None = None):
             upload_calls.append(self.name)
+            if self.name in existing_blobs:
+                raise FileExistsError(f"blob already exists: {self.name}")
             existing_blobs.add(self.name)
 
         def exists(self):
@@ -363,3 +370,12 @@ def test_upload_artifact_reuses_existing_remote_object_for_same_path(monkeypatch
     assert out_one == out_two
     assert len(upload_calls) == 2
     assert upload_calls[0] == upload_calls[1]
+
+
+def test_blob_exists_propagates_lookup_errors():
+    class BrokenBucket:
+        def get_blob(self, _blob_name: str):
+            raise PermissionError("denied")
+
+    with pytest.raises(PermissionError):
+        _blob_exists(BrokenBucket(), "reports/run/report.html")

--- a/tests/hardening/test_config_and_upload.py
+++ b/tests/hardening/test_config_and_upload.py
@@ -107,12 +107,19 @@ def test_should_export_html_honors_nested_module_config(monkeypatch):
 
 
 def _install_fake_google_storage(monkeypatch, calls: list):
+    existing_blobs: set[str] = set()
+
     class FakeBlob:
         def __init__(self, name: str):
             self.name = name
 
         def upload_from_filename(self, filename: str, content_type: str | None = None):
             calls.append(("upload", self.name, content_type, filename))
+            existing_blobs.add(self.name)
+
+        def exists(self):
+            calls.append(("exists", self.name))
+            return self.name in existing_blobs
 
     class FakeBucket:
         def __init__(self, name: str):
@@ -121,6 +128,10 @@ def _install_fake_google_storage(monkeypatch, calls: list):
         def blob(self, blob_name: str):
             calls.append(("blob", self.name, blob_name))
             return FakeBlob(blob_name)
+
+        def get_blob(self, blob_name: str):
+            calls.append(("get_blob", self.name, blob_name))
+            return FakeBlob(blob_name) if blob_name in existing_blobs else None
 
     class FakeClient:
         def bucket(self, bucket_name: str):
@@ -166,9 +177,8 @@ def test_save_output_gcs_is_idempotent_for_same_path(sample_df, monkeypatch):
     save_output(sample_df, path)
 
     uploads = [c for c in calls if c[0] == "upload"]
-    assert len(uploads) == 2
+    assert len(uploads) == 1
     assert uploads[0][1] == "runs/shared_run/imputation_output.csv"
-    assert uploads[1][1] == "runs/shared_run/imputation_output.csv"
 
 
 def test_save_output_gcs_falls_back_to_versioned_key_on_primary_failure(sample_df, monkeypatch):
@@ -288,3 +298,64 @@ def test_upload_artifact_falls_back_to_versioned_key_on_primary_failure(monkeypa
     assert upload_calls[0].endswith("/imputation/report.html")
     assert upload_calls[1].endswith(".html")
     assert upload_calls[1] != upload_calls[0]
+
+
+def test_upload_artifact_reuses_existing_remote_object_for_same_path(monkeypatch, tmp_path):
+    local = tmp_path / "report.html"
+    local.write_text("<html>ok</html>", encoding="utf-8")
+
+    upload_calls: list[str] = []
+    existing_blobs: set[str] = set()
+
+    class FakeBlob:
+        def __init__(self, name: str):
+            self.name = name
+
+        def upload_from_filename(self, filename: str, content_type: str | None = None):
+            upload_calls.append(self.name)
+            existing_blobs.add(self.name)
+
+        def exists(self):
+            return self.name in existing_blobs
+
+    class FakeBucket:
+        def __init__(self, name: str):
+            self.name = name
+
+        def blob(self, blob_name: str):
+            return FakeBlob(blob_name)
+
+        def get_blob(self, blob_name: str):
+            return FakeBlob(blob_name) if blob_name in existing_blobs else None
+
+    class FakeClient:
+        def bucket(self, bucket_name: str):
+            return FakeBucket(bucket_name)
+
+    storage_mod = types.ModuleType("google.cloud.storage")
+    setattr(storage_mod, "Client", FakeClient)
+    cloud_mod = types.ModuleType("google.cloud")
+    setattr(cloud_mod, "storage", storage_mod)
+    google_mod = types.ModuleType("google")
+    setattr(google_mod, "cloud", cloud_mod)
+    monkeypatch.setitem(sys.modules, "google", google_mod)
+    monkeypatch.setitem(sys.modules, "google.cloud", cloud_mod)
+    monkeypatch.setitem(sys.modules, "google.cloud.storage", storage_mod)
+    monkeypatch.setenv("ANALYST_REPORT_BUCKET", "gs://example-bucket")
+    monkeypatch.setenv("ANALYST_REPORT_PREFIX", "analyst_toolkit/reports")
+
+    out_one = upload_artifact(
+        local_path=str(local),
+        run_id="run_retry",
+        module="imputation",
+        session_id="sess_retry",
+    )
+    out_two = upload_artifact(
+        local_path=str(local),
+        run_id="run_retry",
+        module="imputation",
+        session_id="sess_retry",
+    )
+
+    assert out_one == out_two
+    assert len(upload_calls) == 1

--- a/tests/hardening/test_config_and_upload.py
+++ b/tests/hardening/test_config_and_upload.py
@@ -173,12 +173,15 @@ def test_save_output_gcs_is_idempotent_for_same_path(sample_df, monkeypatch):
     _install_fake_google_storage(monkeypatch, calls)
 
     path = "gs://example-bucket/runs/shared_run/imputation_output.csv"
-    save_output(sample_df, path)
-    save_output(sample_df, path)
+    out_one = save_output(sample_df, path)
+    out_two = save_output(sample_df, path)
 
+    assert out_one == path
+    assert out_two == path
     uploads = [c for c in calls if c[0] == "upload"]
-    assert len(uploads) == 1
+    assert len(uploads) == 2
     assert uploads[0][1] == "runs/shared_run/imputation_output.csv"
+    assert uploads[1][1] == "runs/shared_run/imputation_output.csv"
 
 
 def test_save_output_gcs_falls_back_to_versioned_key_on_primary_failure(sample_df, monkeypatch):
@@ -358,4 +361,5 @@ def test_upload_artifact_reuses_existing_remote_object_for_same_path(monkeypatch
     )
 
     assert out_one == out_two
-    assert len(upload_calls) == 1
+    assert len(upload_calls) == 2
+    assert upload_calls[0] == upload_calls[1]

--- a/tests/m00_utils/test_plot_runtime.py
+++ b/tests/m00_utils/test_plot_runtime.py
@@ -2,10 +2,7 @@ import os
 import tempfile
 from pathlib import Path
 
-from analyst_toolkit.m00_utils.plot_runtime import (
-    _is_writable_path,
-    configure_plot_runtime_env,
-)
+from analyst_toolkit.m00_utils.plot_runtime import configure_plot_runtime_env
 
 
 def test_configure_plot_runtime_env_uses_writable_tmp_cache(monkeypatch, tmp_path):
@@ -43,16 +40,17 @@ def test_configure_plot_runtime_env_respects_existing_settings(monkeypatch, tmp_
 def test_configure_plot_runtime_env_uses_existing_xdg_cache_when_mpl_is_unset(
     monkeypatch, tmp_path
 ):
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir()
     xdg_dir = tmp_path / "cache"
     xdg_dir.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
     monkeypatch.setenv("XDG_CACHE_HOME", str(xdg_dir))
     monkeypatch.delenv("MPLCONFIGDIR", raising=False)
 
     configure_plot_runtime_env()
 
-    expected_mpl_dir = Path.home() / ".matplotlib"
-    if not _is_writable_path(expected_mpl_dir):
-        expected_mpl_dir = xdg_dir / "matplotlib"
+    expected_mpl_dir = fake_home / ".matplotlib"
 
     assert os.environ["XDG_CACHE_HOME"] == str(xdg_dir)
     assert os.environ["MPLCONFIGDIR"] == str(expected_mpl_dir)

--- a/tests/mcp_server/test_input_ingest.py
+++ b/tests/mcp_server/test_input_ingest.py
@@ -130,6 +130,50 @@ def test_inputs_upload_reuses_session_for_anonymous_idempotent_retry(client, cle
     assert response_one.json()["session_id"] == response_two.json()["session_id"]
 
 
+def test_inputs_upload_conflict_does_not_mutate_original_session_or_descriptor(
+    client, clean_input_env
+):
+    response_one = client.post(
+        "/inputs/upload",
+        files={
+            "file": ("dirty_penguins.csv", b"species,bill_length_mm\nAdelie,39.1\n", "text/csv")
+        },
+        data={
+            "load_into_session": "true",
+            "idempotency_key": "stable-upload-conflict",
+            "run_id": "retry_upload_conflict_run",
+        },
+    )
+    assert response_one.status_code == 200
+    payload_one = response_one.json()
+    input_id = payload_one["input"]["input_id"]
+    session_id = payload_one["session_id"]
+
+    response_two = client.post(
+        "/inputs/upload",
+        files={
+            "file": ("dirty_penguins.csv", b"species,bill_length_mm\nGentoo,46.5\n", "text/csv")
+        },
+        data={
+            "load_into_session": "true",
+            "idempotency_key": "stable-upload-conflict",
+            "run_id": "retry_upload_conflict_run",
+        },
+    )
+
+    assert response_two.status_code == 409
+    detail = response_two.json()["detail"]
+    assert detail["code"] == "INPUT_CONFLICT"
+    assert input_registry.get_session_input_id(session_id) == input_id
+    descriptor = input_registry.get_descriptor(input_id)
+    assert descriptor is not None
+    assert descriptor.sha256 == payload_one["input"]["sha256"]
+    assert descriptor.session_id == session_id
+    session_df = StateStore.get(session_id)
+    assert session_df is not None
+    assert session_df.iloc[0]["species"] == "Adelie"
+
+
 def test_inputs_register_server_path_loads_into_session(client, clean_input_env):
     tmp_path = clean_input_env
 
@@ -390,6 +434,58 @@ def test_inputs_register_returns_conflict_for_descriptor_reuse_mismatch(client, 
     detail = second.json()["detail"]
     assert detail["code"] == "INPUT_CONFLICT"
     assert isinstance(detail["trace_id"], str)
+
+
+def test_inputs_register_conflict_does_not_mutate_original_session_or_descriptor(
+    client, clean_input_env
+):
+    tmp_path = clean_input_env
+
+    source_one = tmp_path / "dirty_penguins.csv"
+    source_two = tmp_path / "clean_penguins.csv"
+    _write_sample_csv(source_one)
+    pd.DataFrame(
+        {
+            "species": ["Chinstrap"],
+            "bill_length_mm": [50.0],
+        }
+    ).to_csv(source_two, index=False)
+
+    first = client.post(
+        "/inputs/register",
+        json={
+            "uri": str(source_one),
+            "load_into_session": True,
+            "idempotency_key": "shared-session-key",
+            "run_id": "register_conflict_run",
+        },
+    )
+    assert first.status_code == 200
+    first_payload = first.json()
+    input_id = first_payload["input"]["input_id"]
+    session_id = first_payload["session_id"]
+
+    second = client.post(
+        "/inputs/register",
+        json={
+            "uri": str(source_two),
+            "load_into_session": True,
+            "idempotency_key": "shared-session-key",
+            "run_id": "register_conflict_run",
+        },
+    )
+
+    assert second.status_code == 409
+    detail = second.json()["detail"]
+    assert detail["code"] == "INPUT_CONFLICT"
+    assert input_registry.get_session_input_id(session_id) == input_id
+    descriptor = input_registry.get_descriptor(input_id)
+    assert descriptor is not None
+    assert descriptor.original_reference == str(source_one)
+    assert descriptor.session_id == session_id
+    session_df = StateStore.get(session_id)
+    assert session_df is not None
+    assert session_df.iloc[0]["species"] == "Adelie"
 
 
 def test_get_input_descriptor_tool_returns_not_found_for_unknown_input_id(client, clean_input_env):

--- a/tests/mcp_server/test_input_ingest.py
+++ b/tests/mcp_server/test_input_ingest.py
@@ -100,6 +100,36 @@ def test_inputs_upload_reuses_input_id_for_same_payload(client, clean_input_env)
     assert response_one.json()["input"]["input_id"] == response_two.json()["input"]["input_id"]
 
 
+def test_inputs_upload_reuses_session_for_anonymous_idempotent_retry(client, clean_input_env):
+    response_one = client.post(
+        "/inputs/upload",
+        files={
+            "file": ("dirty_penguins.csv", b"species,bill_length_mm\nAdelie,39.1\n", "text/csv")
+        },
+        data={
+            "load_into_session": "true",
+            "idempotency_key": "stable-upload-retry",
+            "run_id": "retry_upload_run",
+        },
+    )
+    response_two = client.post(
+        "/inputs/upload",
+        files={
+            "file": ("dirty_penguins.csv", b"species,bill_length_mm\nAdelie,39.1\n", "text/csv")
+        },
+        data={
+            "load_into_session": "true",
+            "idempotency_key": "stable-upload-retry",
+            "run_id": "retry_upload_run",
+        },
+    )
+
+    assert response_one.status_code == 200
+    assert response_two.status_code == 200
+    assert response_one.json()["input"]["input_id"] == response_two.json()["input"]["input_id"]
+    assert response_one.json()["session_id"] == response_two.json()["session_id"]
+
+
 def test_inputs_register_server_path_loads_into_session(client, clean_input_env):
     tmp_path = clean_input_env
 
@@ -161,6 +191,37 @@ def test_inputs_register_reuses_input_id_with_stable_idempotency_key(client, cle
     assert response_one.json()["status"] == "pass"
     assert response_two.json()["status"] == "pass"
     assert response_one.json()["input"]["input_id"] == response_two.json()["input"]["input_id"]
+
+
+def test_inputs_register_reuses_session_for_anonymous_idempotent_retry(client, clean_input_env):
+    tmp_path = clean_input_env
+
+    source = tmp_path / "dirty_penguins.csv"
+    _write_sample_csv(source)
+
+    response_one = client.post(
+        "/inputs/register",
+        json={
+            "uri": str(source),
+            "load_into_session": True,
+            "idempotency_key": "stable-register-session-key",
+            "run_id": "retry_register_run",
+        },
+    )
+    response_two = client.post(
+        "/inputs/register",
+        json={
+            "uri": str(source),
+            "load_into_session": True,
+            "idempotency_key": "stable-register-session-key",
+            "run_id": "retry_register_run",
+        },
+    )
+
+    assert response_one.status_code == 200
+    assert response_two.status_code == 200
+    assert response_one.json()["input"]["input_id"] == response_two.json()["input"]["input_id"]
+    assert response_one.json()["session_id"] == response_two.json()["session_id"]
 
 
 def test_inputs_register_uses_distinct_input_ids_for_distinct_idempotency_keys(

--- a/tests/mcp_server/test_input_ingest.py
+++ b/tests/mcp_server/test_input_ingest.py
@@ -224,6 +224,61 @@ def test_inputs_register_reuses_session_for_anonymous_idempotent_retry(client, c
     assert response_one.json()["session_id"] == response_two.json()["session_id"]
 
 
+def test_inputs_register_allocates_new_session_when_old_binding_was_reused_for_other_input(
+    client, clean_input_env
+):
+    tmp_path = clean_input_env
+
+    source_one = tmp_path / "dirty_penguins.csv"
+    source_two = tmp_path / "different_penguins.csv"
+    _write_sample_csv(source_one)
+    pd.DataFrame(
+        {
+            "species": ["Chinstrap"],
+            "bill_length_mm": [50.0],
+        }
+    ).to_csv(source_two, index=False)
+
+    response_one = client.post(
+        "/inputs/register",
+        json={
+            "uri": str(source_one),
+            "load_into_session": True,
+            "idempotency_key": "stable-register-session-key",
+            "run_id": "retry_register_run",
+        },
+    )
+    assert response_one.status_code == 200
+    original_session_id = response_one.json()["session_id"]
+
+    competing_response = client.post(
+        "/inputs/register",
+        json={
+            "uri": str(source_two),
+            "load_into_session": True,
+            "session_id": original_session_id,
+            "run_id": "other_register_run",
+        },
+    )
+    assert competing_response.status_code == 200
+    assert competing_response.json()["session_id"] == original_session_id
+
+    response_two = client.post(
+        "/inputs/register",
+        json={
+            "uri": str(source_one),
+            "load_into_session": True,
+            "idempotency_key": "stable-register-session-key",
+            "run_id": "retry_register_run",
+        },
+    )
+
+    assert response_two.status_code == 200
+    assert response_one.json()["input"]["input_id"] == response_two.json()["input"]["input_id"]
+    assert response_two.json()["session_id"] != original_session_id
+    assert StateStore.get_metadata(response_two.json()["session_id"]) is not None
+
+
 def test_inputs_register_uses_distinct_input_ids_for_distinct_idempotency_keys(
     client, clean_input_env
 ):


### PR DESCRIPTION
## Summary
- reuse the existing live bound session for anonymous `register_input` and `upload_input` retries with stable `idempotency_key`s
- reuse the primary remote GCS artifact object on same-run retries instead of minting suffixed sibling objects
- document the updated retry contract and add a stdio duplicate-instance troubleshooting note

## Validation
- `pytest tests/mcp_server/test_input_ingest.py tests/hardening/test_config_and_upload.py -q`
- `ruff check src/analyst_toolkit/mcp_server/input/ingest.py src/analyst_toolkit/mcp_server/io_storage.py tests/mcp_server/test_input_ingest.py tests/hardening/test_config_and_upload.py`
- `ruff format --check src/analyst_toolkit/mcp_server/input/ingest.py src/analyst_toolkit/mcp_server/io_storage.py tests/mcp_server/test_input_ingest.py tests/hardening/test_config_and_upload.py`

## Live QA
- repeated `register_input` reused the same `session_id`
- repeated `upload_input` reused the same `session_id`
- repeated `validation`, `final_audit`, and `get_pipeline_dashboard` returned stable remote artifact URLs on the same run/session
- SQLite cleanup ended at `session_count: 0`

## Follow-up
- duplicate stdio MCP instance detection/warning is tracked in #161
