### PR TITLE
chore: ignore .playwright-mcp/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,8 @@ htmlcov/
 # ===============================
 local_plans/
 resource_hub/monolith_decomposition_execution_plan.md
+
+# ===============================
+# Playwright
+# ===============================
+.playwright-mcp/


### PR DESCRIPTION
## Summary
- Adds `.playwright-mcp/` to `.gitignore` — auto-generated by Playwright, shouldn't be tracked.

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)