### PR TITLE
docs: bump version to v0.5.1 in README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,17 @@ Format:
 
 - None.
 
+## [0.5.1] - 2026-04-17
+
+### Fixed
+
+- Remove top-level `anyOf`/`oneOf` from MCP tool schemas (`auto_heal`, `infer_configs`, `cockpit_schemas`, `drift`) to comply with OpenAI API stricter tool schema validation; fixes Codex CLI startup failure (#181).
+- Pipeline dashboard iframes now prefer local file server URLs over remote GCS URLs when `destination_delivery` provides them, so embedded reports load in the browser (#181).
+
+### Security
+
+- Acknowledge `CVE-2025-71176` (pytest 8.x) pending pytest 9 compatibility review.
+
 ## [0.5.0] - 2026-03-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 <p align="center">
   <img alt="MIT License" src="https://img.shields.io/badge/license-MIT-blue">
   <img alt="Status" src="https://img.shields.io/badge/status-stable-brightgreen">
-  <img alt="Version" src="https://img.shields.io/badge/version-v0.5.0-blueviolet">
+  <img alt="Version" src="https://img.shields.io/badge/version-v0.5.1-blueviolet">
   <a href="https://github.com/G-Schumacher44/analyst_toolkit/actions/workflows/analyst-toolkit-mcp-ci.yml">
     <img alt="CI" src="https://github.com/G-Schumacher44/analyst_toolkit/actions/workflows/analyst-toolkit-mcp-ci.yml/badge.svg">
   </a>


### PR DESCRIPTION
## Summary
- Bumps version badge in README from v0.5.0 → v0.5.1
- Adds v0.5.1 entry to CHANGELOG

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)