### PR TITLE
fix: v0.5.1 patch — Codex schema compat, dashboard local URLs, pytest CVE

### DIFF
--- a/.pip-audit-known-vulns
+++ b/.pip-audit-known-vulns
@@ -6,3 +6,7 @@
 # Pygments 2.19.2 — no patched release available yet (transitive dep via pytest/sphinx)
 # Added: 2026-03-25 | Revisit by: 2026-04-25
 CVE-2026-4539
+
+# pytest 8.4.2 — fixed in 9.0.3, holding off on major upgrade until compatibility verified
+# Added: 2026-04-17 | Revisit by: 2026-05-17
+CVE-2025-71176


### PR DESCRIPTION
## Summary
- Remove top-level `anyOf`/`oneOf` from MCP tool schemas (`auto_heal`, `infer_configs`, `cockpit_schemas`, `drift`) to comply with OpenAI API's stricter validation (breaks Codex CLI)
- Prefer local file server URLs over remote GCS URLs when rendering pipeline dashboard iframes
- Pass `destination_delivery` through the cockpit pipeline dashboard payload so local URLs are available to the renderer
- Ignore `CVE-2025-71176` (pytest 8.x) pending pytest 9 compatibility review
- Fix stale `oneOf` assertion in registry test
- Ruff formatting fix on `dashboard_views.py`

## Test plan
- [ ] CI passes on this PR
- [ ] Codex CLI starts without `invalid_function_parameters` error after schema fixes
- [ ] Pipeline dashboard embeds use `127.0.0.1` local URLs when available

🤖 Generated with [Claude Code](https://claude.com/claude-code)