### PR TITLE
fix: harden sqlite state and pipeline contracts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,5 +125,8 @@ include = [
   "analyst_toolkit.*",
 ]
 
+[tool.setuptools.package-data]
+"analyst_toolkit.config_templates" = ["*.yaml", "golden_templates/*.yaml"]
+
 [project.scripts]
 analyst-toolkit = "analyst_toolkit.run_toolkit_pipeline:main"

--- a/src/analyst_toolkit/config_templates/__init__.py
+++ b/src/analyst_toolkit/config_templates/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled public MCP template resources."""

--- a/src/analyst_toolkit/config_templates/auto_heal_request_template.yaml
+++ b/src/analyst_toolkit/config_templates/auto_heal_request_template.yaml
@@ -1,0 +1,20 @@
+gcs_path: "gs://bucket/path/to/input.csv"
+session_id: null
+input_id: null
+run_id: "auto_heal_run_001"
+async_mode: false
+
+runtime:
+  run:
+    run_id: "auto_heal_run_001"
+    input_path: "gs://bucket/path/to/input.csv"
+  artifacts:
+    export_html: true
+    plotting: false
+  destinations:
+    gcs:
+      enabled: false
+      bucket_uri: "gs://bucket/path/to/reviews"
+      prefix: "auto_heal"
+  execution:
+    upload_artifacts: true

--- a/src/analyst_toolkit/config_templates/data_dictionary_request_template.yaml
+++ b/src/analyst_toolkit/config_templates/data_dictionary_request_template.yaml
@@ -1,0 +1,20 @@
+gcs_path: "gs://bucket/path/to/data.csv"
+session_id: null
+input_id: null
+run_id: "data_dictionary_prelaunch_001"
+profile_depth: "standard"
+include_examples: true
+prelaunch_report: true
+
+runtime:
+  run:
+    input_path: "gs://bucket/path/to/data.csv"
+    run_id: "data_dictionary_prelaunch_001"
+  artifacts:
+    export_html: true
+    plotting: false
+  destinations:
+    gcs:
+      enabled: false
+      bucket_uri: "gs://bucket"
+      prefix: "reports/data_dictionary"

--- a/src/analyst_toolkit/config_templates/diag_config_template.yaml
+++ b/src/analyst_toolkit/config_templates/diag_config_template.yaml
@@ -1,0 +1,61 @@
+# ------------------------------------------------------------------------------
+# Config File: run_diagnostics_config.yaml
+# Module: Diagnostics (M01)
+# Purpose: Generates a high-level statistical and structural profile of a DataFrame.
+# ------------------------------------------------------------------------------
+# This module is non-destructive. It produces reports and plots without modifying data.
+# ------------------------------------------------------------------------------
+
+# Execution context
+notebook: true               # Show inline output in notebooks
+run_id: "0002_QA"            # Identifier for tagging output files
+logging: "auto"                # Options: 'on', 'off', or 'auto' (auto = on in notebook mode)
+
+# ⚙️ Diagnostics settings
+diagnostics:
+  input_path: "data/raw/synthetic_penguins_v3.5.csv"
+
+  profile:
+    run: true                # Master toggle to run the profile step
+
+    settings:
+      # Output controls
+      export: true
+      export_html: true
+      export_html_path: "exports/reports/diagnostics/{run_id}_diagnostics_report.html"
+      as_csv: false          # Export format: false = XLSX, true = CSV
+      export_path: "exports/reports/diagnostics/diagnostics_summary.xlsx"
+      checkpoint: false
+      checkpoint_path: "exports/joblib/{run_id}/{run_id}_m02_diag_checkpoint.joblib"
+
+      # Display + analysis controls
+      show_inline: true
+      include_samples: true
+      include_metadata: true
+      encoding: "utf-8"
+      max_rows: 5
+      high_cardinality_threshold: 15
+
+      # Quality checks
+      quality_checks:
+        skew_threshold: 2.0
+        expected_dtypes:
+          tag_id: "object"
+          species: "object"
+          bill length (mm): "float64"
+          bill depth (mm): "float64"
+          flipper_length_mm: "float64"
+          body_mass_g: "float64"
+          age_group: "object"
+          sex: "object"
+          colony_id: "object"
+          island: "object"
+          capture_date: "object"
+          health_status: "object"
+          study_name: "object"
+          clutch_completion: "object"
+          date_egg: "object"
+
+  plotting:
+    run: true
+    save_dir: "exports/plots/diagnostics/"   # Directory to save diagnostic plots                             # Max preview rows per section

--- a/src/analyst_toolkit/config_templates/dups_config_template.yaml
+++ b/src/analyst_toolkit/config_templates/dups_config_template.yaml
@@ -1,0 +1,10 @@
+duplicates:
+  run: true
+
+  subset_columns: ['tag_id', 'species', 'capture_date']
+  keep: 'first'
+  mode: 'flag'
+  input_path: "data/processed/example.csv"
+  settings:
+    export_html: true
+    export_html_path: "exports/reports/duplicates/{run_id}_duplicates_report.html"

--- a/src/analyst_toolkit/config_templates/final_audit_config_template.yaml
+++ b/src/analyst_toolkit/config_templates/final_audit_config_template.yaml
@@ -1,0 +1,77 @@
+final_audit:
+  run: true
+
+  input_df_path: "data/processed/example_cleaned.joblib"
+  raw_data_path: "data/raw/example.csv"
+
+  final_edits:
+    run: true
+    drop_columns:
+      - 'body_mass_g_zscore_outlier'
+      - 'bill_length_mm_iqr_outlier'
+    rename_columns: {}
+    coerce_dtypes: {}
+
+  certification:
+    run: true
+    schema_validation:
+      run: true
+      fail_on_error: true
+      rules:
+        expected_columns:
+          - "tag_id"
+          - "species"
+          - "bill_length_mm"
+          - "bill_depth_mm"
+          - "flipper_length_mm"
+          - "body_mass_g"
+          - "age_group"
+          - "sex"
+          - "colony_id"
+          - "island"
+          - "capture_date"
+          - "health_status"
+          - "study_name"
+          - "clutch_completion"
+          - "date_egg"
+
+        expected_types:
+          tag_id: "object"
+          species: "object"
+          bill_length_mm: "float64"
+          bill_depth_mm: "float64"
+          flipper_length_mm: "float64"
+          body_mass_g: "float64"
+          age_group: "object"
+          sex: "object"
+          colony_id: "object"
+          island: "object"
+          capture_date: "datetime64[ns]"
+          health_status: "object"
+          study_name: "object"
+          clutch_completion: "object"
+          date_egg: "datetime64[ns]"
+
+        categorical_values:
+          species: ["Adelie", "Chinstrap", "Gentoo", "UNKNOWN"]
+          island: ["Dream", "Biscoe", "Torgersen", "Cormorant", "Shortcut", "UNKNOWN"]
+          sex: ["MALE", "FEMALE", "UNKNOWN"]
+          clutch_completion: ["yes", "no", "UNKNOWN"]
+          age_group: ["Juvenile", "Adult", "Chick", "UNKNOWN"]
+          health_status: ["Healthy", "Critical", "Underweight", "Sick", "Overweight", "UNKNOWN"]
+
+        disallowed_null_columns:
+          - 'tag_id'
+          - 'species'
+          - 'island'
+          - 'sex'
+          - 'body_mass_g'
+
+  settings:
+    export_html: true
+    paths:
+      report_excel: "exports/reports/final_audit/{run_id}_final_audit_report.xlsx"
+      report_joblib: "exports/reports/final_audit/{run_id}_final_audit_report.joblib"
+      report_html: "exports/reports/final_audit/{run_id}_final_audit_report.html"
+      checkpoint_csv: "exports/data/final_audit/{run_id}_certified.csv"
+      checkpoint_joblib: "exports/joblib/{run_id}/{run_id}_certified.joblib"

--- a/src/analyst_toolkit/config_templates/golden_templates/compliance_audit.yaml
+++ b/src/analyst_toolkit/config_templates/golden_templates/compliance_audit.yaml
@@ -1,0 +1,10 @@
+# Golden Config: Compliance Audit
+# Purpose: Focused on PII and regulatory compliance: strict null checks and categorical validation.
+description: "Focused on PII and regulatory compliance: strict null checks and categorical validation."
+validation:
+  rules:
+    schema_validation:
+      rules:
+        disallowed_null_columns: ["ssn_hash", "consent_flag", "user_id"]
+    categorical_checks:
+      consent_flag: {"allowed_values": ["Y", "N", "PENDING"]}

--- a/src/analyst_toolkit/config_templates/golden_templates/fraud_detection.yaml
+++ b/src/analyst_toolkit/config_templates/golden_templates/fraud_detection.yaml
@@ -1,0 +1,14 @@
+# Golden Config: Fraud Detection
+# Purpose: Strict outliers and identity-based duplicate checks.
+description: "Strict detection for potential fraud: high-precision outliers and identity-based duplicate checks."
+outliers:
+  method: "iqr"
+  iqr_multiplier: 1.1
+  columns: ["transaction_amount", "frequency_24h"]
+duplicates:
+  subset_columns: ["device_id", "user_email", "billing_zip"]
+  mode: "flag"
+validation:
+  rules:
+    range_checks:
+      transaction_amount: {"min": 0, "max": 10000}

--- a/src/analyst_toolkit/config_templates/golden_templates/quick_migration.yaml
+++ b/src/analyst_toolkit/config_templates/golden_templates/quick_migration.yaml
@@ -1,0 +1,14 @@
+# Golden Config: Quick Migration
+# Purpose: Fast data prep for database migration: heavy on renaming and type coercion.
+description: "Fast data prep for database migration: heavy on renaming and type coercion."
+normalization:
+  rules:
+    standardize_text_columns: ["first_name", "last_name", "city"]
+    coerce_dtypes:
+      user_id: "int64"
+      created_at: "datetime64[ns]"
+      is_active: "bool"
+imputation:
+  rules:
+    strategies:
+      default: "mode"

--- a/src/analyst_toolkit/config_templates/imputation_config_template.yaml
+++ b/src/analyst_toolkit/config_templates/imputation_config_template.yaml
@@ -1,0 +1,48 @@
+imputation:
+  run: true
+
+  input_path: "data/processed/example.csv"
+
+  rules:
+    strategies:
+      bill_length_mm: 'mean'
+      body_mass_g: 'mean'
+      bill_depth_mm: 'median'
+      flipper_length_mm: 'median'
+
+      sex: 'mode'
+
+      tag_id:
+        strategy: 'constant'
+        value: 'UNKNOWN'
+      species:
+        strategy: 'constant'
+        value: 'UNKNOWN'
+      age_group:
+        strategy: 'constant'
+        value: 'UNKNOWN'
+      colony_id:
+        strategy: 'constant'
+        value: 'UNKNOWN'
+      island:
+        strategy: 'constant'
+        value: 'UNKNOWN'
+      study_name:
+        strategy: 'constant'
+        value: 'UNKNOWN'
+      capture_date:
+        strategy: 'constant'
+        value: "1900-01-01"
+      date_egg:
+        strategy: 'constant'
+        value: "1900-01-01"
+      clutch_completion:
+        strategy: 'constant'
+        value: 'UNKNOWN'
+      health_status:
+        strategy: 'constant'
+        value: 'UNKNOWN'
+
+  settings:
+    export_html: true
+    export_html_path: "exports/reports/imputation/{run_id}_imputation_report.html"

--- a/src/analyst_toolkit/config_templates/normalization_config_template.yaml
+++ b/src/analyst_toolkit/config_templates/normalization_config_template.yaml
@@ -1,0 +1,103 @@
+normalization:
+  run: true
+
+  input_path: "data/processed/example_validated.csv"
+
+  rules:
+    rename_columns:
+      'bill length (mm)': 'bill_length_mm'
+      'bill depth (mm)': 'bill_depth_mm'
+
+    standardize_text_columns:
+      - 'clutch_completion'
+      - 'sex'
+
+    value_mappings:
+      sex:
+        '.': null
+        'male': 'MALE'
+        'female': 'FEMALE'
+        'm': 'MALE'
+        'f': 'FEMALE'
+        '?': 'UNKNOWN'
+        'unknown': 'UNKNOWN'
+      species:
+        'unknown': 'UNKNOWN'
+      island:
+        'unknown': 'UNKNOWN'
+      colony_id:
+        'biscoe 2': 'Biscoe West'
+        'cormorant NW': 'Cormorant East'
+        'invalid_colony': 'UNKNOWN'
+        'Torgersen': 'Torgersen North'
+        'Cormorant': 'Cormorant East'
+        'torgersen SE': 'Torgersen North'
+        'TORGERSEN 4': 'Torgersen North'
+        '/Shortcut': 'Shortcut Point'
+        ' short point': 'Shortcut Point'
+        'Biscoe': 'Biscoe West'
+        'Unknown': 'UNKNOWN'
+        'dream island': 'Dream South'
+        'Dream Island': 'Dream South'
+        'dream': 'Dream South'
+      age_group:
+        'juvenille': 'Juvenile'
+        'unk': 'UNKNOWN'
+        'ADLT': 'Adult'
+        'chik': 'Chick'
+      health_status:
+        'Unwell': 'Sick'
+        'Critically Ill': 'Critical'
+        'critcal ill': 'Critical'
+        'Overwight': 'Overweight'
+        'under weight': 'Underweight'
+        'Unknown': 'UNKNOWN'
+        'ok': 'UNKNOWN'
+      study_name:
+        'PAPR12021': 'PAPRI2021'
+        'papri2024': 'PAPRI2024'
+        'STUDY_2022': 'PAPRI2022'
+        'PP2020': 'PAPRI2020'
+        'PAPR2023': 'PAPRI2023'
+        'PAPRI20X9': 'UNKNOWN'
+
+    fuzzy_matching:
+      run: true
+      settings:
+        species:
+          master_list: ["Adelie", "Chinstrap", "Gentoo"]
+          score_cutoff: 80
+        island:
+          master_list: ["Torgersen", "Biscoe", "Dream", "Shortcut", "Cormorant"]
+          score_cutoff: 85
+
+    parse_datetimes:
+      capture_date:
+        format: '%Y-%m-%d'
+        errors: 'coerce'
+        utc: false
+        make_naive: true
+      date_egg:
+        format: '%Y-%m-%d'
+        errors: 'coerce'
+        utc: false
+        make_naive: true
+    preview_columns:
+      - 'sex'
+      - 'island'
+      - 'species'
+      - 'health_status'
+      - 'colony_id'
+      - 'age_group'
+      - 'study_name'
+      - 'capture_date'
+      - 'date_egg'
+      - 'clutch_completion'
+
+    coerce_dtypes:
+      bill_length_mm: 'float64'
+      flipper_length_mm: 'float64'
+
+  settings:
+    export_html: true
+    export_html_path: "exports/reports/normalization/{run_id}_normalization_report.html"

--- a/src/analyst_toolkit/config_templates/outlier_config_template.yaml
+++ b/src/analyst_toolkit/config_templates/outlier_config_template.yaml
@@ -1,0 +1,63 @@
+# ------------------------------------------------------------------------------
+# Config File: run_outlier_detection_config.yaml
+# Module: Outlier Detection (M05)
+# Purpose: Identifies numeric outliers using IQR or Z-score methods.
+# ------------------------------------------------------------------------------
+# This module flags outliers in numeric columns and supports visualization,
+# column-specific thresholds, and export of flagged results.
+# ------------------------------------------------------------------------------
+
+# Execution context
+notebook: true
+run_id: "0002_QA"
+logging: "auto"               # Options: 'on', 'off', or 'auto'
+
+# Outlier detection configuration
+outlier_detection:
+  run: true
+
+  # Input data path
+  input_path: "data/processed/df_validated.csv"
+
+  # Detection rules
+  detection_specs:
+    # Per-column overrides
+    bill_length_mm:
+      method: 'iqr'
+      iqr_multiplier: 1.5
+
+    body_mass_g:
+      method: 'zscore'
+      zscore_threshold: 3.5
+
+    # Global default for all other numeric columns
+    __default__:
+      method: 'iqr'
+      iqr_multiplier: 2.0
+
+  # Columns to exclude from analysis
+  exclude_columns: ['id', 'tag_id']
+
+  # Append boolean flags (e.g., 'bill_length_mm_outlier') to output
+  append_flags: true
+
+  # Plotting settings
+  plotting:
+    run: true
+    plot_save_dir: "exports/plots/outliers/{run_id}"
+    plot_types: ['box', 'hist', 'violin']      # Options: 'box', 'hist', 'violin'
+    show_plots_inline: true                    # Enables PlotViewer in notebook
+    hue: "species"                             # Optional grouping variable for plots
+
+  # Export reports
+  export:
+    run: true
+    export_dir: "exports/reports/outliers/detection/"
+    as_csv: false                              # false = XLSX with multiple sheets
+    export_html: true
+    export_html_path: "exports/reports/outliers/detection/{run_id}_outlier_report.html"
+
+  # Checkpoint results
+  checkpoint:
+    run: true
+    checkpoint_path: "exports/joblib/{run_id}/{run_id}_m05_outliers_flagged.joblib"

--- a/src/analyst_toolkit/config_templates/runtime_overlay_template.yaml
+++ b/src/analyst_toolkit/config_templates/runtime_overlay_template.yaml
@@ -1,0 +1,37 @@
+runtime:
+  run:
+    run_id: example_run_001
+    session_id:
+    input_path: gs://bucket/path/to/data.csv
+
+  artifacts:
+    export_html: true
+    export_xlsx:
+    export_data:
+    plotting: false
+    artifact_mode: single_html
+    collision_policy: overwrite
+
+  destinations:
+    local:
+      enabled: true
+      root: exports
+    gcs:
+      enabled: false
+      bucket_uri: gs://my-report-bucket
+      prefix: analyst_toolkit/reports
+    drive:
+      enabled: false
+      folder_id:
+
+  paths:
+    report_root: exports/reports
+    plot_root: exports/plots
+    checkpoint_root: exports/joblib
+    data_root: exports/data
+
+  execution:
+    allow_plot_generation: false
+    upload_artifacts: true
+    persist_history: true
+    strict_config: false

--- a/src/analyst_toolkit/config_templates/validation_config_template.yaml
+++ b/src/analyst_toolkit/config_templates/validation_config_template.yaml
@@ -1,0 +1,70 @@
+validation:
+  input_path: "data/raw/example.csv"
+
+  # Schema and content validation rules
+  schema_validation:
+    run: true
+    fail_on_error: false   # Set to false in audit mode to detect all issues
+
+    rules:
+      expected_columns:
+        - "tag_id"
+        - "species"
+        - "bill_length_mm"
+        - "bill_depth_mm"
+        - "flipper_length_mm"
+        - "body_mass_g"
+        - "age_group"
+        - "sex"
+        - "colony_id"
+        - "island"
+        - "capture_date"
+        - "health_status"
+        - "study_name"
+        - "clutch_completion"
+        - "date_egg"
+
+      expected_types:
+        tag_id: "object"
+        species: "object"
+        bill_length_mm: "float64"
+        bill_depth_mm: "float64"
+        flipper_length_mm: "int64"
+        body_mass_g: "float64"
+        age_group: "object"
+        sex: "object"
+        colony_id: "object"
+        island: "object"
+        capture_date: "object"
+        health_status: "object"
+        study_name: "object"
+        clutch_completion: "object"
+        date_egg: "object"
+
+      categorical_values:
+        species: ["Adelie", "Chinstrap", "Gentoo"]
+        island: ["Dream", "Biscoe", "Torgersen", "Cormorant", "Shortcut"]
+        sex: ["MALE", "FEMALE", "UNKNOWN"]
+        colony_id: ["Biscoe West", "Cormorant East", "Dream South", "Shortcut Point", "Torgersen North"]
+        clutch_completion: ["Yes", "No"]
+        age_group: ["Juvenile", "Adult", "Chick", "UNKNOWN"]
+        health_status: ["Healthy", "Critical", "Underweight", "Sick", "Overweight", "UNKNOWN"]
+        study_name: ["PAPRI2019", "PAPRI2020", "PAPRI2021", "PAPRI2022", "PAPRI2023", "PAPRI2024"]
+
+      numeric_ranges:
+        bill_length_mm:
+          min: 30.0
+          max: 65.0
+        bill_depth_mm:
+          min: 12.0
+          max: 23.5
+        flipper_length_mm:
+          min: 160.0
+          max: 255.0
+        body_mass_g:
+          min: 2300.0
+          max: 7500.0
+
+  settings:
+    export_html: true
+    export_html_path: "exports/reports/validation/{run_id}_validation_report.html"

--- a/src/analyst_toolkit/m00_utils/pipeline_config_validation.py
+++ b/src/analyst_toolkit/m00_utils/pipeline_config_validation.py
@@ -30,12 +30,51 @@ class PipelineRunnerConfig(BaseModel):
 
     model_config = ConfigDict(extra="allow")
 
-    # Historical runner behavior allows omitted run_id, but "default_run" is not
-    # appropriate for deterministic reruns because artifact/output names will collide.
-    run_id: str = "default_run"
+    run_id: str
     notebook: bool = False
     pipeline_entry_path: str
     modules: dict[str, PipelineModuleSelection] = Field(default_factory=dict)
+
+
+class OutlierHandlingExportConfig(BaseModel):
+    run: bool = False
+    export_path: str | None = None
+    as_csv: bool = False
+    export_html: bool = False
+    export_html_path: str | None = None
+
+
+class OutlierHandlingCheckpointConfig(BaseModel):
+    run: bool = False
+    checkpoint_path: str | None = None
+
+
+class OutlierHandlingSettingsConfig(BaseModel):
+    show_inline: bool = True
+    export: OutlierHandlingExportConfig = Field(default_factory=OutlierHandlingExportConfig)
+    checkpoint: OutlierHandlingCheckpointConfig = Field(
+        default_factory=OutlierHandlingCheckpointConfig
+    )
+
+
+class OutlierHandlingConfig(BaseModel):
+    run: bool = False
+    input_df_path: str | None = None
+    detection_results_path: str | None = None
+    handling_specs: dict[str, Any] = Field(default_factory=dict)
+    settings: OutlierHandlingSettingsConfig = Field(default_factory=OutlierHandlingSettingsConfig)
+
+
+class RunnerValidationSchemaConfig(BaseModel):
+    run: bool = True
+    fail_on_error: bool = False
+    rules: dict[str, Any] = Field(default_factory=dict)
+
+
+class RunnerValidationConfig(BaseModel):
+    schema_validation: RunnerValidationSchemaConfig = Field(
+        default_factory=RunnerValidationSchemaConfig
+    )
 
 
 _RUNNER_MODULE_SPECS: dict[str, dict[str, str]] = {
@@ -51,8 +90,17 @@ _RUNNER_MODULE_SPECS: dict[str, dict[str, str]] = {
         "root_key": "outlier_detection",
         "coerce_key": "outlier_detection",
     },
+    "outlier_handling": {
+        "module_name": "outlier_handling",
+        "root_key": "outlier_handling",
+    },
     "imputation": {"module_name": "imputation", "root_key": "imputation"},
     "final_audit": {"module_name": "final_audit", "root_key": "final_audit"},
+}
+
+_RUNNER_ONLY_MODELS: dict[str, type[BaseModel]] = {
+    "validation": RunnerValidationConfig,
+    "outlier_handling": OutlierHandlingConfig,
 }
 
 
@@ -87,7 +135,7 @@ def validate_runner_module_config(
     coerce_key = spec.get("coerce_key", module_name)
     coerced = coerce_config(config, coerce_key)
     normalized = normalize_module_config(module_name, coerced)
-    model = CONFIG_MODELS.get(module_name)
+    model = _RUNNER_ONLY_MODELS.get(module_name) or CONFIG_MODELS.get(module_name)
     if model is None:
         raise PipelineConfigValidationError(
             f"No shared config model is registered for runner module '{runner_module_name}' "
@@ -95,14 +143,18 @@ def validate_runner_module_config(
         )
 
     try:
-        model.model_validate(normalized)
+        validated = model.model_validate(normalized)
     except ValidationError as exc:
         raise PipelineConfigValidationError(
             f"Invalid config for runner module '{runner_module_name}': {exc}"
         ) from exc
 
-    effective = normalized
-    canonical = deepcopy(normalized)
+    validated_dump = validated.model_dump()
+    if root_key in validated_dump and isinstance(validated_dump[root_key], dict):
+        effective = validated_dump[root_key]
+    else:
+        effective = validated_dump
+    canonical = deepcopy(effective)
 
     return {
         "runner_module": runner_module_name,

--- a/src/analyst_toolkit/m10_final_audit/final_audit_producer.py
+++ b/src/analyst_toolkit/m10_final_audit/final_audit_producer.py
@@ -15,11 +15,14 @@ Outputs:
 This module is called by the M10 pipeline runner and does not export files directly.
 """
 
+import logging
 from typing import Any
 
 import pandas as pd
 
 from analyst_toolkit.m02_validation.validate_data import run_validation_suite
+
+logger = logging.getLogger(__name__)
 
 
 def _apply_final_edits(df: pd.DataFrame, config: dict) -> tuple[pd.DataFrame, pd.DataFrame]:
@@ -62,6 +65,7 @@ def _apply_final_edits(df: pd.DataFrame, config: dict) -> tuple[pd.DataFrame, pd
                 }
             )
         if failed_columns:
+            logger.warning("Final audit dtype coercion failed for columns: %s", failed_columns)
             changelog.append(
                 {
                     "Action": "coerce_dtypes_failed",

--- a/src/analyst_toolkit/mcp_server/destination_routing.py
+++ b/src/analyst_toolkit/mcp_server/destination_routing.py
@@ -40,7 +40,7 @@ def compact_destination_metadata(destinations: dict[str, Any]) -> dict[str, Any]
         if status in {"", "disabled"}:
             continue
         item = {"status": status}
-        for key in ("path", "url", "folder_id"):
+        for key in ("path", "url", "folder_id", "requested_root_status"):
             value = payload.get(key)
             if value:
                 item[key] = value

--- a/src/analyst_toolkit/mcp_server/input/__init__.py
+++ b/src/analyst_toolkit/mcp_server/input/__init__.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from analyst_toolkit.mcp_server.input.models import InputDescriptor, InputSourceType
 
 __all__ = [
     "get_input_descriptor",
@@ -12,25 +17,62 @@ __all__ = [
 ]
 
 
-def get_input_descriptor(*args: Any, **kwargs: Any):
+def get_input_descriptor(input_id: str) -> "InputDescriptor | None":
     from analyst_toolkit.mcp_server.input.ingest import get_input_descriptor as _impl
 
-    return _impl(*args, **kwargs)
+    return _impl(input_id)
 
 
-def ingest_uploaded_bytes(*args: Any, **kwargs: Any):
+def ingest_uploaded_bytes(
+    *,
+    filename: str,
+    payload: bytes,
+    media_type: str | None,
+    session_id: str | None = None,
+    run_id: str | None = None,
+    load_into_session: bool = True,
+    idempotency_key: str | None = None,
+) -> tuple["InputDescriptor", "pd.DataFrame | None", str | None]:
     from analyst_toolkit.mcp_server.input.ingest import ingest_uploaded_bytes as _impl
 
-    return _impl(*args, **kwargs)
+    return _impl(
+        filename=filename,
+        payload=payload,
+        media_type=media_type,
+        session_id=session_id,
+        run_id=run_id,
+        load_into_session=load_into_session,
+        idempotency_key=idempotency_key,
+    )
 
 
-def load_dataframe(*args: Any, **kwargs: Any):
+def load_dataframe(
+    *,
+    path: str | None = None,
+    session_id: str | None = None,
+    input_id: str | None = None,
+) -> "pd.DataFrame":
     from analyst_toolkit.mcp_server.input.ingest import load_dataframe as _impl
 
-    return _impl(*args, **kwargs)
+    return _impl(path=path, session_id=session_id, input_id=input_id)
 
 
-def register_input_source(*args: Any, **kwargs: Any):
+def register_input_source(
+    *,
+    reference: str,
+    source_type: "InputSourceType | None" = None,
+    session_id: str | None = None,
+    run_id: str | None = None,
+    load_into_session: bool = True,
+    idempotency_key: str | None = None,
+) -> tuple["InputDescriptor", "pd.DataFrame | None", str | None]:
     from analyst_toolkit.mcp_server.input.ingest import register_input_source as _impl
 
-    return _impl(*args, **kwargs)
+    return _impl(
+        reference=reference,
+        source_type=source_type,
+        session_id=session_id,
+        run_id=run_id,
+        load_into_session=load_into_session,
+        idempotency_key=idempotency_key,
+    )

--- a/src/analyst_toolkit/mcp_server/input/adapters.py
+++ b/src/analyst_toolkit/mcp_server/input/adapters.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -9,8 +10,12 @@ from analyst_toolkit.mcp_server.input.errors import InputNotSupportedError
 from analyst_toolkit.mcp_server.input.models import InputSourceType
 from analyst_toolkit.mcp_server.input.storage import validate_server_visible_path
 
+_WINDOWS_ABSOLUTE_PATH_RE = re.compile(r"^[A-Za-z]:[\\/]")
+
 
 def detect_source_type(reference: str) -> InputSourceType:
+    if _WINDOWS_ABSOLUTE_PATH_RE.match(reference):
+        return "server_path"
     parsed = urlparse(reference)
     if parsed.scheme == "gs":
         return "gcs"

--- a/src/analyst_toolkit/mcp_server/input/ingest.py
+++ b/src/analyst_toolkit/mcp_server/input/ingest.py
@@ -78,6 +78,18 @@ def _ensure_descriptor_compatible(descriptor: InputDescriptor) -> None:
     raise InputConflictError(f"Conflicting descriptor for input_id '{descriptor.input_id}'.")
 
 
+def _ensure_session_binding_compatible(*, session_id: str | None, input_id: str) -> None:
+    """Abort before session mutation if an explicit session is already bound elsewhere."""
+    if session_id is None:
+        return
+    bound_input_id = get_session_input_id(session_id)
+    if bound_input_id is None or bound_input_id == input_id:
+        return
+    raise InputConflictError(
+        f"Session '{session_id}' is already bound to input_id '{bound_input_id}'."
+    )
+
+
 def ingest_uploaded_bytes(
     *,
     filename: str,
@@ -109,6 +121,7 @@ def ingest_uploaded_bytes(
         run_id=run_id,
     )
     _ensure_descriptor_compatible(descriptor)
+    _ensure_session_binding_compatible(session_id=session_id, input_id=input_id)
     df: pd.DataFrame | None = None
     effective_session_id = session_id
     if load_into_session:
@@ -162,6 +175,7 @@ def register_input_source(
         run_id=run_id,
     )
     _ensure_descriptor_compatible(descriptor)
+    _ensure_session_binding_compatible(session_id=session_id, input_id=input_id)
     df: pd.DataFrame | None = None
     effective_session_id = session_id
     if load_into_session:

--- a/src/analyst_toolkit/mcp_server/input/limits.py
+++ b/src/analyst_toolkit/mcp_server/input/limits.py
@@ -84,7 +84,7 @@ def enforce_tabular_limits(
             f"({row_count} rows > {row_limit})."
         )
 
-    memory_limit = max_input_memory_bytes()
+    memory_limit = _env_int(memory_env_name, max_input_memory_bytes())
     if memory_limit and memory_usage_bytes > memory_limit:
         raise InputPayloadTooLargeError(
             f"Input '{reference}' exceeds {memory_env_name} "

--- a/src/analyst_toolkit/mcp_server/input/loaders.py
+++ b/src/analyst_toolkit/mcp_server/input/loaders.py
@@ -66,10 +66,11 @@ def load_dataframe_from_descriptor(descriptor: InputDescriptor) -> pd.DataFrame:
     path = Path(descriptor.resolved_reference).resolve(strict=False)
     safe_reference = _safe_descriptor_reference(descriptor, path)
     enforce_input_bytes_limit(path.stat().st_size, reference=safe_reference)
-    if path.suffix == ".parquet":
+    suffix = path.suffix.lower()
+    if suffix == ".parquet":
         return _read_parquet_with_limits(path, reference=safe_reference)
-    if path.suffix == ".csv":
+    if suffix == ".csv":
         return _read_csv_with_limits(path, reference=safe_reference)
     raise InputNotSupportedError(
-        f"Unsupported file format: {path.suffix or '<none>'}. Supported formats are .csv and .parquet."
+        f"Unsupported file format: {suffix or '<none>'}. Supported formats are .csv and .parquet."
     )

--- a/src/analyst_toolkit/mcp_server/input/models.py
+++ b/src/analyst_toolkit/mcp_server/input/models.py
@@ -13,6 +13,26 @@ INPUT_ID_PATTERN = rf"^{INPUT_ID_PREFIX}[a-f0-9]{{{INPUT_ID_HEX_LENGTH}}}$"
 _UNSET = object()
 
 
+def _deep_freeze(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return MappingProxyType({key: _deep_freeze(val) for key, val in value.items()})
+    if isinstance(value, list | tuple):
+        return tuple(_deep_freeze(item) for item in value)
+    if isinstance(value, set):
+        return frozenset(_deep_freeze(item) for item in value)
+    return value
+
+
+def _deep_thaw(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _deep_thaw(val) for key, val in value.items()}
+    if isinstance(value, tuple):
+        return [_deep_thaw(item) for item in value]
+    if isinstance(value, frozenset):
+        return sorted(_deep_thaw(item) for item in value)
+    return value
+
+
 @dataclass(frozen=True)
 class InputDescriptor:
     input_id: str
@@ -28,7 +48,7 @@ class InputDescriptor:
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "metadata", MappingProxyType(dict(self.metadata)))
+        object.__setattr__(self, "metadata", _deep_freeze(dict(self.metadata)))
 
     def same_canonical_input(self, other: "InputDescriptor") -> bool:
         if not isinstance(other, InputDescriptor):
@@ -42,7 +62,7 @@ class InputDescriptor:
             and self.media_type == other.media_type
             and self.file_size_bytes == other.file_size_bytes
             and self.sha256 == other.sha256
-            and dict(self.metadata) == dict(other.metadata)
+            and _deep_thaw(self.metadata) == _deep_thaw(other.metadata)
         )
 
     def with_runtime_binding(
@@ -73,5 +93,5 @@ class InputDescriptor:
             "sha256": self.sha256,
             "session_id": self.session_id,
             "run_id": self.run_id,
-            "metadata": dict(self.metadata),
+            "metadata": _deep_thaw(self.metadata),
         }

--- a/src/analyst_toolkit/mcp_server/input/registry.py
+++ b/src/analyst_toolkit/mcp_server/input/registry.py
@@ -91,7 +91,23 @@ def _refresh_input_locked(
     return descriptor
 
 
-def _refresh_session_locked(session_id: str, input_id: str, now: float) -> None:
+def _assert_session_binding_compatible_locked(session_id: str, input_id: str) -> None:
+    existing = _SESSION_INPUTS.get(session_id)
+    if existing is not None and existing.input_id != input_id:
+        raise InputConflictError(
+            f"Session '{session_id}' is already bound to input_id '{existing.input_id}'."
+        )
+
+
+def _refresh_session_locked(
+    session_id: str,
+    input_id: str,
+    now: float,
+    *,
+    allow_rebind: bool = False,
+) -> None:
+    if not allow_rebind:
+        _assert_session_binding_compatible_locked(session_id, input_id)
     _SESSION_INPUTS[session_id] = _SessionBinding(
         input_id=input_id,
         expires_at=_expires_at(now),
@@ -138,6 +154,12 @@ def save_descriptor(descriptor: InputDescriptor) -> InputDescriptor:
             effective_descriptor = descriptor.with_runtime_binding(
                 session_id=descriptor.session_id or existing_descriptor.session_id,
                 run_id=descriptor.run_id or existing_descriptor.run_id,
+            )
+
+        if effective_descriptor.session_id:
+            _assert_session_binding_compatible_locked(
+                effective_descriptor.session_id,
+                effective_descriptor.input_id,
             )
 
         effective_descriptor = _refresh_input_locked(

--- a/src/analyst_toolkit/mcp_server/io.py
+++ b/src/analyst_toolkit/mcp_server/io.py
@@ -7,6 +7,7 @@ import logging
 import os
 import threading
 from collections import OrderedDict
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -59,7 +60,7 @@ RUN_ID_OVERRIDE_ALLOWED = _env_bool("ANALYST_MCP_ALLOW_RUN_ID_OVERRIDE", False)
 DEDUP_RUN_ID_WARNINGS = _env_bool("ANALYST_MCP_DEDUP_RUN_ID_WARNINGS", True)
 _HISTORY_LOCKS_GUARD = threading.Lock()
 _MAX_HISTORY_LOCKS = 256
-_HISTORY_LOCKS: OrderedDict[str, threading.Lock] = OrderedDict()
+_HISTORY_LOCKS: OrderedDict[str, dict[str, Any]] = OrderedDict()
 _LIFECYCLE_WARNINGS_GUARD = threading.Lock()
 _MAX_LIFECYCLE_WARNING_KEYS = 512
 _SEEN_LIFECYCLE_WARNING_KEYS: set[tuple[str, str]] = set()
@@ -381,8 +382,7 @@ def append_to_run_history(run_id: str, entry: dict, session_id: Optional[str] = 
     history_dir.mkdir(parents=True, exist_ok=True)
 
     history_file = history_dir / f"{run_id}_history.json"
-    lock = _history_lock_for(history_file)
-    with lock:
+    with _history_lock(history_file):
         history, parse_meta = _read_history_file_safe(history_file)
         if parse_meta["parse_errors"]:
             logger.warning(
@@ -425,8 +425,7 @@ def _get_run_history_with_meta(
         path_root = _resolve_path_root(run_id, session_id)
         history_file = history_root / path_root / f"{run_id}_history.json"
         if history_file.exists():
-            lock = _history_lock_for(history_file)
-            with lock:
+            with _history_lock(history_file):
                 return _read_history_file_safe(history_file)
         return [], meta
 
@@ -436,8 +435,7 @@ def _get_run_history_with_meta(
         reverse=True,
     )
     if candidates:
-        lock = _history_lock_for(candidates[0])
-        with lock:
+        with _history_lock(candidates[0]):
             return _read_history_file_safe(candidates[0])
     return [], meta
 
@@ -445,15 +443,43 @@ def _get_run_history_with_meta(
 def _history_lock_for(path: Path) -> threading.Lock:
     key = str(path.resolve())
     with _HISTORY_LOCKS_GUARD:
-        lock = _HISTORY_LOCKS.get(key)
-        if lock is not None:
+        entry = _HISTORY_LOCKS.get(key)
+        if entry is not None:
             _HISTORY_LOCKS.move_to_end(key)
-            return lock
+            return entry["lock"]
         if len(_HISTORY_LOCKS) >= _MAX_HISTORY_LOCKS:
-            _HISTORY_LOCKS.popitem(last=False)
+            for stale_key, stale_entry in list(_HISTORY_LOCKS.items()):
+                if stale_entry["use_count"] == 0:
+                    _HISTORY_LOCKS.pop(stale_key)
+                    break
         lock = threading.Lock()
-        _HISTORY_LOCKS[key] = lock
+        _HISTORY_LOCKS[key] = {"lock": lock, "use_count": 0}
         return lock
+
+
+def _release_history_lock(path: Path) -> None:
+    key = str(path.resolve())
+    with _HISTORY_LOCKS_GUARD:
+        entry = _HISTORY_LOCKS.get(key)
+        if entry is None:
+            return
+        entry["use_count"] = max(0, int(entry.get("use_count", 0)) - 1)
+        _HISTORY_LOCKS.move_to_end(key)
+
+
+@contextmanager
+def _history_lock(path: Path):
+    key = str(path.resolve())
+    lock = _history_lock_for(path)
+    with _HISTORY_LOCKS_GUARD:
+        entry = _HISTORY_LOCKS.get(key)
+        if entry is not None:
+            entry["use_count"] += 1
+    try:
+        with lock:
+            yield
+    finally:
+        _release_history_lock(path)
 
 
 def _should_emit_lifecycle_warning(session_id: str, requested_run_id: str) -> bool:

--- a/src/analyst_toolkit/mcp_server/io_storage.py
+++ b/src/analyst_toolkit/mcp_server/io_storage.py
@@ -5,7 +5,6 @@ import os
 import tempfile
 from pathlib import Path
 from typing import Callable
-from uuid import uuid4
 
 import pandas as pd
 
@@ -250,16 +249,10 @@ def save_output(df: pd.DataFrame, path: str) -> str:
                 blob = bucket.blob(blob_path)
                 try:
                     blob.upload_from_filename(tmp_path, content_type=content_type)
-                except Exception as first_exc:
+                except Exception:
                     if _blob_exists(bucket, blob_path):
                         return _gcs_uri(bucket_name, blob_path)
-                    alt_blob_path = _versioned_blob_path(blob_path)
-                    alt_blob = bucket.blob(alt_blob_path)
-                    try:
-                        alt_blob.upload_from_filename(tmp_path, content_type=content_type)
-                    except Exception:
-                        raise first_exc
-                    return f"gs://{bucket_name}/{alt_blob_path}"
+                    raise
             except ImportError:
                 # Backward-compatible fallback for environments using gcsfs-style paths.
                 if suffix == ".parquet":
@@ -332,20 +325,5 @@ def upload_artifact(
     except Exception as first_exc:
         if _blob_exists(bucket, blob_path):
             return _gcs_url(bucket_name, blob_path)
-        # Fallback for idempotent reruns where same-key overwrite/delete permissions vary.
-        alt_name = f"{p.stem}_{uuid4().hex[:8]}{p.suffix}"
-        alt_path = f"{prefix}/{path_root}/{module}/{alt_name}"
-        try:
-            return _upload(alt_path)
-        except Exception:
-            logger.warning(
-                "Artifact upload failed for primary and fallback paths: %s ; %s",
-                first_exc,
-                alt_path,
-            )
-            return ""
-
-
-def _versioned_blob_path(blob_path: str) -> str:
-    p = Path(blob_path)
-    return str(p.with_name(f"{p.stem}_{uuid4().hex[:8]}{p.suffix}"))
+        logger.warning("Artifact upload failed for primary path: %s", first_exc)
+        return ""

--- a/src/analyst_toolkit/mcp_server/job_state.py
+++ b/src/analyst_toolkit/mcp_server/job_state.py
@@ -109,20 +109,21 @@ class JobStore:
             for job_id in expired:
                 cls._jobs.pop(job_id, None)
 
-        overflow = len(cls._jobs) - cls._max_jobs
+        terminal_jobs = [
+            (job_id, job)
+            for job_id, job in cls._jobs.items()
+            if str(job.get("state")) in {"succeeded", "failed"}
+        ]
+        overflow = len(terminal_jobs) - cls._max_jobs
         if overflow <= 0:
             return
 
         def sort_key(item: tuple[str, dict[str, Any]]) -> tuple[int, float]:
             _, job = item
-            state = str(job.get("state"))
-            terminal_rank = 0 if state in {"succeeded", "failed"} else 1
             timestamp = float(job.get("finished_at") or job.get("updated_at") or 0)
-            return terminal_rank, timestamp
+            return 0, timestamp
 
-        for job_id, _job in sorted(cls._jobs.items(), key=sort_key):
-            if len(cls._jobs) <= cls._max_jobs:
-                break
+        for job_id, _job in sorted(terminal_jobs, key=sort_key)[:overflow]:
             cls._jobs.pop(job_id, None)
 
     @classmethod

--- a/src/analyst_toolkit/mcp_server/local_artifact_server.py
+++ b/src/analyst_toolkit/mcp_server/local_artifact_server.py
@@ -148,8 +148,10 @@ class _ArtifactRequestHandler(SimpleHTTPRequestHandler):
         if artifact_root is None:
             logger.error("artifact_root not set on artifact server instance")
             return str(Path("__missing__").resolve(strict=False))
-        if parsed_path in {"/exports", "/exports/", "/reports", "/reports/"}:
+        if parsed_path in {"/exports", "/exports/"}:
             relative = PurePosixPath(".")
+        elif parsed_path in {"/reports", "/reports/"}:
+            relative = PurePosixPath("reports")
         elif parsed_path.startswith("/exports/"):
             relative = PurePosixPath(parsed_path.removeprefix("/exports/"))
         elif parsed_path.startswith("/reports/"):

--- a/src/analyst_toolkit/mcp_server/schemas.py
+++ b/src/analyst_toolkit/mcp_server/schemas.py
@@ -26,14 +26,22 @@ class ToolResponse(TypedDict):
 _GCS_PATH_PROP = {
     "gcs_path": {
         "type": "string",
-        "description": "Local file path (.csv / .parquet) or GCS URI (gs://bucket/path) to load data from. Optional if session_id is used.",
+        "description": (
+            "Local file path (.csv / .parquet) or GCS URI (gs://bucket/path) to load "
+            "data from. Optional only when exactly one of session_id or input_id is used "
+            "instead."
+        ),
     }
 }
 
 _SESSION_ID_PROP = {
     "session_id": {
         "type": "string",
-        "description": "Optional: In-memory session identifier from a previous tool run. If provided, gcs_path is ignored.",
+        "description": (
+            "Optional: Identifier for an existing session/run context backed by the active "
+            "session store. Use this instead of gcs_path or input_id; the selectors are "
+            "mutually exclusive."
+        ),
     }
 }
 
@@ -44,7 +52,7 @@ INPUT_ID_PROP = {
         "description": (
             "Optional: Canonical server-managed input reference returned by input "
             f"ingest/register flows. Uses a stable {INPUT_ID_HEX_LENGTH}-hex suffix collision budget. "
-            "If provided, gcs_path and session_id are ignored."
+            "Use this instead of gcs_path or session_id; the selectors are mutually exclusive."
         ),
     }
 }
@@ -108,7 +116,7 @@ def base_input_schema(extra_props: dict | None = None) -> dict:
     return {
         "type": "object",
         "properties": props,
-        "anyOf": [
+        "oneOf": [
             {"required": ["gcs_path"]},
             {"required": ["session_id"]},
             {"required": ["input_id"]},

--- a/src/analyst_toolkit/mcp_server/server.py
+++ b/src/analyst_toolkit/mcp_server/server.py
@@ -394,7 +394,8 @@ async def upload_input(
             },
         )
     try:
-        descriptor, df, effective_session_id = ingest_uploaded_bytes(
+        descriptor, df, effective_session_id = await asyncio.to_thread(
+            ingest_uploaded_bytes,
             filename=file.filename or "upload.csv",
             payload=payload,
             media_type=file.content_type,

--- a/src/analyst_toolkit/mcp_server/state.py
+++ b/src/analyst_toolkit/mcp_server/state.py
@@ -3,12 +3,12 @@
 import json
 import logging
 import os
-import pickle
 import sqlite3
 import threading
 import time
 import uuid
 from datetime import datetime, timezone
+from io import BytesIO
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -36,9 +36,15 @@ def _session_backend() -> str:
 def _sqlite_state_path() -> Path:
     raw_path = os.environ.get("ANALYST_MCP_SESSION_DB_PATH", "").strip()
     if raw_path:
-        path = Path(raw_path).expanduser().resolve(strict=False)
+        raw_candidate = Path(raw_path).expanduser()
+        if raw_candidate.is_symlink():
+            raise ValueError("SQLite session persistence cannot use a symlinked database path.")
+        path = raw_candidate.resolve(strict=False)
     else:
         path = (_session_state_home() / SESSION_SQLITE_PATH_DEFAULT).resolve(strict=False)
+
+    if not path.is_absolute():
+        raise ValueError("SQLite session persistence requires an absolute path.")
 
     exports_root = (Path.cwd() / "exports").resolve(strict=False)
     path_parents = {path, *path.parents}
@@ -47,6 +53,15 @@ def _sqlite_state_path() -> Path:
             "SQLite session persistence cannot use a path under ./exports; "
             "choose a private state path outside public artifact roots."
         )
+
+    private_root = _session_state_home()
+    try:
+        path.relative_to(private_root)
+    except ValueError as exc:
+        raise ValueError(
+            "SQLite session persistence must use a path under the private session state root."
+        ) from exc
+
     return path
 
 
@@ -73,11 +88,26 @@ class StateStore:
     def _sqlite_connect_unsafe(cls) -> sqlite3.Connection:
         path = _sqlite_state_path()
         path.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            if path.parent.is_symlink():
+                raise ValueError(
+                    "SQLite session persistence cannot use a symlinked parent directory."
+                )
+            os.chmod(path.parent, 0o700)
+        except OSError as exc:
+            raise ValueError(
+                f"Could not enforce private permissions on SQLite session directory: {path.parent}"
+            ) from exc
         conn = sqlite3.connect(path, timeout=10.0)
         try:
             os.chmod(path, 0o600)
-        except OSError:
-            logger.debug("Could not tighten SQLite session store permissions for %s", path)
+            stat_result = path.stat()
+            if hasattr(os, "getuid") and stat_result.st_uid != os.getuid():
+                raise ValueError("SQLite session store must be owned by the current user.")
+        except OSError as exc:
+            raise ValueError(
+                f"Could not tighten SQLite session store permissions for {path}"
+            ) from exc
         conn.execute(
             """
             CREATE TABLE IF NOT EXISTS sessions (
@@ -86,20 +116,29 @@ class StateStore:
                 started_at TEXT NOT NULL,
                 updated_at TEXT NOT NULL,
                 last_accessed REAL NOT NULL,
+                dataframe_format TEXT NOT NULL,
                 dataframe_blob BLOB NOT NULL,
                 metadata_json TEXT NOT NULL,
                 configs_json TEXT NOT NULL
             )
             """
         )
+        columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(sessions)").fetchall() if len(row) > 1
+        }
+        if "dataframe_format" not in columns:
+            conn.execute(
+                "ALTER TABLE sessions ADD COLUMN dataframe_format TEXT NOT NULL DEFAULT 'pickle'"
+            )
+            conn.commit()
         return conn
 
     @classmethod
     def _sqlite_fetch_row_unsafe(cls, conn: sqlite3.Connection, session_id: str):
         cursor = conn.execute(
             """
-            SELECT session_id, run_id, started_at, updated_at, last_accessed, dataframe_blob,
-                   metadata_json, configs_json
+            SELECT session_id, run_id, started_at, updated_at, last_accessed, dataframe_format,
+                   dataframe_blob, metadata_json, configs_json
             FROM sessions
             WHERE session_id = ?
             """,
@@ -109,22 +148,31 @@ class StateStore:
 
     @classmethod
     def _sqlite_configs_from_row(cls, row) -> Dict[str, str]:
+        if row is None or not row[8]:
+            return {}
+        loaded = json.loads(row[8])
+        return loaded if isinstance(loaded, dict) else {}
+
+    @classmethod
+    def _sqlite_metadata_from_row(cls, row) -> dict:
         if row is None or not row[7]:
             return {}
         loaded = json.loads(row[7])
         return loaded if isinstance(loaded, dict) else {}
 
     @classmethod
-    def _sqlite_metadata_from_row(cls, row) -> dict:
-        if row is None or not row[6]:
-            return {}
-        loaded = json.loads(row[6])
-        return loaded if isinstance(loaded, dict) else {}
+    def _sqlite_df_from_row(cls, row) -> pd.DataFrame:
+        fmt = row[5]
+        blob = row[6]
+        if fmt != "parquet":
+            raise ValueError(f"Unsupported SQLite session dataframe format: {fmt}")
+        return pd.read_parquet(BytesIO(blob))
 
     @classmethod
-    def _sqlite_df_from_row(cls, row) -> pd.DataFrame:
-        # SQLite session blobs come only from this process's own StateStore writes.
-        return pickle.loads(row[5])
+    def _sqlite_df_blob(cls, df: pd.DataFrame) -> bytes:
+        buf = BytesIO()
+        df.to_parquet(buf, index=False)
+        return buf.getvalue()
 
     @classmethod
     def _sqlite_evict_session_unsafe(cls, conn: sqlite3.Connection, sid: str, reason: str) -> None:
@@ -198,14 +246,15 @@ class StateStore:
                         """
                         INSERT INTO sessions (
                             session_id, run_id, started_at, updated_at, last_accessed,
-                            dataframe_blob, metadata_json, configs_json
+                            dataframe_format, dataframe_blob, metadata_json, configs_json
                         )
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                         ON CONFLICT(session_id) DO UPDATE SET
                             run_id = excluded.run_id,
                             started_at = excluded.started_at,
                             updated_at = excluded.updated_at,
                             last_accessed = excluded.last_accessed,
+                            dataframe_format = excluded.dataframe_format,
                             dataframe_blob = excluded.dataframe_blob,
                             metadata_json = excluded.metadata_json,
                             configs_json = excluded.configs_json
@@ -216,7 +265,8 @@ class StateStore:
                             started_at,
                             now_iso,
                             time.time(),
-                            sqlite3.Binary(pickle.dumps(df, protocol=pickle.HIGHEST_PROTOCOL)),
+                            "parquet",
+                            sqlite3.Binary(cls._sqlite_df_blob(df)),
                             json.dumps(metadata),
                             json.dumps(configs),
                         ),
@@ -453,9 +503,9 @@ class StateStore:
                         """
                         INSERT INTO sessions (
                             session_id, run_id, started_at, updated_at, last_accessed,
-                            dataframe_blob, metadata_json, configs_json
+                            dataframe_format, dataframe_blob, metadata_json, configs_json
                         )
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         (
                             new_session_id,
@@ -463,9 +513,8 @@ class StateStore:
                             now_ts.strftime("%Y%m%d_%H%M%S"),
                             now_iso,
                             time.time(),
-                            sqlite3.Binary(
-                                pickle.dumps(df.copy(), protocol=pickle.HIGHEST_PROTOCOL)
-                            ),
+                            "parquet",
+                            sqlite3.Binary(cls._sqlite_df_blob(df.copy())),
                             json.dumps(metadata),
                             json.dumps(configs),
                         ),

--- a/src/analyst_toolkit/mcp_server/templates.py
+++ b/src/analyst_toolkit/mcp_server/templates.py
@@ -4,6 +4,7 @@ templates.py — Template discovery for tool calls and MCP resources.
 
 from dataclasses import dataclass
 from functools import lru_cache
+from importlib import resources
 from pathlib import Path
 from urllib.parse import unquote, urlparse
 
@@ -12,12 +13,9 @@ import yaml
 RESOURCE_SCHEME = "analyst"
 RESOURCE_HOST = "templates"
 
-# Resolve config/ relative to the project root, not CWD.
-# This ensures templates are found regardless of where the process starts
-# (e.g. stdio mode spawned from a different workspace).
 _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
-CONFIG_DIR = _PROJECT_ROOT / "config"
-GOLDEN_TEMPLATE_DIR = CONFIG_DIR / "golden_templates"
+_SOURCE_CONFIG_DIR = _PROJECT_ROOT / "config"
+_BUNDLED_CONFIG_ROOT = resources.files("analyst_toolkit.config_templates")
 GOLDEN_TEMPLATE_FILENAMES: tuple[str, ...] = (
     "compliance_audit.yaml",
     "fraud_detection.yaml",
@@ -35,7 +33,7 @@ class TemplateSpec:
 
     @property
     def path(self) -> Path:
-        return CONFIG_DIR / self.filename
+        return _config_template_path(self.filename)
 
     @property
     def relative_path(self) -> str:
@@ -123,10 +121,28 @@ CONFIG_TEMPLATE_SPECS: tuple[TemplateSpec, ...] = (
 
 def _iter_golden_template_files() -> list[Path]:
     return [
-        GOLDEN_TEMPLATE_DIR / filename
+        _golden_template_dir() / filename
         for filename in GOLDEN_TEMPLATE_FILENAMES
-        if (GOLDEN_TEMPLATE_DIR / filename).is_file()
+        if (_golden_template_dir() / filename).is_file()
     ]
+
+
+def _bundled_config_dir() -> Path:
+    candidate = Path(str(_BUNDLED_CONFIG_ROOT))
+    if candidate.exists():
+        return candidate
+    return _SOURCE_CONFIG_DIR
+
+
+def _golden_template_dir() -> Path:
+    return _bundled_config_dir() / "golden_templates"
+
+
+def _config_template_path(filename: str) -> Path:
+    bundled = _bundled_config_dir() / filename
+    if bundled.is_file():
+        return bundled
+    return _SOURCE_CONFIG_DIR / filename
 
 
 @lru_cache(maxsize=1)
@@ -200,12 +216,12 @@ def resolve_template_uri(uri: str) -> Path:
     if group == "golden":
         if filename not in GOLDEN_TEMPLATE_FILENAMES:
             raise FileNotFoundError(f"Golden resource is not in the exposed allowlist: {uri}")
-        base = GOLDEN_TEMPLATE_DIR
+        base = _golden_template_dir()
     elif group == "config":
         allowed = {spec.filename for spec in list_config_template_specs()}
         if filename not in allowed:
             raise FileNotFoundError(f"Config resource is not in the exposed allowlist: {uri}")
-        base = CONFIG_DIR
+        base = _bundled_config_dir()
     else:
         raise FileNotFoundError(f"Unknown template group in URI: {uri}")
 

--- a/src/analyst_toolkit/mcp_server/tools/auto_heal.py
+++ b/src/analyst_toolkit/mcp_server/tools/auto_heal.py
@@ -44,10 +44,21 @@ def _sanitize_dashboard_step_summary(summary: dict | None) -> dict:
         return {}
 
     sanitized = {k: v for k, v in summary.items() if k != "error"}
-    if "error" in summary:
+    if summary.get("error_code"):
+        sanitized["error_code"] = summary["error_code"]
+    elif "error" in summary:
         sanitized["error_code"] = "AUTO_HEAL_STEP_FAILED"
+    if summary.get("trace_id"):
+        sanitized["trace_id"] = summary["trace_id"]
+    elif "error" in summary:
         sanitized["trace_id"] = new_trace_id()
     return sanitized
+
+
+def _step_failure_summary(step: str, error_code: str, exc: Exception) -> dict:
+    trace_id = new_trace_id()
+    logger.exception("auto_heal %s step failed (trace_id=%s)", step, trace_id, exc_info=exc)
+    return {"error_code": error_code, "trace_id": trace_id}
 
 
 async def _run_auto_heal_pipeline(
@@ -85,6 +96,7 @@ async def _run_auto_heal_pipeline(
 
     configs = infer_res.get("configs", {})
     current_session_id = infer_res.get("session_id")
+    run_id = infer_res.get("run_id") or run_id
 
     summary = {}
     failed_steps: list[str] = []
@@ -110,7 +122,9 @@ async def _run_auto_heal_pipeline(
             if _is_terminal_failure(norm_res.get("status")):
                 failed_steps.append("normalization")
         except Exception as e:
-            summary["normalization"] = {"error": str(e)}
+            failure = _step_failure_summary("normalization", "NORMALIZATION_FAILED", e)
+            summary["normalization"] = failure
+            norm_res = {"status": "error", "summary": failure}
             failed_steps.append("normalization")
 
     # 3. Apply Imputation if inferred
@@ -140,7 +154,9 @@ async def _run_auto_heal_pipeline(
                     failed_steps.append("imputation")
 
         except Exception as e:
-            summary["imputation"] = {"error": str(e)}
+            failure = _step_failure_summary("imputation", "IMPUTATION_FAILED", e)
+            summary["imputation"] = failure
+            imp_res = {"status": "error", "summary": failure}
             failed_steps.append("imputation")
 
     # Final Metadata

--- a/src/analyst_toolkit/mcp_server/tools/cockpit_capabilities.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit_capabilities.py
@@ -183,7 +183,7 @@ def build_capability_catalog(*, golden_configs: dict[str, Any]) -> dict[str, Any
             continue
         tool_name = spec.tool
         root_key = spec.config_root
-        template_path = spec.path.as_posix()
+        template_path = spec.relative_path
         root = _load_template_root(root_key, template_path)
         knobs = []
         for knob in _KEY_KNOBS.get(tool_name, []):

--- a/src/analyst_toolkit/mcp_server/tools/cockpit_history.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit_history.py
@@ -27,7 +27,6 @@ from analyst_toolkit.mcp_server.tools.cockpit_templates import (
 )
 
 MAX_ARTIFACT_ROWS = 24
-_WORKSPACE_ROOT = Path.cwd().resolve(strict=False)
 
 
 def _module_display_name(module: str) -> str:
@@ -44,15 +43,26 @@ def _module_display_name(module: str) -> str:
     return mapping.get(module, module.replace("_", " ").title())
 
 
-def _artifact_root_label(root: Any) -> str:
+def _artifact_root_label(root: Any, workspace_root: Path | None = None) -> str:
     text = str(root or "").strip()
     if not text:
         return ""
     path = Path(text).expanduser().resolve(strict=False)
+    resolved_workspace = workspace_root or Path.cwd().resolve(strict=False)
     try:
-        return path.relative_to(_WORKSPACE_ROOT).as_posix()
+        return path.relative_to(resolved_workspace).as_posix()
     except ValueError:
         return path.name or "artifacts"
+
+
+def _parse_history_timestamp(value: Any) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
 
 
 def _read_history_entries(path: Path) -> list[dict[str, Any]]:
@@ -71,17 +81,14 @@ def _history_sort_value(path: Path) -> float:
     except OSError:
         return 0.0
     history = _read_history_entries(path)
-    newest = ""
+    newest = None
     for entry in history:
-        timestamp = str(entry.get("timestamp", "") or "")
-        if timestamp > newest:
+        timestamp = _parse_history_timestamp(entry.get("timestamp"))
+        if timestamp and (newest is None or timestamp > newest):
             newest = timestamp
     if not newest:
         return fallback
-    try:
-        return datetime.fromisoformat(newest.replace("Z", "+00:00")).timestamp()
-    except ValueError:
-        return fallback
+    return newest.timestamp()
 
 
 def _iter_recent_history_files(limit: int) -> list[Path]:

--- a/src/analyst_toolkit/mcp_server/tools/cockpit_schemas.py
+++ b/src/analyst_toolkit/mcp_server/tools/cockpit_schemas.py
@@ -86,8 +86,8 @@ DATA_DICTIONARY_INPUT_SCHEMA = {
         "session_id": {
             "type": "string",
             "description": (
-                "Optional in-memory session identifier to use as the primary input source "
-                "when building from an existing run context."
+                "Identifier for an existing session/run context (may be in-memory or "
+                "persisted by the session backend, e.g., SQLite)."
             ),
         },
         **INPUT_ID_PROP,
@@ -119,7 +119,7 @@ DATA_DICTIONARY_INPUT_SCHEMA = {
             "description": "Reserve a prelaunch dictionary/readiness surface seeded from infer_configs.",
         },
     },
-    "anyOf": [
+    "oneOf": [
         {"required": ["gcs_path"]},
         {"required": ["session_id"]},
         {"required": ["input_id"]},

--- a/src/analyst_toolkit/mcp_server/tools/duplicates.py
+++ b/src/analyst_toolkit/mcp_server/tools/duplicates.py
@@ -169,7 +169,7 @@ async def _toolkit_duplicates(
         )
         artifact_path = artifact_delivery["local_path"]
         artifact_url = artifact_delivery["url"]
-        status_warnings.extend(artifact_delivery["warnings"])
+        artifact_warnings = artifact_delivery["warnings"]
 
         xlsx_path = f"exports/reports/duplicates/{run_id}_duplicates_report.xlsx"
         xlsx_delivery = deliver_artifact(
@@ -180,7 +180,7 @@ async def _toolkit_duplicates(
             session_id=session_id,
         )
         xlsx_url = xlsx_delivery["url"]
-        status_warnings.extend(xlsx_delivery["warnings"])
+        artifact_warnings.extend(xlsx_delivery["warnings"])
 
         # Upload plots - search both root and run_id subdir
         plot_dirs = [Path("exports/plots/duplicates"), Path(f"exports/plots/duplicates/{run_id}")]
@@ -195,9 +195,11 @@ async def _toolkit_duplicates(
                         session_id=session_id,
                     )
                     plot_delivery[plot_file.name] = delivered
-                    status_warnings.extend(delivered["warnings"])
+                    artifact_warnings.extend(delivered["warnings"])
                     if delivered["url"]:
                         plot_urls[plot_file.name] = delivered["url"]
+    else:
+        artifact_warnings = []
 
     artifact_contract = build_artifact_contract(
         export_url,
@@ -216,7 +218,12 @@ async def _toolkit_duplicates(
         required_html=should_export_html(config),
         probe_local_paths=True,
     )
-    warnings = status_warnings + advisory_warnings + artifact_contract["artifact_warnings"]
+    warnings = (
+        status_warnings
+        + advisory_warnings
+        + artifact_warnings
+        + artifact_contract["artifact_warnings"]
+    )
     base_status = "pass" if duplicate_count == 0 else "warn"
     if status_warnings and base_status == "pass":
         base_status = "warn"

--- a/src/analyst_toolkit/mcp_server/tools/final_audit.py
+++ b/src/analyst_toolkit/mcp_server/tools/final_audit.py
@@ -111,15 +111,21 @@ async def _toolkit_final_audit(
     ):
         kwargs.setdefault(key, runtime_overrides.get(key))
 
-    run_id, lifecycle = resolve_run_context(run_id, session_id)
-
     config = coerce_config(config, "final_audit")
 
     # Resolve session_id from input_id so config discovery can find inferred configs
+    descriptor = None
     if not session_id and input_id:
         descriptor = get_input_descriptor(input_id)
         if descriptor and descriptor.session_id:
             session_id = descriptor.session_id
+    elif input_id:
+        descriptor = get_input_descriptor(input_id)
+
+    if descriptor and descriptor.run_id and not run_id:
+        run_id = descriptor.run_id
+
+    run_id, lifecycle = resolve_run_context(run_id, session_id)
 
     # Auto-discover inferred configs from session when no explicit config is provided
     inferred_config: dict = {}
@@ -153,8 +159,14 @@ async def _toolkit_final_audit(
     # infer_configs embeds /tmp paths that expire after the inference call returns;
     # agents often pass those same stale paths back as explicit config.
     _strip_transient_paths(inferred_config)
+    nested_inferred = inferred_config.get("final_audit")
+    if isinstance(nested_inferred, dict):
+        _strip_transient_paths(nested_inferred)
     if isinstance(config, dict):
         _strip_transient_paths(config)
+        nested_config = config.get("final_audit")
+        if isinstance(nested_config, dict):
+            _strip_transient_paths(nested_config)
 
     config, runtime_meta = resolve_layered_config(
         inferred=inferred_config,
@@ -265,8 +277,11 @@ async def _toolkit_final_audit(
     artifact_delivery: dict[str, Any] = empty_delivery_state()
     xlsx_delivery: dict[str, Any] = empty_delivery_state()
 
-    # M10 exports to these locations (matches final_audit_pipeline.py defaults)
-    artifact_path = f"exports/reports/final_audit/{run_id}_final_audit_report.html"
+    # M10 exports to these configured locations; use the effective settings-path contract
+    # instead of a parallel hard-coded path so delivery stays aligned with runtime config.
+    artifact_path = paths_cfg.get(
+        "report_html", "exports/reports/final_audit/{run_id}_final_audit_report.html"
+    ).format(run_id=run_id)
     artifact_delivery = deliver_artifact(
         artifact_path,
         run_id,
@@ -279,10 +294,9 @@ async def _toolkit_final_audit(
     warnings.extend(artifact_delivery["warnings"])
 
     xlsx_path = (
-        module_cfg.get("final_audit", {})
-        .get("settings", {})
-        .get("paths", {})
-        .get("report_excel", "exports/reports/final_audit/{run_id}_final_audit_report.xlsx")
+        paths_cfg.get(
+            "report_excel", "exports/reports/final_audit/{run_id}_final_audit_report.xlsx"
+        )
     ).format(run_id=run_id)
     xlsx_expected = Path(xlsx_path).exists()
     xlsx_url = ""

--- a/src/analyst_toolkit/mcp_server/tools/infer_configs.py
+++ b/src/analyst_toolkit/mcp_server/tools/infer_configs.py
@@ -1,6 +1,7 @@
 """MCP tool: toolkit_infer_configs — config generation via analyst_toolkit_deploy."""
 
 import inspect
+import logging
 import os
 import tempfile
 from pathlib import Path
@@ -21,12 +22,14 @@ from analyst_toolkit.mcp_server.io import (
     save_session_config,
     save_to_session,
 )
-from analyst_toolkit.mcp_server.response_utils import next_action, with_next_actions
+from analyst_toolkit.mcp_server.response_utils import new_trace_id, next_action, with_next_actions
 from analyst_toolkit.mcp_server.runtime_overlay import (
     normalize_runtime_overlay,
     runtime_to_tool_overrides,
 )
 from analyst_toolkit.mcp_server.schemas import INPUT_ID_PROP
+
+logger = logging.getLogger("analyst_toolkit.mcp_server.infer_configs")
 
 _SUPPORTED_INFER_MODULES = {
     "diagnostics",
@@ -339,7 +342,6 @@ async def _toolkit_infer_configs(
     session_id = session_id or runtime_overrides.get("session_id")
     input_id = input_id or runtime_overrides.get("input_id")
     run_id = run_id or runtime_overrides.get("run_id")
-    run_id, _lifecycle = resolve_run_context(run_id, session_id)
     options = options or {}
 
     # When input_id is provided with session_id, use input_id as the data source
@@ -362,12 +364,15 @@ async def _toolkit_infer_configs(
     try:
         df = load_input(gcs_path, session_id=load_session, input_id=input_id)
     except Exception as exc:
+        trace_id = new_trace_id()
+        logger.exception("infer_configs input load failed (trace_id=%s)", trace_id, exc_info=exc)
         return {
             "status": "error",
             "module": "infer_configs",
-            "error": f"Failed to load input: {type(exc).__name__}: {exc}",
+            "error": "Failed to load input. See trace_id.",
             "error_code": "INPUT_LOAD_FAILED",
             "config_yaml": "",
+            "trace_id": trace_id,
         }
 
     # Resolve session_id from input descriptor if not provided
@@ -382,6 +387,8 @@ async def _toolkit_infer_configs(
         descriptor = get_input_descriptor(input_id)
 
     session_recreated_warning: str | None = None
+    if descriptor and descriptor.run_id and not run_id:
+        run_id = descriptor.run_id
 
     # If we still don't have a session, start one
     if not session_id:
@@ -404,6 +411,8 @@ async def _toolkit_infer_configs(
                 f"Session {session_id} metadata was not found; the session was recreated "
                 "before saving inferred configs."
             )
+
+    run_id, _lifecycle = resolve_run_context(run_id, session_id)
 
     # Always materialize an input snapshot locally for inference.
     # This avoids path-construction drift between modules and ensures deterministic reads.

--- a/src/analyst_toolkit/mcp_server/tools/outliers.py
+++ b/src/analyst_toolkit/mcp_server/tools/outliers.py
@@ -155,12 +155,14 @@ async def _toolkit_outliers(
     html_requested = should_export_html(config)
     expect_reports = html_requested and outlier_count > 0
     runtime_artifacts = runtime_cfg.get("artifacts", {}) if isinstance(runtime_cfg, dict) else {}
+    plotting_requested_runtime = runtime_artifacts.get("plotting") is True
+    expect_plots = plotting_requested and outlier_count > 0
     if runtime_artifacts.get("export_html") is True and not expect_reports:
         artifact_warnings.append(
             "runtime.artifacts.export_html=true requested report artifacts, but outlier "
             "detection found no outliers so HTML/XLSX outputs were disabled."
         )
-    if runtime_artifacts.get("plotting") is True and not expect_reports:
+    if plotting_requested_runtime and not expect_plots:
         artifact_warnings.append(
             "runtime.artifacts.plotting=true requested plot artifacts, but outlier detection "
             "found no outliers so plots were disabled."
@@ -224,7 +226,7 @@ async def _toolkit_outliers(
         plot_urls=plot_urls,
         expect_html=expect_reports,
         expect_xlsx=expect_reports,
-        expect_plots=expect_reports and plotting_requested,
+        expect_plots=expect_plots,
         required_html=False,
         probe_local_paths=True,
     )

--- a/src/analyst_toolkit/mcp_server/tools/read_artifact.py
+++ b/src/analyst_toolkit/mcp_server/tools/read_artifact.py
@@ -1,4 +1,4 @@
-"""MCP tool: read_artifact — read container-local artifact content through MCP."""
+"""MCP tool: read_artifact — read small container-local artifacts through MCP."""
 
 import base64
 import logging
@@ -22,6 +22,9 @@ def _is_stdio_mode() -> bool:
 
 
 _MAX_ARTIFACT_BYTES = int(os.environ.get("ANALYST_MCP_MAX_ARTIFACT_READ_BYTES", 10 * 1024 * 1024))
+_MAX_INLINE_TEXT_BYTES = int(
+    os.environ.get("ANALYST_MCP_MAX_INLINE_TEXT_ARTIFACT_BYTES", 100 * 1024)
+)
 
 _ARTIFACT_ROOT = Path(os.environ.get("ANALYST_MCP_ARTIFACT_SERVER_ROOT", "exports")).resolve(
     strict=False
@@ -95,12 +98,13 @@ async def _toolkit_read_artifact(
 ) -> dict:
     """Read a container-local artifact and return its content through MCP.
 
-    This bridges the container isolation gap: when the artifact server at
-    127.0.0.1:8765 is not reachable from the client, agents can use this
-    tool to retrieve artifact content directly through the MCP protocol.
+    This bridges the container isolation gap: when the local artifact server
+    is not reachable from the client, agents can use this tool to retrieve
+    artifact content directly through the MCP protocol.
 
-    Text artifacts (HTML, CSV, JSON, etc.) are returned as plain text.
-    Binary artifacts are returned as base64-encoded strings.
+    Small text artifacts (HTML, CSV, JSON, etc.) are returned inline as plain text.
+    Binary artifacts are returned as base64-encoded strings. Large text artifacts
+    return a compact reference instead of in-band content.
     """
     trace_id = new_trace_id()
 
@@ -140,6 +144,23 @@ async def _toolkit_read_artifact(
 
     try:
         if is_text:
+            if file_size > _MAX_INLINE_TEXT_BYTES:
+                return {
+                    "status": "pass",
+                    "module": "read_artifact",
+                    "artifact_path": str(resolved),
+                    "filename": resolved.name,
+                    "media_type": media_type,
+                    "encoding": "text",
+                    "size_bytes": file_size,
+                    "artifact_reference": str(resolved),
+                    "message": (
+                        "Artifact content omitted from the MCP response because the text file "
+                        f"is {file_size} bytes. Use the local artifact server or read the file "
+                        "directly for large dashboards and logs."
+                    ),
+                    "trace_id": trace_id,
+                }
             content = resolved.read_text(encoding="utf-8")
             return {
                 "status": "pass",
@@ -182,9 +203,12 @@ register_tool(
     fn=_toolkit_read_artifact,
     description=(
         "Read a container-local artifact file and return its content through MCP. "
-        "Use this when localhost artifact URLs are not reachable from the client. "
-        "Text files (HTML, CSV, JSON) are returned as plain text; binary files "
-        "as base64. Pass the artifact_path returned by module tools."
+        "Use this for small config, log, or report files when the local artifact server "
+        "is not reachable from the client. Small text files (HTML, CSV, JSON) are returned "
+        "inline as plain text; binary files are returned as base64. Large dashboards and "
+        "logs return a compact artifact reference instead. Prefer the artifact server for "
+        "large HTML dashboards or other bulky artifacts. Pass the artifact_path returned by "
+        "module tools."
     ),
     input_schema={
         "type": "object",

--- a/src/analyst_toolkit/mcp_server/tools/session.py
+++ b/src/analyst_toolkit/mcp_server/tools/session.py
@@ -42,6 +42,7 @@ async def _toolkit_manage_session(
     run_id: str | None = None,
     copy_configs: bool = True,
     include_configs: bool = False,
+    confirm_clear_all: bool = False,
 ) -> dict:
     """
     Manage session lifecycle: list, inspect, fork, rebind, or clear.
@@ -227,6 +228,14 @@ async def _toolkit_manage_session(
                 "cleared_session_id": session_id,
             }
         else:
+            if not confirm_clear_all:
+                return {
+                    "status": "error",
+                    "module": "manage_session",
+                    "action": "clear",
+                    "error": "confirm_clear_all=true is required to clear every session.",
+                    "error_code": "CLEAR_ALL_CONFIRMATION_REQUIRED",
+                }
             sessions = StateStore.list_sessions()
             count = len(sessions)
             StateStore.clear()
@@ -277,6 +286,14 @@ _INPUT_SCHEMA = {
             "type": "boolean",
             "description": "Whether to copy inferred configs when forking. Defaults to true.",
             "default": True,
+        },
+        "confirm_clear_all": {
+            "type": "boolean",
+            "description": (
+                "Required when action=clear and session_id is omitted. "
+                "Set true to clear every session."
+            ),
+            "default": False,
         },
         "include_configs": {
             "type": "boolean",

--- a/src/analyst_toolkit/mcp_server/tools/validation.py
+++ b/src/analyst_toolkit/mcp_server/tools/validation.py
@@ -144,7 +144,8 @@ async def _toolkit_validation(
                     violations_found.append(check_name)
                     violations_detail[check_name] = make_json_safe(check.get("details", {}))
 
-    passed = len(violations_found) == 0
+    has_validation_config = has_actionable_validation_config(base_cfg)
+    passed = has_validation_config and len(violations_found) == 0
 
     artifact_path = ""
     artifact_url = ""
@@ -156,7 +157,7 @@ async def _toolkit_validation(
     status_warnings.extend(lifecycle["warnings"])
     status_warnings.extend(runtime_warnings)
     status_warnings.extend(runtime_meta["runtime_warnings"])
-    if not has_actionable_validation_config(base_cfg):
+    if not has_validation_config:
         advisory_warnings.append(INFER_CONFIG_REQUIRED_WARNING)
     status_warnings.extend(export_delivery["warnings"])
     if should_export_html(config):
@@ -196,7 +197,10 @@ async def _toolkit_validation(
         probe_local_paths=True,
     )
     warnings = status_warnings + advisory_warnings + artifact_contract["artifact_warnings"]
-    base_status = "fail" if violations_found else ("warn" if status_warnings else "pass")
+    if not has_validation_config:
+        base_status = "warn"
+    else:
+        base_status = "fail" if violations_found else ("warn" if status_warnings else "pass")
     status = fold_status_with_artifacts(
         base_status, artifact_contract["missing_required_artifacts"]
     )

--- a/src/analyst_toolkit/run_toolkit_pipeline.py
+++ b/src/analyst_toolkit/run_toolkit_pipeline.py
@@ -66,7 +66,7 @@ def run_full_pipeline(config_path: str):
     logging.info(f"--- Loading Master Orchestration Config from {config_path} ---")
     master_config = validate_pipeline_runner_config(load_config(config_path))
 
-    run_id = master_config.get("run_id", "default_run")
+    run_id = master_config["run_id"]
     notebook_mode = master_config.get("notebook", False)
     modules_to_run = master_config.get("modules", {})
     entry_path = master_config.get("pipeline_entry_path")
@@ -153,7 +153,9 @@ def run_full_pipeline(config_path: str):
                 "M07 Outlier Handling cannot run because M06 Outlier Detection did not return results."
             )
         logging.info("--- Starting Module: OUTLIER_HANDLING ---")
-        module_config = load_config(module_info["config_path"])
+        module_config = _load_validated_module_config(
+            "outlier_handling", module_info["config_path"]
+        )
         df = run_outlier_handling_pipeline(
             config=module_config,
             df=df,

--- a/tests/hardening/test_auto_heal_behavior.py
+++ b/tests/hardening/test_auto_heal_behavior.py
@@ -177,7 +177,9 @@ async def test_auto_heal_returns_error_when_step_raises(monkeypatch):
     assert res["status"] == "error"
     assert "normalization" in res["failed_steps"]
     assert "normalization" in res["summary"]
-    assert "normalization boom" in res["summary"]["normalization"]["error"]
+    assert res["summary"]["normalization"]["error_code"] == "NORMALIZATION_FAILED"
+    assert isinstance(res["summary"]["normalization"]["trace_id"], str)
+    assert res["summary"]["normalization"]["trace_id"]
     assert all(action["tool"] != "final_audit" for action in res["next_actions"])
 
 

--- a/tests/hardening/test_config_and_upload.py
+++ b/tests/hardening/test_config_and_upload.py
@@ -189,7 +189,7 @@ def test_save_output_gcs_is_idempotent_for_same_path(sample_df, monkeypatch):
     assert not any(call[1].startswith("runs/shared_run/imputation_output_") for call in uploads)
 
 
-def test_save_output_gcs_falls_back_to_versioned_key_on_primary_failure(sample_df, monkeypatch):
+def test_save_output_gcs_raises_on_primary_failure_without_existing_object(sample_df, monkeypatch):
     calls: list[tuple[str, str]] = []
 
     class FakeBlob:
@@ -220,12 +220,10 @@ def test_save_output_gcs_falls_back_to_versioned_key_on_primary_failure(sample_d
     monkeypatch.setitem(sys.modules, "google.cloud.storage", storage_mod)
 
     path = "gs://example-bucket/runs/run_1/imputation_output.csv"
-    out = save_output(sample_df, path)
+    with pytest.raises(PermissionError):
+        save_output(sample_df, path)
 
-    assert out.startswith("gs://example-bucket/runs/run_1/")
-    assert out.endswith(".csv")
-    assert out != path
-    assert len([c for c in calls if c[0] == "upload"]) == 2
+    assert len([c for c in calls if c[0] == "upload"]) == 1
 
 
 def test_load_input_auto_normalizes_bucket_like_path(monkeypatch):
@@ -256,7 +254,9 @@ def test_resolve_run_context_dedupes_mismatch_warning(sample_df, monkeypatch):
     assert lifecycle_b["warnings"] == []
 
 
-def test_upload_artifact_falls_back_to_versioned_key_on_primary_failure(monkeypatch, tmp_path):
+def test_upload_artifact_returns_empty_on_primary_failure_without_existing_object(
+    monkeypatch, tmp_path
+):
     local = tmp_path / "report.html"
     local.write_text("<html>ok</html>", encoding="utf-8")
 
@@ -301,11 +301,9 @@ def test_upload_artifact_falls_back_to_versioned_key_on_primary_failure(monkeypa
         session_id="sess_retry",
     )
 
-    assert out.startswith("https://storage.googleapis.com/example-bucket/")
-    assert len(upload_calls) == 2
+    assert out == ""
+    assert len(upload_calls) == 1
     assert upload_calls[0].endswith("/imputation/report.html")
-    assert upload_calls[1].endswith(".html")
-    assert upload_calls[1] != upload_calls[0]
 
 
 def test_upload_artifact_reuses_existing_remote_object_for_same_path(monkeypatch, tmp_path):

--- a/tests/hardening/test_pipeline_integrations.py
+++ b/tests/hardening/test_pipeline_integrations.py
@@ -216,3 +216,14 @@ def test_apply_final_edits_handles_dtype_coercion_failures():
     assert out["flag"].dtype == "int64"
     assert out["score"].tolist() == ["bad", "2"]
     assert set(changelog["Action"]) == {"coerce_dtypes", "coerce_dtypes_failed"}
+
+
+def test_apply_final_edits_logs_dtype_coercion_failures(caplog):
+    from analyst_toolkit.m10_final_audit.final_audit_producer import _apply_final_edits
+
+    df = pd.DataFrame({"score": ["bad"]})
+
+    with caplog.at_level("WARNING"):
+        _apply_final_edits(df, {"coerce_dtypes": {"score": "float64"}})
+
+    assert "Final audit dtype coercion failed" in caplog.text

--- a/tests/hardening/test_state_store.py
+++ b/tests/hardening/test_state_store.py
@@ -1,9 +1,19 @@
 import threading
 import time
+from pathlib import Path
 
 import pytest
 
 from analyst_toolkit.mcp_server.state import StateStore
+
+
+def _configure_sqlite_state_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    state_home = tmp_path / "state_home"
+    db_path = state_home / "analyst_toolkit" / "session_store.db"
+    monkeypatch.setenv("XDG_STATE_HOME", str(state_home))
+    monkeypatch.setenv("ANALYST_MCP_SESSION_BACKEND", "sqlite")
+    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", str(db_path))
+    return db_path
 
 
 def test_save_and_get(sample_df):
@@ -118,8 +128,7 @@ def test_non_expired_session_survives_cleanup(sample_df, monkeypatch):
 
 
 def test_sqlite_backend_save_and_get(sample_df, tmp_path, monkeypatch):
-    monkeypatch.setenv("ANALYST_MCP_SESSION_BACKEND", "sqlite")
-    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", str(tmp_path / "session_store.db"))
+    db_path = _configure_sqlite_state_env(monkeypatch, tmp_path)
 
     sid = StateStore.save(sample_df, run_id="sqlite_run")
 
@@ -131,11 +140,12 @@ def test_sqlite_backend_save_and_get(sample_df, tmp_path, monkeypatch):
 
     pd.testing.assert_frame_equal(result, sample_df)
     assert StateStore.get_run_id(sid) == "sqlite_run"
+    assert db_path.stat().st_mode & 0o777 == 0o600
+    assert db_path.parent.stat().st_mode & 0o777 == 0o700
 
 
 def test_sqlite_backend_persists_configs_and_fork(sample_df, tmp_path, monkeypatch):
-    monkeypatch.setenv("ANALYST_MCP_SESSION_BACKEND", "sqlite")
-    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", str(tmp_path / "session_store.db"))
+    _configure_sqlite_state_env(monkeypatch, tmp_path)
 
     sid = StateStore.save(sample_df, run_id="sqlite_run")
     StateStore.save_config(sid, "validation", "validation:\n  run: true\n")
@@ -148,8 +158,7 @@ def test_sqlite_backend_persists_configs_and_fork(sample_df, tmp_path, monkeypat
 
 
 def test_sqlite_backend_rebind_and_clear(sample_df, tmp_path, monkeypatch):
-    monkeypatch.setenv("ANALYST_MCP_SESSION_BACKEND", "sqlite")
-    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", str(tmp_path / "session_store.db"))
+    _configure_sqlite_state_env(monkeypatch, tmp_path)
 
     sid = StateStore.save(sample_df, run_id="sqlite_run")
 
@@ -163,8 +172,7 @@ def test_sqlite_backend_rebind_and_clear(sample_df, tmp_path, monkeypatch):
 def test_sqlite_backend_ttl_cleanup(sample_df, tmp_path, monkeypatch):
     import analyst_toolkit.mcp_server.state as state_module
 
-    monkeypatch.setenv("ANALYST_MCP_SESSION_BACKEND", "sqlite")
-    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", str(tmp_path / "session_store.db"))
+    _configure_sqlite_state_env(monkeypatch, tmp_path)
     monkeypatch.setattr(state_module, "SESSION_TTL_SECONDS", 1)
 
     sid = StateStore.save(sample_df, run_id="sqlite_run")
@@ -175,9 +183,8 @@ def test_sqlite_backend_ttl_cleanup(sample_df, tmp_path, monkeypatch):
 
 
 def test_sqlite_concurrent_saves_are_thread_safe(tmp_path, monkeypatch):
-    monkeypatch.setenv("ANALYST_MCP_SESSION_BACKEND", "sqlite")
-    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", str(tmp_path / "session_store.db"))
-    ids = []
+    _configure_sqlite_state_env(monkeypatch, tmp_path)
+    saved = []
     errors = []
     lock = threading.Lock()
 
@@ -188,7 +195,7 @@ def test_sqlite_concurrent_saves_are_thread_safe(tmp_path, monkeypatch):
             df = pd.DataFrame({"col": [i]})
             sid = StateStore.save(df, run_id=f"run_{i}")
             with lock:
-                ids.append(sid)
+                saved.append((sid, i))
         except Exception as e:
             with lock:
                 errors.append(e)
@@ -200,14 +207,17 @@ def test_sqlite_concurrent_saves_are_thread_safe(tmp_path, monkeypatch):
         thread.join()
 
     assert not errors, f"Errors during concurrent sqlite saves: {errors}"
-    assert len(ids) == 20
-    for sid in ids:
-        assert StateStore.get(sid) is not None
+    assert len(saved) == 20
+    assert len({sid for sid, _ in saved}) == 20
+    for sid, i in saved:
+        stored = StateStore.get(sid)
+        assert stored is not None
+        assert stored.iloc[0]["col"] == i
+        assert StateStore.get_run_id(sid) == f"run_{i}"
 
 
 def test_sqlite_concurrent_reads_are_safe(sample_df, tmp_path, monkeypatch):
-    monkeypatch.setenv("ANALYST_MCP_SESSION_BACKEND", "sqlite")
-    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", str(tmp_path / "session_store.db"))
+    _configure_sqlite_state_env(monkeypatch, tmp_path)
     sid = StateStore.save(sample_df, run_id="sqlite_run")
     errors = []
     lock = threading.Lock()
@@ -257,3 +267,49 @@ def test_sqlite_state_path_rejects_exports_root(monkeypatch):
 
     with pytest.raises(ValueError, match="cannot use a path under ./exports"):
         state_module._sqlite_state_path()
+
+
+def test_sqlite_state_path_requires_private_root(monkeypatch, tmp_path):
+    import analyst_toolkit.mcp_server.state as state_module
+
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path / "state_home"))
+    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", str(tmp_path / "elsewhere" / "db.sqlite"))
+
+    with pytest.raises(ValueError, match="private session state root"):
+        state_module._sqlite_state_path()
+
+
+def test_sqlite_state_path_rejects_symlink(monkeypatch, tmp_path):
+    import analyst_toolkit.mcp_server.state as state_module
+
+    state_home = tmp_path / "state_home"
+    state_home.mkdir()
+    target = state_home / "target.sqlite"
+    target.write_text("", encoding="utf-8")
+    link = state_home / "link.sqlite"
+    link.symlink_to(target)
+    monkeypatch.setenv("XDG_STATE_HOME", str(state_home))
+    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", str(link))
+
+    with pytest.raises(ValueError, match="symlinked database path"):
+        state_module._sqlite_state_path()
+
+
+def test_sqlite_rejects_legacy_pickle_rows(sample_df, tmp_path, monkeypatch):
+    import sqlite3
+
+    db_path = _configure_sqlite_state_env(monkeypatch, tmp_path)
+    sid = StateStore.save(sample_df, run_id="sqlite_run")
+
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            "UPDATE sessions SET dataframe_format = ? WHERE session_id = ?",
+            ("pickle", sid),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    with pytest.raises(ValueError, match="Unsupported SQLite session dataframe format"):
+        StateStore.get(sid)

--- a/tests/m00_utils/test_rendering_utils.py
+++ b/tests/m00_utils/test_rendering_utils.py
@@ -57,3 +57,21 @@ def test_markdown_helpers_fall_back_without_ipython(monkeypatch, capsys):
     assert "### Warnings" in out
     assert "- first" in out
     assert "- second" in out
+
+
+def test_display_markdown_summary_falls_back_when_to_markdown_import_errors(monkeypatch, capsys):
+    monkeypatch.setitem(sys.modules, "IPython", None)
+    monkeypatch.setitem(sys.modules, "IPython.display", None)
+    module = _import_rendering_utils()
+
+    def raise_import_error(*args, **kwargs):
+        raise ImportError("tabulate missing")
+
+    monkeypatch.setattr(pd.DataFrame, "to_markdown", raise_import_error)
+
+    module.display_markdown_summary("Summary", pd.DataFrame({"col": [1, 2]}), max_rows=1)
+
+    out = capsys.readouterr().out
+    assert "### Summary" in out
+    assert "col" in out
+    assert "1" in out

--- a/tests/mcp_server/test_destination_routing.py
+++ b/tests/mcp_server/test_destination_routing.py
@@ -2,7 +2,10 @@ import logging
 from pathlib import Path
 
 from analyst_toolkit.mcp_server import destination_routing
-from analyst_toolkit.mcp_server.destination_routing import deliver_artifact
+from analyst_toolkit.mcp_server.destination_routing import (
+    compact_destination_metadata,
+    deliver_artifact,
+)
 
 
 def test_deliver_artifact_mirrors_to_local_root(tmp_path, monkeypatch):
@@ -241,3 +244,17 @@ def test_local_relative_path_strips_exports_for_absolute_path_inside_cwd(
     assert routed == tmp_path / "exports" / "reports" / "data_dictionary" / "run1_report.html"
     assert "requested_root_status" not in delivery["destinations"]["local"]
     assert not any("rejected" in rec.getMessage().lower() for rec in caplog.records)
+
+
+def test_compact_destination_metadata_preserves_requested_root_status():
+    compact = compact_destination_metadata(
+        {
+            "local": {
+                "status": "available",
+                "path": "/tmp/report.html",
+                "requested_root_status": "rejected",
+            }
+        }
+    )
+
+    assert compact["local"]["requested_root_status"] == "rejected"

--- a/tests/mcp_server/test_input_ingest.py
+++ b/tests/mcp_server/test_input_ingest.py
@@ -1,11 +1,14 @@
+from io import BytesIO
 from pathlib import Path
 
 import pandas as pd
 import pytest
+from fastapi import UploadFile
 
 import analyst_toolkit.mcp_server.server as server_module
 from analyst_toolkit.mcp_server.input import registry as input_registry
 from analyst_toolkit.mcp_server.input.errors import InputError, InputPathDeniedError
+from analyst_toolkit.mcp_server.input.models import InputDescriptor
 from analyst_toolkit.mcp_server.input.storage import validate_server_visible_path
 from analyst_toolkit.mcp_server.state import StateStore
 from analyst_toolkit.mcp_server.tools import diagnostics as diagnostics_tool
@@ -75,6 +78,62 @@ def test_inputs_upload_rejects_empty_payload(client, clean_input_env):
     detail = response.json()["detail"]
     assert detail["code"] == "INPUT_EMPTY_UPLOAD"
     assert isinstance(detail["trace_id"], str)
+
+
+@pytest.mark.asyncio
+async def test_http_upload_input_offloads_ingest_to_thread(monkeypatch, clean_input_env):
+    monkeypatch.setattr(server_module, "_require_http_auth", lambda request: "trace_http_upload")
+    calls: list[tuple[object, tuple, dict]] = []
+
+    async def fake_to_thread(func, /, *args, **kwargs):
+        calls.append((func, args, kwargs))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(server_module.asyncio, "to_thread", fake_to_thread)
+
+    descriptor = InputDescriptor(
+        input_id="input_deadbeefdeadbeef",
+        source_type="upload",
+        original_reference="dirty_penguins.csv",
+        resolved_reference=str(clean_input_env / "inputs" / "staged.csv"),
+        display_name="dirty_penguins.csv",
+        media_type="text/csv",
+        file_size_bytes=29,
+        sha256="abc123",
+        session_id="sess_upload",
+        run_id="upload_run",
+    )
+
+    def fake_ingest_uploaded_bytes(**kwargs):
+        return descriptor, pd.DataFrame({"species": ["Adelie"]}), "sess_upload"
+
+    monkeypatch.setattr(server_module, "ingest_uploaded_bytes", fake_ingest_uploaded_bytes)
+
+    upload = UploadFile(
+        file=BytesIO(b"species,bill_length_mm\nAdelie,39.1\n"),
+        filename="dirty_penguins.csv",
+        headers={"content-type": "text/csv"},
+    )
+    response = await server_module.upload_input(
+        request=object(),
+        file=upload,
+        session_id=None,
+        run_id="upload_run",
+        idempotency_key="upload_http",
+        load_into_session=True,
+    )
+
+    assert response.status_code == 200
+    payload = response.body.decode("utf-8")
+    assert '"status":"pass"' in payload
+    assert '"session_id":"sess_upload"' in payload
+    assert calls
+    func, args, kwargs = calls[0]
+    assert func is fake_ingest_uploaded_bytes
+    assert not args
+    assert kwargs["filename"] == "dirty_penguins.csv"
+    assert kwargs["run_id"] == "upload_run"
+    assert kwargs["idempotency_key"] == "upload_http"
 
 
 def test_inputs_upload_reuses_input_id_for_same_payload(client, clean_input_env):
@@ -268,7 +327,7 @@ def test_inputs_register_reuses_session_for_anonymous_idempotent_retry(client, c
     assert response_one.json()["session_id"] == response_two.json()["session_id"]
 
 
-def test_inputs_register_allocates_new_session_when_old_binding_was_reused_for_other_input(
+def test_inputs_register_rejects_conflicting_explicit_session_rebind_and_preserves_retry_binding(
     client, clean_input_env
 ):
     tmp_path = clean_input_env
@@ -304,8 +363,8 @@ def test_inputs_register_allocates_new_session_when_old_binding_was_reused_for_o
             "run_id": "other_register_run",
         },
     )
-    assert competing_response.status_code == 200
-    assert competing_response.json()["session_id"] == original_session_id
+    assert competing_response.status_code == 409
+    assert competing_response.json()["detail"]["code"] == "INPUT_CONFLICT"
 
     response_two = client.post(
         "/inputs/register",
@@ -319,8 +378,8 @@ def test_inputs_register_allocates_new_session_when_old_binding_was_reused_for_o
 
     assert response_two.status_code == 200
     assert response_one.json()["input"]["input_id"] == response_two.json()["input"]["input_id"]
-    assert response_two.json()["session_id"] != original_session_id
-    assert StateStore.get_metadata(response_two.json()["session_id"]) is not None
+    assert response_two.json()["session_id"] == original_session_id
+    assert StateStore.get_metadata(original_session_id) is not None
 
 
 def test_inputs_register_uses_distinct_input_ids_for_distinct_idempotency_keys(

--- a/tests/mcp_server/test_input_limits.py
+++ b/tests/mcp_server/test_input_limits.py
@@ -1,0 +1,17 @@
+import pytest
+
+from analyst_toolkit.mcp_server.input.errors import InputPayloadTooLargeError
+from analyst_toolkit.mcp_server.input.limits import enforce_tabular_limits
+
+
+def test_enforce_tabular_limits_uses_custom_memory_env_name(monkeypatch):
+    monkeypatch.setenv("ANALYST_MCP_MAX_INPUT_MEMORY_BYTES", "1000")
+    monkeypatch.setenv("ANALYST_CUSTOM_MEMORY_LIMIT", "10")
+
+    with pytest.raises(InputPayloadTooLargeError, match="ANALYST_CUSTOM_MEMORY_LIMIT"):
+        enforce_tabular_limits(
+            row_count=1,
+            memory_usage_bytes=11,
+            reference="dataset.csv",
+            memory_env_name="ANALYST_CUSTOM_MEMORY_LIMIT",
+        )

--- a/tests/mcp_server/test_input_loaders.py
+++ b/tests/mcp_server/test_input_loaders.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
+from analyst_toolkit.mcp_server.input.adapters import detect_source_type
 from analyst_toolkit.mcp_server.input.errors import InputPayloadTooLargeError
 from analyst_toolkit.mcp_server.input.loaders import load_dataframe_from_descriptor
 from analyst_toolkit.mcp_server.input.models import InputDescriptor
@@ -141,3 +142,17 @@ def test_load_dataframe_from_descriptor_rejects_gcs_prefix_over_object_limit(mon
 
     with pytest.raises(InputPayloadTooLargeError, match="ANALYST_MCP_MAX_GCS_PREFIX_OBJECTS"):
         load_dataframe_from_descriptor(descriptor)
+
+
+def test_load_dataframe_from_descriptor_accepts_uppercase_csv_suffix(tmp_path):
+    source = tmp_path / "rows.CSV"
+    pd.DataFrame({"a": [1, 2]}).to_csv(source, index=False)
+
+    result = load_dataframe_from_descriptor(_descriptor_for(source))
+
+    assert list(result["a"]) == [1, 2]
+
+
+def test_detect_source_type_accepts_windows_absolute_paths():
+    assert detect_source_type(r"C:\data\dirty_penguins.csv") == "server_path"
+    assert detect_source_type("D:/datasets/dirty_penguins.csv") == "server_path"

--- a/tests/mcp_server/test_input_registry.py
+++ b/tests/mcp_server/test_input_registry.py
@@ -26,6 +26,7 @@ def _descriptor(
     session_id: str | None = None,
     run_id: str | None = None,
     sha256: str | None = None,
+    metadata: dict | None = None,
 ) -> InputDescriptor:
     return InputDescriptor(
         input_id=input_id,
@@ -38,7 +39,7 @@ def _descriptor(
         sha256=sha256,
         session_id=session_id,
         run_id=run_id,
-        metadata={"kind": "test"},
+        metadata=metadata or {"kind": "test"},
     )
 
 
@@ -65,6 +66,27 @@ def test_registry_rejects_conflicting_descriptor_reuse(clean_registry):
     original = input_registry.get_descriptor("input_conflict")
     assert original is not None
     assert original.sha256 == "abc"
+
+
+def test_registry_rejects_conflicting_session_rebind_via_descriptor(clean_registry):
+    input_registry.save_descriptor(_descriptor("input_a", session_id="sess_conflict"))
+
+    with pytest.raises(InputConflictError, match="already bound"):
+        input_registry.save_descriptor(_descriptor("input_b", session_id="sess_conflict"))
+
+    assert input_registry.get_session_input_id("sess_conflict") == "input_a"
+    assert input_registry.get_descriptor("input_b") is None
+
+
+def test_bind_session_input_rejects_conflicting_rebind(clean_registry):
+    input_registry.save_descriptor(_descriptor("input_a"))
+    input_registry.save_descriptor(_descriptor("input_b"))
+    input_registry.bind_session_input("sess_conflict", "input_a")
+
+    with pytest.raises(InputConflictError, match="already bound"):
+        input_registry.bind_session_input("sess_conflict", "input_b")
+
+    assert input_registry.get_session_input_id("sess_conflict") == "input_a"
 
 
 def test_registry_evicts_oldest_entries_when_capacity_is_exceeded(monkeypatch):
@@ -115,6 +137,19 @@ def test_get_registry_stats_reports_current_counts(clean_registry):
     assert stats["session_binding_count"] == 1
     assert stats["max_entries"] == 8
     assert stats["ttl_sec"] == 3600.0
+
+
+def test_input_descriptor_metadata_is_deeply_frozen(clean_registry):
+    nested = {"kind": "test", "nested": {"labels": ["a", "b"]}}
+    descriptor = _descriptor("input_nested", metadata=nested)
+
+    nested["nested"]["labels"].append("c")
+
+    assert descriptor.metadata["nested"]["labels"] == ("a", "b")
+    assert descriptor.to_dict()["metadata"] == {
+        "kind": "test",
+        "nested": {"labels": ["a", "b"]},
+    }
 
 
 def test_new_input_id_uses_16_hex_entropy_budget():

--- a/tests/mcp_server/test_local_artifact_server.py
+++ b/tests/mcp_server/test_local_artifact_server.py
@@ -100,6 +100,18 @@ def test_translate_path_accepts_reports_prefix(tmp_path):
     assert translated == (root / "reports" / "pipeline" / "run1_dashboard.html")
 
 
+def test_translate_path_maps_bare_reports_prefix_to_reports_dir(tmp_path):
+    root = tmp_path / "exports"
+    handler = artifact_server_module._ArtifactRequestHandler.__new__(
+        artifact_server_module._ArtifactRequestHandler
+    )
+    handler.server = type("Server", (), {"artifact_root": root})()
+
+    translated = Path(handler.translate_path("/reports/"))
+
+    assert translated == (root / "reports")
+
+
 def test_ensure_local_artifact_server_returns_conflict_without_health_match(
     monkeypatch, tmp_path, reset_artifact_server
 ):

--- a/tests/mcp_server/test_rpc_cockpit_dashboard.py
+++ b/tests/mcp_server/test_rpc_cockpit_dashboard.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 import pytest
 
 import analyst_toolkit.mcp_server.tools.cockpit as cockpit_module
@@ -122,7 +124,6 @@ def test_build_recent_run_cards_discovers_local_dashboards(mocker, tmp_path, mon
         "build_data_health_report",
         return_value={"health_score": 94.0, "health_status": "green"},
     )
-    mocker.patch.object(cockpit_history_module, "_WORKSPACE_ROOT", tmp_path)
     monkeypatch.chdir(tmp_path)
 
     cards = cockpit_module._build_recent_run_cards(limit=5)
@@ -133,3 +134,26 @@ def test_build_recent_run_cards_discovers_local_dashboards(mocker, tmp_path, mon
     assert card["auto_heal_dashboard"].endswith(f"{run_id}_auto_heal_report.html")
     assert card["final_audit_dashboard"].endswith(f"{run_id}_final_audit_report.html")
     assert card["best_dashboard"] == card["final_audit_dashboard"]
+
+
+def test_history_sort_value_parses_iso_timestamps_not_lexicographic(tmp_path):
+    history_file = tmp_path / "run_history.json"
+    history_file.write_text(
+        '[{"timestamp":"2026-03-01T08:00:00Z"},{"timestamp":"2026-03-01T09:00:00+01:00"}]',
+        encoding="utf-8",
+    )
+
+    sort_value = cockpit_history_module._history_sort_value(history_file)
+
+    expected = datetime.fromisoformat("2026-03-01T08:00:00+00:00").timestamp()
+    assert sort_value == pytest.approx(expected)
+
+
+def test_artifact_root_label_uses_current_workspace(tmp_path, monkeypatch):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    artifact_root = workspace / "exports"
+    artifact_root.mkdir()
+    monkeypatch.chdir(workspace)
+
+    assert cockpit_history_module._artifact_root_label(str(artifact_root)) == "exports"

--- a/tests/mcp_server/test_rpc_cockpit_dashboard.py
+++ b/tests/mcp_server/test_rpc_cockpit_dashboard.py
@@ -142,11 +142,15 @@ def test_history_sort_value_parses_iso_timestamps_not_lexicographic(tmp_path):
         '[{"timestamp":"2026-03-01T08:00:00Z"},{"timestamp":"2026-03-01T09:00:00+01:00"}]',
         encoding="utf-8",
     )
+    original_enabled = cockpit_history_module._trusted_history_enabled
+    cockpit_history_module._trusted_history_enabled = lambda: True
 
-    sort_value = cockpit_history_module._history_sort_value(history_file)
-
-    expected = datetime.fromisoformat("2026-03-01T08:00:00+00:00").timestamp()
-    assert sort_value == pytest.approx(expected)
+    try:
+        sort_value = cockpit_history_module._history_sort_value(history_file)
+        expected = datetime.fromisoformat("2026-03-01T08:00:00+00:00").timestamp()
+        assert sort_value == pytest.approx(expected)
+    finally:
+        cockpit_history_module._trusted_history_enabled = original_enabled
 
 
 def test_artifact_root_label_uses_current_workspace(tmp_path, monkeypatch):

--- a/tests/mcp_server/test_rpc_cockpit_guides.py
+++ b/tests/mcp_server/test_rpc_cockpit_guides.py
@@ -85,6 +85,7 @@ def test_rpc_capability_catalog_tool(client):
         for item in result["workflow_templates"]
     )
     modules = {item["tool"]: item for item in result["modules"]}
+    assert all(str(item["template_path"]).startswith("config/") for item in result["modules"])
     final_audit_knobs = {k["path"]: k["default"] for k in modules["final_audit"]["key_knobs"]}
     assert "summary.run" not in final_audit_knobs
     assert final_audit_knobs["final_edits.run"] is True

--- a/tests/mcp_server/test_rpc_tool_registry.py
+++ b/tests/mcp_server/test_rpc_tool_registry.py
@@ -43,7 +43,7 @@ def test_rpc_tools_list(client):
 
 
 def test_rpc_tools_list_exposes_data_dictionary_input_id_schema(client):
-    """Verify data_dictionary advertises the shared input_id and anyOf input contract."""
+    """Verify data_dictionary advertises the shared input_id and oneOf input contract."""
     payload = {"jsonrpc": "2.0", "id": 33, "method": "tools/list", "params": {}}
     response = client.post("/rpc", json=payload)
     assert response.status_code == 200
@@ -52,12 +52,10 @@ def test_rpc_tools_list_exposes_data_dictionary_input_id_schema(client):
     input_schema = data_dictionary["inputSchema"]
 
     assert input_schema["properties"]["input_id"]["pattern"] == INPUT_ID_PATTERN
-    assert input_schema["properties"]["input_id"]["description"].endswith(
-        "If provided, gcs_path and session_id are ignored."
-    )
-    assert {"required": ["input_id"]} in input_schema["anyOf"]
-    assert {"required": ["gcs_path"]} in input_schema["anyOf"]
-    assert {"required": ["session_id"]} in input_schema["anyOf"]
+    assert "mutually exclusive" in input_schema["properties"]["input_id"]["description"].lower()
+    assert {"required": ["input_id"]} in input_schema["oneOf"]
+    assert {"required": ["gcs_path"]} in input_schema["oneOf"]
+    assert {"required": ["session_id"]} in input_schema["oneOf"]
 
 
 def test_rpc_tools_list_standardizes_input_id_pattern_across_tool_schemas(client):

--- a/tests/test_job_state.py
+++ b/tests/test_job_state.py
@@ -99,3 +99,33 @@ def test_job_store_caps_retained_jobs(tmp_path, monkeypatch):
     assert len(jobs) == 3
     assert created[0] not in job_ids
     assert created[1] not in job_ids
+
+
+def test_job_store_does_not_prune_in_flight_jobs(tmp_path, monkeypatch):
+    _reset_job_store(tmp_path, monkeypatch)
+    monkeypatch.setattr(JobStore, "_max_jobs", 1)
+    monkeypatch.setattr(JobStore, "_job_ttl_sec", 0.0)
+
+    first_succeeded = JobStore.create(module="auto_heal", run_id="done_1")
+    JobStore.mark_running(first_succeeded)
+    JobStore.mark_succeeded(first_succeeded, result={"status": "pass"})
+
+    queued = JobStore.create(module="auto_heal", run_id="queued")
+    running = JobStore.create(module="auto_heal", run_id="running")
+    JobStore.mark_running(running)
+    second_succeeded = JobStore.create(module="auto_heal", run_id="done_2")
+    JobStore.mark_running(second_succeeded)
+    JobStore.mark_succeeded(second_succeeded, result={"status": "pass"})
+
+    queued_job = JobStore.get(queued)
+    running_job = JobStore.get(running)
+    first_succeeded_job = JobStore.get(first_succeeded)
+    second_succeeded_job = JobStore.get(second_succeeded)
+
+    assert queued_job is not None
+    assert queued_job["state"] == "queued"
+    assert running_job is not None
+    assert running_job["state"] == "running"
+    assert first_succeeded_job is None
+    assert second_succeeded_job is not None
+    assert second_succeeded_job["state"] == "succeeded"

--- a/tests/test_mcp_tool_regressions.py
+++ b/tests/test_mcp_tool_regressions.py
@@ -739,7 +739,12 @@ async def test_toolkit_validation_warns_without_inferred_or_explicit_config(mock
         config={},
     )
 
+    assert result["status"] == "warn"
+    assert result["passed"] is False
+    assert result["summary"]["passed"] is False
     assert any("Run infer_configs first" in warning for warning in result["warnings"])
+    assert result["next_actions"][0]["tool"] == "infer_configs"
+    assert all(action["tool"] != "final_audit" for action in result["next_actions"])
 
 
 @pytest.mark.asyncio
@@ -1116,6 +1121,77 @@ async def test_final_audit_auto_discovers_inferred_cert_config(mocker, monkeypat
 
 
 @pytest.mark.asyncio
+async def test_final_audit_uses_configured_artifact_paths_and_strips_nested_transient_paths(
+    mocker, monkeypatch, tmp_path
+):
+    df = pd.DataFrame({"value": [1]})
+    run_id = "final_audit_custom_paths"
+    session_id = "sess_final_custom"
+    monkeypatch.chdir(tmp_path)
+
+    html_rel = f"exports/reports/custom/{run_id}_custom.html"
+    xlsx_rel = f"exports/reports/custom/{run_id}_custom.xlsx"
+    delivered_paths: list[str] = []
+    captured_config: dict = {}
+
+    def fake_run_final_audit_pipeline(*, config, df, run_id, notebook):
+        captured_config.update(config)
+        html_path = tmp_path / html_rel
+        xlsx_path = tmp_path / xlsx_rel
+        html_path.parent.mkdir(parents=True, exist_ok=True)
+        html_path.write_text("<html>final</html>", encoding="utf-8")
+        xlsx_path.write_text("xlsx", encoding="utf-8")
+        return df
+
+    def fake_deliver_artifact(local_path, *args, **kwargs):
+        delivered_paths.append(local_path)
+        return {
+            "reference": local_path,
+            "local_path": local_path,
+            "url": "",
+            "warnings": [],
+            "destinations": {},
+        }
+
+    mocker.patch.object(final_audit_tool, "load_input", return_value=df)
+    mocker.patch.object(
+        final_audit_tool, "run_final_audit_pipeline", side_effect=fake_run_final_audit_pipeline
+    )
+    mocker.patch.object(final_audit_tool, "save_to_session", return_value=session_id)
+    mocker.patch.object(final_audit_tool, "get_session_metadata", return_value={"row_count": 1})
+    mocker.patch.object(final_audit_tool, "save_output", return_value="gs://dummy/final.csv")
+    mocker.patch.object(final_audit_tool, "append_to_run_history", return_value=None)
+    mocker.patch.object(final_audit_tool, "deliver_artifact", side_effect=fake_deliver_artifact)
+    mocker.patch.object(
+        final_audit_tool,
+        "run_validation_suite",
+        return_value={"schema_conformity": {"passed": True, "details": {}}},
+    )
+
+    result = await final_audit_tool._toolkit_final_audit(
+        session_id=session_id,
+        run_id=run_id,
+        config={
+            "final_audit": {
+                "raw_data_path": "/tmp/stale.csv",
+                "certification": {"schema_validation": {"rules": {"expected_columns": ["value"]}}},
+                "settings": {
+                    "paths": {
+                        "report_html": html_rel,
+                        "report_excel": xlsx_rel,
+                    }
+                },
+            }
+        },
+    )
+
+    assert result["status"] in {"pass", "warn"}
+    assert html_rel in delivered_paths
+    assert xlsx_rel in delivered_paths
+    assert captured_config["final_audit"]["raw_data_path"] != "/tmp/stale.csv"
+
+
+@pytest.mark.asyncio
 async def test_final_audit_explicit_config_overrides_inferred(mocker, monkeypatch):
     """Explicit config should take precedence over inferred session config."""
     df = pd.DataFrame({"id": [1, 2], "value": ["a", "b"]})
@@ -1366,6 +1442,7 @@ async def test_final_audit_resolves_session_from_input_id(mocker, monkeypatch):
     )
 
     # Should discover cert rules from the input_id's linked session
+    assert result["run_id"] == "fa_input_id_run"
     assert "rule_contract_missing" not in result.get("violations_found", [])
     cert_cfg = result["effective_config"].get("certification", {})
     schema_cfg = cert_cfg.get("schema_validation", {})

--- a/tests/test_mcp_tool_regressions_infer.py
+++ b/tests/test_mcp_tool_regressions_infer.py
@@ -362,7 +362,9 @@ async def test_infer_configs_returns_structured_error_on_load_failure(monkeypatc
 
     assert result["status"] == "error"
     assert result["error_code"] == "INPUT_LOAD_FAILED"
-    assert "Session not found" in result["error"]
+    assert result["error"] == "Failed to load input. See trace_id."
+    assert isinstance(result.get("trace_id"), str)
+    assert result["trace_id"]
 
 
 @pytest.mark.asyncio
@@ -408,9 +410,10 @@ async def test_auto_heal_returns_error_when_infer_configs_load_fails(monkeypatch
         return {
             "status": "error",
             "module": "infer_configs",
-            "error": "Failed to load input: InputNotFoundError: not found",
+            "error": "Failed to load input. See trace_id.",
             "error_code": "INPUT_LOAD_FAILED",
             "config_yaml": "",
+            "trace_id": "trace_autoheal_infer",
         }
 
     monkeypatch.setattr(auto_heal_tool, "_toolkit_infer_configs", failing_infer_configs)
@@ -558,11 +561,17 @@ async def test_infer_configs_repopulates_stale_session_resolved_from_input_id(mo
     )
 
     assert result["status"] == "pass"
+    assert result["run_id"] == "stale_session_repopulate"
     assert result["session_id"] != "sess_stale_input"
     assert StateStore.get("sess_stale_input") is None
     assert StateStore.get(result["session_id"]) is not None
     assert StateStore.get_config(result["session_id"], "validation") is not None
     assert any("saved to a new session" in warning for warning in result["warnings"])
+    assert any(
+        action.get("arguments", {}).get("session_id") == result["session_id"]
+        for action in result["next_actions"]
+        if isinstance(action, dict)
+    )
     StateStore.clear()
 
 
@@ -604,7 +613,13 @@ async def test_infer_configs_resolves_session_from_input_id(monkeypatch, mocker)
     )
 
     assert result["status"] == "pass"
+    assert result["run_id"] == "infer_resolve_run"
     assert result["session_id"] == session_id
     stored = StateStore.get_config(session_id, "normalization")
     assert stored is not None
+    assert any(
+        action.get("arguments", {}).get("session_id") == session_id
+        for action in result["next_actions"]
+        if isinstance(action, dict)
+    )
     StateStore.clear()

--- a/tests/test_mcp_tool_regressions_io.py
+++ b/tests/test_mcp_tool_regressions_io.py
@@ -3,12 +3,37 @@ import base64
 import pandas as pd
 import pytest
 
+import analyst_toolkit.mcp_server.io as io_module
 import analyst_toolkit.mcp_server.tools.read_artifact as read_artifact_tool
 import analyst_toolkit.mcp_server.tools.session as session_tool
 import analyst_toolkit.mcp_server.tools.upload_input as upload_input_tool
 from analyst_toolkit.mcp_server.state import StateStore
 
 # ── manage_session tool tests ──
+
+
+def _configure_sqlite_state_env(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    state_home = tmp_path / "state_home"
+    db_path = state_home / "analyst_toolkit" / "session_store.db"
+    monkeypatch.setenv("XDG_STATE_HOME", str(state_home))
+    monkeypatch.setenv("ANALYST_MCP_SESSION_BACKEND", "sqlite")
+    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", str(db_path))
+
+
+def test_history_lock_for_does_not_evict_in_use_lock(tmp_path, monkeypatch):
+    monkeypatch.setattr(io_module, "_MAX_HISTORY_LOCKS", 1)
+    monkeypatch.setattr(io_module, "_HISTORY_LOCKS", io_module.OrderedDict())
+
+    first = tmp_path / "first.json"
+    second = tmp_path / "second.json"
+
+    with io_module._history_lock(first):
+        first_lock = io_module._history_lock_for(first)
+        second_lock = io_module._history_lock_for(second)
+        same_first_lock = io_module._history_lock_for(first)
+
+        assert second_lock is not first_lock
+        assert same_first_lock is first_lock
 
 
 @pytest.mark.asyncio
@@ -32,8 +57,7 @@ async def test_manage_session_list():
 
 @pytest.mark.asyncio
 async def test_manage_session_list_reports_sqlite_policy(monkeypatch, tmp_path):
-    monkeypatch.setenv("ANALYST_MCP_SESSION_BACKEND", "sqlite")
-    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", str(tmp_path / "session_store.db"))
+    _configure_sqlite_state_env(monkeypatch, tmp_path)
     StateStore.clear()
     df = pd.DataFrame({"a": [1, 2]})
     StateStore.save(df, run_id="sqlite_run")
@@ -86,8 +110,7 @@ async def test_manage_session_inspect_can_include_configs():
 
 @pytest.mark.asyncio
 async def test_manage_session_inspect_reports_sqlite_expiry(monkeypatch, tmp_path):
-    monkeypatch.setenv("ANALYST_MCP_SESSION_BACKEND", "sqlite")
-    monkeypatch.setenv("ANALYST_MCP_SESSION_DB_PATH", str(tmp_path / "session_store.db"))
+    _configure_sqlite_state_env(monkeypatch, tmp_path)
     StateStore.clear()
     sid = StateStore.save(pd.DataFrame({"x": [1, 2, 3]}), run_id="inspect_run")
 
@@ -178,6 +201,35 @@ async def test_manage_session_fork_missing_source():
     )
     assert result["status"] == "error"
     assert result["error_code"] == "SESSION_NOT_FOUND"
+
+
+@pytest.mark.asyncio
+async def test_manage_session_clear_all_requires_confirmation():
+    StateStore.clear()
+    StateStore.save(pd.DataFrame({"a": [1]}), run_id="run_1")
+
+    result = await session_tool._toolkit_manage_session(action="clear")
+
+    assert result["status"] == "error"
+    assert result["error_code"] == "CLEAR_ALL_CONFIRMATION_REQUIRED"
+    assert len(StateStore.list_sessions()) == 1
+    StateStore.clear()
+
+
+@pytest.mark.asyncio
+async def test_manage_session_clear_all_with_confirmation():
+    StateStore.clear()
+    StateStore.save(pd.DataFrame({"a": [1]}), run_id="run_1")
+    StateStore.save(pd.DataFrame({"a": [2]}), run_id="run_2")
+
+    result = await session_tool._toolkit_manage_session(
+        action="clear",
+        confirm_clear_all=True,
+    )
+
+    assert result["status"] == "pass"
+    assert result["cleared_count"] == 2
+    assert StateStore.list_sessions() == {}
 
 
 @pytest.mark.asyncio
@@ -352,3 +404,22 @@ async def test_read_artifact_stdio_mode_allows_cwd_path(tmp_path, monkeypatch):
     )
     assert result["status"] == "pass"
     assert result["encoding"] == "text"
+
+
+@pytest.mark.asyncio
+async def test_read_artifact_omits_large_text_payload(tmp_path, monkeypatch):
+    artifact_dir = tmp_path / "exports" / "reports" / "validation"
+    artifact_dir.mkdir(parents=True)
+    artifact = artifact_dir / "run1_validation_report.html"
+    artifact.write_text("x" * 256, encoding="utf-8")
+    monkeypatch.setattr(read_artifact_tool, "_ARTIFACT_ROOT", tmp_path / "exports")
+    monkeypatch.setattr(read_artifact_tool, "_MAX_INLINE_TEXT_BYTES", 128)
+
+    result = await read_artifact_tool._toolkit_read_artifact(
+        artifact_path=str(artifact),
+    )
+    assert result["status"] == "pass"
+    assert result["encoding"] == "text"
+    assert "artifact_content" not in result
+    assert result["artifact_reference"] == str(artifact)
+    assert "Use the local artifact server" in result["message"]

--- a/tests/test_pipeline_config_validation.py
+++ b/tests/test_pipeline_config_validation.py
@@ -33,6 +33,11 @@ def test_validate_pipeline_runner_config_requires_pipeline_entry_path():
         validate_pipeline_runner_config({"run_id": "x", "modules": {}})
 
 
+def test_validate_pipeline_runner_config_requires_run_id():
+    with pytest.raises(PipelineConfigValidationError, match="run_id"):
+        validate_pipeline_runner_config({"pipeline_entry_path": "data.csv", "modules": {}})
+
+
 def test_validate_runner_module_config_normalizes_validation_gatekeeper_template():
     config = _load_yaml("config/certification_config_template.yaml")
 
@@ -56,6 +61,18 @@ def test_validate_runner_module_config_normalizes_outlier_detection_template():
     assert "outlier_detection" in validated["canonical_config"]
 
 
+def test_validate_runner_module_config_normalizes_outlier_handling_template():
+    config = _load_yaml("config/handling_config_template.yaml")
+    config["outlier_handling"]["run"] = "true"
+
+    validated = validate_runner_module_config("outlier_handling", config)
+
+    assert validated["module_name"] == "outlier_handling"
+    assert validated["root_key"] == "outlier_handling"
+    assert validated["effective_config"]["run"] is True
+    assert "outlier_handling" in validated["canonical_config"]
+
+
 def test_validate_runner_module_config_rejects_unsupported_runner_module():
     with pytest.raises(PipelineConfigValidationError, match="Unsupported runner module"):
-        validate_runner_module_config("outlier_handling", {})
+        validate_runner_module_config("totally_unknown_module", {})

--- a/tests/test_template_contracts.py
+++ b/tests/test_template_contracts.py
@@ -24,6 +24,11 @@ from analyst_toolkit.mcp_server.tools.preflight_config import (
     _unknown_effective_keys,
 )
 
+_RUNNER_COERCE_KEYS = {
+    # Historical runner/public key for the outliers module uses outlier_detection.
+    "outliers": "outlier_detection",
+}
+
 
 def test_template_resource_uris_cover_template_files():
     resources = list_template_resources()
@@ -47,6 +52,12 @@ def test_template_resource_uris_cover_template_files():
     assert "analyst://templates/config/run_toolkit_config.yaml" not in uris
     assert "analyst://templates/config/handling_config_template.yaml" not in uris
     assert "analyst://templates/config/certification_config_template.yaml" not in uris
+
+
+def test_template_specs_resolve_to_bundled_package_resources():
+    for spec in list_config_template_specs():
+        assert spec.path.is_file(), spec.filename
+        assert "config_templates" in str(spec.path), spec.filename
 
 
 def test_all_template_resources_parse_as_yaml_mapping():
@@ -86,7 +97,7 @@ def test_public_module_templates_match_current_config_contracts():
         assert isinstance(raw.get(spec.config_root), dict), spec.filename
 
         module_name = spec.tool
-        coerce_key = "outlier_detection" if module_name == "outliers" else module_name
+        coerce_key = _RUNNER_COERCE_KEYS.get(module_name, module_name)
         coerced = coerce_config(raw, coerce_key)
         normalized = normalize_module_config(module_name, coerced)
 
@@ -106,6 +117,8 @@ def test_workflow_request_templates_match_public_tool_input_contracts():
             (Path(__file__).resolve().parent.parent / "config" / filename).read_text()
         )
         assert isinstance(raw, dict), filename
-        assert all(key in schema["properties"] for key in raw), filename
+        assert "properties" in schema, filename
+        assert isinstance(schema.get("properties"), dict), filename
+        assert all(key in schema.get("properties", {}) for key in raw), filename
         assert "runtime" in raw, filename
         assert not any(key in raw for key in ("auto_heal", "data_dictionary")), filename


### PR DESCRIPTION
## Summary
This PR packages the accumulated release-hardening work from `fix/sqlite-state-hardening` back into `dev`.

It closes the remaining high-priority remediation work we walked back from the `dev -> main` release path:
- hardens SQLite-backed session state and removes unsafe pickle deserialization from the durable path
- tightens ingest/session binding, retry, and run-context correctness across MCP tools
- fixes artifact/reporting contract edges in `infer_configs`, `auto_heal`, `final_audit`, and `io_storage`
- adds wheel-safe bundled template discovery and package data for public config templates
- tightens runner-side pipeline validation, input limits, history locking, cockpit history ordering, and local artifact path handling
- finishes the smaller contract/ergonomics items requested in the final remediation pass

## Key areas
- `state.py`, `io.py`, `io_storage.py`
- input ingest/registry/model/loading/limits surfaces
- `infer_configs`, `auto_heal`, `validation`, `final_audit`, `read_artifact`, session management
- template discovery/package data and cockpit capability/history surfaces
- CLI runner validation and outlier-handling config validation path

## Validation
- `pre-commit run --all-files`
- `ruff check src/ tests/`
- `ruff format --check src/ tests/`
- `mypy src/analyst_toolkit/mcp_server`
- focused regression slices during implementation
- broader MCP/runtime sweep:
  - `pytest tests/test_pipeline_config_validation.py tests/test_mcp_tool_regressions.py tests/test_mcp_tool_regressions_infer.py tests/test_mcp_tool_regressions_io.py tests/mcp_server/test_input_ingest.py tests/mcp_server/test_input_loaders.py tests/mcp_server/test_input_limits.py tests/mcp_server/test_input_registry.py tests/mcp_server/test_local_artifact_server.py tests/mcp_server/test_rpc_cockpit_dashboard.py tests/mcp_server/test_rpc_cockpit_guides.py tests/hardening/test_auto_heal_behavior.py tests/hardening/test_config_and_upload.py tests/hardening/test_pipeline_integrations.py tests/hardening/test_state_store.py tests/test_job_state.py tests/m00_utils/test_rendering_utils.py tests/test_template_contracts.py -q`

## Release posture
This PR is intended to stabilize `dev` before the `0.5.0` release PR is reopened against `main`.

Still intentionally deferred:
- #161 duplicate stdio MCP instance detection/warning
- #149 generic `StateStore.save/fork` idempotent session-creation semantics
- #142 upstream dependency advisory cleanup once patched
